### PR TITLE
Travis CI Initial Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ before_install:
   - export PHDF5_DIR=$PWD/phdf5_install
   - export HDF5_DIR=$PWD/hdf5_install
   - export PETSC_DIR=$PWD/petsc_install
-  - ls -ll
 
 before_script:
   - cd data

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
 
 before_script:
   - cd data
-  - ./get_nndc_data.py --batch > /dev/null 2>&1
+  - ./get_nndc_data.py --batch
   - export CROSS_SECTIONS=$PWD/nndc/cross_sections.xml
   - cd ..
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq -y python-numpy
+  - sudo apt-get install -qq -y python-scipy
+  - sudo apt-get install -qq -y python-h5py
+  - sudo apt-get install -qq -y gfortran
+  - sudo apt-get install -qq -y g++
+  - ./tests/travis_install.sh
+  - export FC=gfortran
+  - export MPI_DIR=$PWD/mpich_install
+  - export PHDF5_DIR=$PWD/phdf5_install
+  - export HDF5_DIR=$PWD/hdf5_install
+  - export PETSC_DIR=$PWD/petsc_install
+  - ls -ll
+
+before_script:
+  - cd data
+  - ./get_nndc_data.py --batch > /dev/null 2>&1
+  - export CROSS_SECTIONS=$PWD/nndc/cross_sections.xml
+  - cd ..
+
+script:
+  - cd tests
+  - export OMP_NUM_THREADS=3
+  - ./travis.sh
+  - cd ..

--- a/data/get_nndc_data.py
+++ b/data/get_nndc_data.py
@@ -8,6 +8,12 @@ import sys
 import tarfile
 import glob
 import hashlib
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-b', '--batch', action = 'store_true',
+                    help = 'supresses standard in')
+args = parser.parse_args()
 
 try:
     from urllib.request import urlopen
@@ -118,10 +124,13 @@ shutil.copyfile('cross_sections_nndc.xml', 'nndc/cross_sections.xml')
 # PROMPT USER TO DELETE .TAR.GZ FILES
 
 # Ask user to delete
-if sys.version_info[0] < 3:
-    response = raw_input('Delete *.tar.gz files? ([y]/n) ')
+if not args.batch:
+    if sys.version_info[0] < 3:
+        response = raw_input('Delete *.tar.gz files? ([y]/n) ')
+    else:
+        response = input('Delete *.tar.gz files? ([y]/n) ')
 else:
-    response = input('Delete *.tar.gz files? ([y]/n) ')
+    response = 'y'
 
 # Delete files if requested
 if not response or response.lower().startswith('y'):
@@ -134,10 +143,13 @@ if not response or response.lower().startswith('y'):
 # PROMPT USER TO CONVERT ASCII TO BINARY
 
 # Ask user to convert
-if sys.version_info[0] < 3:
-    response = raw_input('Convert ACE files to binary? ([y]/n) ')
+if not args.batch:
+    if sys.version_info[0] < 3:
+        response = raw_input('Convert ACE files to binary? ([y]/n) ')
+    else:
+        response = input('Convert ACE files to binary? ([y]/n) ')
 else:
-    response = input('Convert ACE files to binary? ([y]/n) ')
+    response = 'y'
 
 # Convert files if requested
 if not response or response.lower().startswith('y'):

--- a/readme.rst
+++ b/readme.rst
@@ -2,9 +2,6 @@
 OpenMC Monte Carlo Particle Transport Code
 ==========================================
 
-.. image:: https://travis-ci.org/bhermanmit/openmc.svg?branch=travis
-    :target: https://travis-ci.org/bhermanmit/openmc
-
 The OpenMC project aims to provide a fully-featured Monte Carlo particle
 transport code based on modern methods. It is a constructive solid geometry,
 continuous-energy transport code that uses ACE format cross sections. The

--- a/readme.rst
+++ b/readme.rst
@@ -2,6 +2,9 @@
 OpenMC Monte Carlo Particle Transport Code
 ==========================================
 
+.. image:: https://travis-ci.org/bhermanmit/openmc.svg?branch=travis
+    :target: https://travis-ci.org/bhermanmit/openmc
+
 The OpenMC project aims to provide a fully-featured Monte Carlo particle
 transport code based on modern methods. It is a constructive solid geometry,
 continuous-energy transport code that uses ACE format cross sections. The

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -509,6 +509,8 @@ else:
     ENDC = ''
     BOLD = ''
 
+return_code = 0
+
 for test in tests:
     print(test + '.'*(50 - len(test)), end='')
     if tests[test].success:
@@ -516,3 +518,6 @@ for test in tests:
     else:
         print(BOLD + FAIL + '[FAILED]' + ENDC)
         print(' '*len(test)+tests[test].msg)
+        return_code = 1
+
+sys.exit(return_code)

--- a/tests/travis.sh
+++ b/tests/travis.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -ev
+
+# Run all debug tests
+if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+  ./run_tests.py -C "^basic-debug$|^hdf5-debug$|^mpi-omp-debug$|^phdf5-omp-debug$|^omp-phdf5-petsc-debug$" -j 4 -s
+else
+  ./run_tests.py -C "^basic-debug$" -j 4
+fi

--- a/tests/travis_install.sh
+++ b/tests/travis_install.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+set -ev
+
+# Build HDF5 and PETSc for rest of debug tests
+if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+
+  # Build MPICH
+  wget -q http://www.mpich.org/static/downloads/3.1.3/mpich-3.1.3.tar.gz
+  tar -xzvf mpich-3.1.3.tar.gz >/dev/null 2>&1
+  cd mpich-3.1.3
+  ./configure --prefix=$PWD/../mpich_install -q
+  make -j >/dev/null 2>&1
+  make install >/dev/null 2>&1
+  cd ..
+
+  # Build PHDF5
+  wget -q http://www.hdfgroup.org/ftp/HDF5/current/src/hdf5-1.8.14.tar.gz
+  tar -xzvf hdf5-1.8.14.tar.gz >/dev/null 2>&1
+  mv hdf5-1.8.14 phdf5-1.8.14; cd phdf5-1.8.14
+  CC=$PWD/../mpich_install/bin/mpicc FC=$PWD/../mpich_install/bin/mpif90 \
+     ./configure \
+     --prefix=$PWD/../phdf5_install -q --enable-fortran \
+     --enable-fortran2003 --enable-parallel
+  make -j >/dev/null 2>&1
+  make install >/dev/null 2>&1
+  cd ..
+
+  # Build HDF5
+  tar -xzvf hdf5-1.8.14.tar.gz >/dev/null 2>&1
+  cd  hdf5-1.8.14
+  CC=gcc FC=gfortran ./configure --prefix=$PWD/../hdf5_install -q \
+                                 --enable-fortran --enable-fortran2003
+  make -j >/dev/null 2>&1
+  make install >/dev/null 2>&1
+  cd ..
+
+  # Build PETSc
+  wget -q http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-3.5.3.tar.gz
+  tar -xzvf petsc-lite-3.5.3.tar.gz >/dev/null 2>&1
+  cd petsc-3.5.3
+  ./configure --prefix=$PWD/../petsc_install -q --download-fblaslapack \
+              --with-mpi-dir=$PWD/../mpich_install --with-share-libraries \
+              --with-fortran-datatypes
+  make PETSC_DIR=/home/travis/build/bhermanmit/openmc/petsc-3.5.3 \
+       PETSC_ARCH=arch-linux2-c-debug all >/dev/null 2>&1
+  make PETSC_DIR=/home/travis/build/bhermanmit/openmc/petsc-3.5.3 \
+       PETSC_ARCH=arch-linux2-c-debug install >/dev/null 2>&1
+  make install >/dev/null 2>&1
+  cd ..
+
+fi


### PR DESCRIPTION
This PR adds scripts that will allow us to take advantage of continuous integration using Travis. When a new set of commits are pushed to master/develop (or anyone else who activates Travis in the future), the basic-debug tests will be run.

In addition, when a pull request is made to develop, mpich/hdf5/phdf5/petsc will be configured and a subset of debug tests are run that covers a suitable combination of the different build configurations. It will test the merge between the PR and the develop branch.

Currently, the commit type tests takes 7 mins and the PR tests take 40 mins (because third party libraries are being built). Once we have this basic support, we can try and reduce these times by pre-building these libraries and downloading them directly.

You can sign in with your github account at https://travis-ci.org/. It will then ask what repos you would like to activate and you can select openmc and play with this branch. Once this PR is ready to be merged, I will activate Travis on the mit-crpg account for OpenMC.

Note, I had to make the following changes to files in OpenMC:
- in the get_nndc python script, I had to suppress the questions and automatically answer yes when executed with --batch
- in the run_tests python script, I had to put a return code in for Travis