### PR TITLE
Fix for output.F90 string length error

### DIFF
--- a/src/output.F90
+++ b/src/output.F90
@@ -216,7 +216,7 @@ contains
 
       i_start = 0
       do
-        if (length - i_start < line_wrap - 1) then
+        if (length - i_start < line_wrap + 1) then
           ! Remainder of message will fit on line
           write(ou, fmt='(1X,A)') message(i_start+1:length)
           exit


### PR DESCRIPTION
We saw this error in #355 and I guess #348.

It looks like there was a typo in line 219.