### PR TITLE
Flipped y pixels for meshline plotting

### DIFF
--- a/src/plot.F90
+++ b/src/plot.F90
@@ -272,11 +272,11 @@ contains
           outrange(1) = int(frac * real(img % width, 8))
           frac = (xyz_ur(outer) - xyz_ll_plot(outer)) / width(outer)
           outrange(2) = int(frac * real(img % width, 8))
-          
-          frac = (xyz_ll(inner) - xyz_ll_plot(inner)) / width(inner)
-          inrange(1) = int(frac * real(img % height, 8))
+
           frac = (xyz_ur(inner) - xyz_ll_plot(inner)) / width(inner)
-          inrange(2) = int(frac * real(img % height, 8))
+          inrange(1) = int((1. - frac) * real(img % height, 8))
+          frac = (xyz_ll(inner) - xyz_ll_plot(inner)) / width(inner)
+          inrange(2) = int((1. - frac) * real(img % height, 8))
 
           ! draw lines
           do out_ = outrange(1), outrange(2)


### PR DESCRIPTION
As pointed out on users group, there was an issue with meshlines plotting.  Specifically, the y pixels on the plot were flipped.

The xml files in tests/test_filter_mesh_3d/ can be used to test this, with the following plots.xml

```xml
<?xml version="1.0"?>
<plots>

  <plot id="1" color="mat" basis="xy">
    <origin>0. 0. 0.</origin>
    <width>500 500</width>
    <pixels>2000 2000</pixels>
    <meshlines meshtype="tally" id="1" linewidth="3" color="255 0 0"/>
  </plot>

</plots>
```
tally.xml

```xml
<?xml version="1.0"?>
<tallies>

  <mesh id="1">
    <type>rectangular</type>
    <lower_left>0 0 -183.00</lower_left>
    <upper_right>182.07 90 183.00</upper_right>
    <dimension>17 17 17</dimension>
  </mesh>

  <tally id="1">
    <filter type="mesh" bins="1" />
    <scores>total</scores>
  </tally>

</tallies>
```

and the following change in the lattice at the bottom of geometry.xml

```xml
  <!-- Core Lattice (Upper Half) -->
  <lattice id="201">
    <type>rectangular</type>
    <dimension>21 21</dimension>
    <lower_left>-224.91 -224.91</lower_left>
    <width>21.42 21.42</width>
    <universes>
      7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7
      7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7
      7 7 7 7 7 7 7 8 8 8 8 8 8 8 7 7 7 7 7 7 7
      7 7 7 7 7 8 8 8 8 8 8 8 8 8 8 8 7 7 7 7 7
      7 7 7 7 8 8 8 8 8 8 8 8 8 8 8 8 8 7 7 7 7
      7 7 7 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 7 7 7
      7 7 7 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 7 7 7
      7 7 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 7 7
      7 7 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 7 7
      7 7 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 7 7
      7 7 8 8 8 8 7 7 7 8 8 8 8 8 8 8 8 8 8 7 7
      7 7 8 8 8 8 7 7 8 8 8 8 8 8 8 8 8 8 8 7 7
      7 7 8 8 8 8 7 8 8 8 8 8 8 8 8 8 8 8 8 7 7
      7 7 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 7 7
      7 7 7 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 7 7 7
      7 7 7 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 7 7 7
      7 7 7 7 8 8 8 8 8 8 8 8 8 8 8 8 8 7 7 7 7
      7 7 7 7 7 8 8 8 8 8 8 8 8 8 8 8 7 7 7 7 7
      7 7 7 7 7 7 7 8 8 8 8 8 8 8 7 7 7 7 7 7 7
      7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7
      7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7
    </universes>
  </lattice>
```

Should produce this output:

![1_plot](https://cloud.githubusercontent.com/assets/1110672/5589387/8e9e3310-90eb-11e4-870a-8a47a044f231.png)










