### PR TITLE
PETSc compatibility for 3.4 and 3.5

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -195,6 +195,20 @@ if(petsc)
     list(INSERT PETSC_PACKAGE_LIBS 0 ${PETSC_RT_LIB})
   endif()
 
+  # If libssl wasn't found, search /usr/lib64
+  if(PETSC_SSL_LIB STREQUAL "PETSC_SSL_LIB-NOTFOUND")
+    find_library(PETSC_SSL_LIB libssl.so /usr/lib64)
+    list(REMOVE_ITEM PETSC_PACKAGE_LIBS PETSC_SSL_LIB-NOTFOUND)
+    list(INSERT PETSC_PACKAGE_LIBS 0 ${PETSC_SSL_LIB})
+  endif()
+
+  # If libcrypto wasn't found, search /usr/lib64
+  if(PETSC_CRYPTO_LIB STREQUAL "PETSC_CRYPTO_LIB-NOTFOUND")
+    find_library(PETSC_CRYPTO_LIB libcrypto.so /usr/lib64)
+    list(REMOVE_ITEM PETSC_PACKAGE_LIBS PETSC_CRYPTO_LIB-NOTFOUND)
+    list(INSERT PETSC_PACKAGE_LIBS 0 ${PETSC_CRYPTO_LIB})
+  endif()
+
   message("-- Using PETSC: ${libpetsc}")
   add_definitions(-DPETSC)
   include_directories($ENV{PETSC_DIR}/include)

--- a/src/output_interface.F90
+++ b/src/output_interface.F90
@@ -1942,7 +1942,6 @@ contains
 #ifdef MPI
 # ifndef HDF5
     integer(MPI_OFFSET_KIND) :: offset           ! offset of data
-    integer                  :: size_offset_kind ! the data offset kind
     integer                  :: size_bank        ! size of bank to write
     integer                  :: datatype
 # endif

--- a/src/solver_interface.F90
+++ b/src/solver_interface.F90
@@ -69,11 +69,17 @@ module solver_interface
 
 #ifdef PETSC
   integer :: petsc_err ! petsc error code
+
+! This handles the variable change from PETSc 3.4 to PETSc 3.5
+! Developers should use PETSC_DEFAULT_DOUBLE when they want to
+! use PETSC_DEFAULT_REAL so that we have compatiblity with 
+! PETSc < 3.5.
 # if (PETSC_VERSION_MAJOR == 3) && (PETSC_VERSION_MINOR <= 4)
   PetscReal :: PETSC_DEFAULT_DOUBLE = PETSC_DEFAULT_DOUBLE_PRECISION
 # else
   PetscReal :: PETSC_DEFAULT_DOUBLE = PETSC_DEFAULT_REAL
 # endif
+
 #endif
 
 contains

--- a/src/solver_interface.F90
+++ b/src/solver_interface.F90
@@ -75,9 +75,9 @@ module solver_interface
 ! use PETSC_DEFAULT_REAL so that we have compatiblity with 
 ! PETSc < 3.5.
 # if (PETSC_VERSION_MAJOR == 3) && (PETSC_VERSION_MINOR <= 4)
-  PetscReal :: PETSC_DEFAULT_DOUBLE = PETSC_DEFAULT_DOUBLE_PRECISION
+    PetscReal :: PETSC_DEFAULT_DOUBLE = PETSC_DEFAULT_DOUBLE_PRECISION
 # else
-  PetscReal :: PETSC_DEFAULT_DOUBLE = PETSC_DEFAULT_REAL
+    PetscReal :: PETSC_DEFAULT_DOUBLE = PETSC_DEFAULT_REAL
 # endif
 
 #endif

--- a/src/solver_interface.F90
+++ b/src/solver_interface.F90
@@ -7,6 +7,8 @@ module solver_interface
 #ifdef PETSC
   use petscksp
   use petscsnes
+# include <finclude/petscsysdef.h>
+# include <petscversion.h>
 #endif
 
   implicit none
@@ -67,6 +69,11 @@ module solver_interface
 
 #ifdef PETSC
   integer :: petsc_err ! petsc error code
+# if (PETSC_VERSION_MAJOR == 3) && (PETSC_VERSION_MINOR <= 4)
+  PetscReal :: PETSC_DEFAULT_DOUBLE = PETSC_DEFAULT_DOUBLE_PRECISION
+# else
+  PetscReal :: PETSC_DEFAULT_DOUBLE = PETSC_DEFAULT_REAL
+# endif
 #endif
 
 contains
@@ -86,7 +93,7 @@ contains
 
     call KSPCreate(PETSC_COMM_WORLD, self % ksp_, petsc_err)
     call KSPSetTolerances(self % ksp_, rtol, atol, &
-         PETSC_DEFAULT_DOUBLE_PRECISION, PETSC_DEFAULT_INTEGER, petsc_err)
+         PETSC_DEFAULT_DOUBLE, PETSC_DEFAULT_INTEGER, petsc_err)
     call KSPSetType(self % ksp_, 'gmres', petsc_err)
     call KSPSetInitialGuessNonzero(self % ksp_, PETSC_TRUE, petsc_err)
     call KSPGetPC(self % ksp_, self % pc_, petsc_err)

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -42,10 +42,10 @@ parser.add_option("-s", "--script", action="store_true", dest="script",
 
 # Default compiler paths
 FC='gfortran'
-MPI_DIR='/opt/mpich/3.1-gnu'
-HDF5_DIR='/opt/hdf5/1.8.12-gnu'
-PHDF5_DIR='/opt/phdf5/1.8.12-gnu'
-PETSC_DIR='/opt/petsc/3.4.4-gnu'
+MPI_DIR='/opt/mpich/3.1.3-gnu'
+HDF5_DIR='/opt/hdf5/1.8.14-gnu'
+PHDF5_DIR='/opt/phdf5/1.8.14-gnu'
+PETSC_DIR='/opt/petsc/3.5.2-gnu'
 
 # Script mode for extra capability
 script_mode = False


### PR DESCRIPTION
This PR addresses #293 and adds compiler directives that define a parameter that indicates whether the PETSc version is > 3.4. PETSc supplies version information when including petscversion.h. 

This PR is necessary because in PETSc v3.5, PETSC_DEFAULT_DOUBLE_PRECISION is now PETSC_DEFAULT_REAL and the MatStructure parameter has been eliminated from KSPSetOperators and from the user defined Jacobian routine.

This PR also increments the default libraries in the run_tests.py script to the latest released versions. I also removed an unused variable from the output_interface that was giving a compiler warning.

The test suite was run for both PETSc v3.4.4 and PETSc v3.5.2 and displayed on the dashboard http://openmc.mit.edu/cdash/index.php?project=OpenMC (Friday, January 23rd). I have one fatal error on every debug build configuration on test_plot_backgroup.py:

```
At line 226 of file /home/bherman/cron_repos/openmc_petsc/src/output.F90
Fortran runtime error: Substring out of bounds: upper bound (99) of 'message' exceeds string length (98)
```

This happened for both 3.4.4 and 3.5.2.

