### PR TITLE
Fixing tally.F90 segfault when trying to tally a particle in a void material

### DIFF
--- a/src/tally.F90
+++ b/src/tally.F90
@@ -1837,8 +1837,10 @@ contains
              p % coord % universe, i_tally)
 
       case (FILTER_MATERIAL)
-        matching_bins(i) = get_next_bin(FILTER_MATERIAL, &
-             p % material, i_tally)
+        if (p % material /= MATERIAL_VOID) then
+          matching_bins(i) = get_next_bin(FILTER_MATERIAL, &
+               p % material, i_tally)
+        endif
 
       case (FILTER_CELL)
         ! determine next cell bin


### PR DESCRIPTION
Hello folks,

I was getting the following error when running OpenMC with [these input files](https://gist.github.com/jdangerx/b5a0f07be79ec8a6e92c):
`At line 2247 of file /home/john/openmc/src/tally.F90
Fortran runtime error: Index '-1' of dimension 1 of array 'tally_maps%items' below lower bound of 1`
I found that we weren't checking if a particle was in a non-void material before trying to index by this material, so I added some code to do so. Now this doesn't segfault on my computer anymore!

