### PR TITLE
XML Validation script

### DIFF
--- a/docs/source/usersguide/input.rst
+++ b/docs/source/usersguide/input.rst
@@ -51,6 +51,55 @@ files are called:
 * ``plots.xml``
 * ``cmfd.xml``
 
+--------------------
+Validating XML Files
+--------------------
+
+Input files can be checked before executing OpenMC using the ``xml_validate``
+script. It is located in ``src/utils/xml_validate.py`` in the source code or in
+``bin/xml_validate`` in the install directory. Before use, the third party
+package TRANG_ must be installed and in your ``PATH`` to convert the compact
+RelaxNG schema to standard RelaxNG format. For Ubuntu, you can install with:
+
+.. code-block:: bash
+ 
+   sudo apt-get install trang
+
+Two command line arguments can be set when running ``xml_validate``:
+
+* ``-i``, ``--input-path`` - Location of OpenMC input files.
+  *Default*: current working directory
+* ``-r``, ``--relaxng-path`` - Location of OpenMC RelaxNG files.
+  *Default*: None
+
+If the RelaxNG path is not set, ``xml_validate`` will search for these files
+because it expects that the user is either running the script located in the
+install directory ``bin`` folder or in ``src/utils``. Once executed, it will
+match OpenMC XML files with their RelaxNG schema and check if they are valid.
+Below is a table of the messages that will be printed after each file is
+checked.
+
+========================  ===================================
+Message                   Description
+========================  ===================================
+[XML ERROR]               Cannot parse XML file.
+[NO RELAXNG FOUND]        No RelaxNG file found for XML file.
+[TRANG FAILED]            TRANG not installed properly.
+[NOT VALID]               XML file does not match RelaxNG.
+[VALID]                   XML file matches RelaxNG.
+========================  ===================================
+
+As an example, if OpenMC is installed in the directory
+``/opt/openmc/0.6.2`` and the current working directory is where
+OpenMC XML input files are located, they can be validated using
+the following command:
+
+.. code-block:: bash
+
+   /opt/openmc/0.6.2/bin/xml_validate
+
+.. _TRANG: http://www.thaiopensource.com/relaxng/trang.html
+
 --------------------------------------
 Settings Specification -- settings.xml
 --------------------------------------

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -272,6 +272,10 @@ install(PROGRAMS utils/statepoint_meshplot.py
 install(PROGRAMS utils/update_inputs.py
   DESTINATION bin
   RENAME update_inputs)
+install(PROGRAMS utils/xml_validate.py
+  DESTINATION bin
+  RENAME xml_validate)
+install(DIRECTORY relaxng DESTINATION share)
 install(FILES ../man/man1/openmc.1 DESTINATION share/man/man1)
 install(FILES ../LICENSE DESTINATION "share/doc/${program}/copyright")
 

--- a/src/input_xml.F90
+++ b/src/input_xml.F90
@@ -904,7 +904,7 @@ contains
     integer :: universe_num
     integer :: n_cells_in_univ
     integer :: coeffs_reqd
-    integer :: temp_int_array3(3)
+    integer :: temp_double_array3(3)
     integer, allocatable :: temp_int_array(:)
     real(8) :: phi, theta, psi
     logical :: file_exists
@@ -1052,10 +1052,10 @@ contains
         end if
 
         ! Copy rotation angles in x,y,z directions
-        call get_node_array(node_cell, "rotation", temp_int_array3)
-        phi   = -temp_int_array3(1) * PI/180.0_8
-        theta = -temp_int_array3(2) * PI/180.0_8
-        psi   = -temp_int_array3(3) * PI/180.0_8
+        call get_node_array(node_cell, "rotation", temp_double_array3)
+        phi   = -temp_double_array3(1) * PI/180.0_8
+        theta = -temp_double_array3(2) * PI/180.0_8
+        psi   = -temp_double_array3(3) * PI/180.0_8
 
         ! Calculate rotation matrix based on angles given
         allocate(c % rotation(3,3))

--- a/src/relaxng/geometry.rnc
+++ b/src/relaxng/geometry.rnc
@@ -8,7 +8,7 @@ element geometry {
         attribute material { ( xsd:int | "void" ) })
     ) &
     (element surfaces { list { xsd:int* } } | attribute surfaces { list { xsd:int* } })? &
-    (element rotation { list { xsd:double+ } } | attribute rotation { list { xsd:double+ } })? &
+    (element rotation { list { xsd:int+ } } | attribute rotation { list { xsd:int+ } })? &
     (element translation { list { xsd:double+ } } | attribute translation { list { xsd:double+ } })?
   }*
 

--- a/src/relaxng/geometry.rnc
+++ b/src/relaxng/geometry.rnc
@@ -8,7 +8,7 @@ element geometry {
         attribute material { ( xsd:int | "void" ) })
     ) &
     (element surfaces { list { xsd:int* } } | attribute surfaces { list { xsd:int* } })? &
-    (element rotation { list { xsd:int+ } } | attribute rotation { list { xsd:int+ } })? &
+    (element rotation { list { xsd:double+ } } | attribute rotation { list { xsd:double+ } })? &
     (element translation { list { xsd:double+ } } | attribute translation { list { xsd:double+ } })?
   }*
 

--- a/src/relaxng/tallies.rnc
+++ b/src/relaxng/tallies.rnc
@@ -27,9 +27,7 @@ element tallies {
        attribute type { ( "cell" | "cellborn" | "material" | "universe" |
         "surface" | "mesh" | "energy" | "energyout" ) }) &
       (element bins { list { xsd:string { maxLength = "20" }+ } } |
-        attribute bins { list { xsd:string { maxLength = "20" }+ } }) &
-      (element groups { xsd:string { maxLength = "20" }+ } | 
-        attribute groups { xsd:string { maxLength = "20" }+ })?
+        attribute bins { list { xsd:string { maxLength = "20" }+ } })
     }* &
     element nuclides {
       list { xsd:string { maxLength = "12" }+ }

--- a/src/relaxng/tallies.rnc
+++ b/src/relaxng/tallies.rnc
@@ -26,8 +26,8 @@ element tallies {
         "surface" | "mesh" | "energy" | "energyout" ) } |
        attribute type { ( "cell" | "cellborn" | "material" | "universe" |
         "surface" | "mesh" | "energy" | "energyout" ) }) &
-      (element bins { list { xsd:string { maxLength = "20" }+ } } |
-        attribute bins { list { xsd:string { maxLength = "20" }+ } })
+      (element bins { list { xsd:double+ } } |
+        attribute bins { list { xsd:double+ } })
     }* &
     element nuclides {
       list { xsd:string { maxLength = "12" }+ }

--- a/src/utils/xml_validate.py
+++ b/src/utils/xml_validate.py
@@ -57,7 +57,12 @@ for xml_file in xml_files:
     print(text + '.'*(30 - len(text)), end="")
 
     # Validate the XML file
-    xml_tree = etree.parse(xml_file)
+    try:
+        xml_tree = etree.parse(xml_file)
+    except etree.XMLSyntaxError as e:
+        print(BOLD + FAIL + '[XML ERROR]' + ENDC)
+        print("    {0}".format(e))
+        continue
 
     # Get xml_filename prefix
     xml_prefix = os.path.basename(xml_file)

--- a/src/utils/xml_validate.py
+++ b/src/utils/xml_validate.py
@@ -79,10 +79,15 @@ for xml_file in xml_files:
             relaxng = etree.RelaxNG(relaxng_doc)
 
             # validate xml file again RelaxNG
-            if relaxng.validate(xml_tree):
+            try:
+                relaxng.assertValid(xml_tree)
                 print(BOLD + OK + '[VALID]' + ENDC)
-            else:
+            except etree.DocumentInvalid as e:
                 print(BOLD + FAIL + '[NOT VALID]' + ENDC)
+                print("    {0}".format(e))
+
+            # remove rng file
+            os.remove(rng_file)
 
         # trang command failed
         else:

--- a/src/utils/xml_validate.py
+++ b/src/utils/xml_validate.py
@@ -99,7 +99,7 @@ for xml_file in xml_files:
             try:
                 relaxng.assertValid(xml_tree)
                 print(BOLD + OK + '[VALID]' + ENDC)
-            except etree.DocumentInvalid as e:
+            except (etree.DocumentInvalid, TypeError) as e:
                 print(BOLD + FAIL + '[NOT VALID]' + ENDC)
                 print("    {0}".format(e))
 

--- a/src/utils/xml_validate.py
+++ b/src/utils/xml_validate.py
@@ -108,7 +108,7 @@ for xml_file in xml_files:
 
         # trang command failed
         else:
-            print(BOLD + FAIL + '[TRANG RNC-->RNG FAILED]' + ENDC)
+            print(BOLD + FAIL + '[TRANG FAILED]' + ENDC)
 
     # RNC file does not exist
     else:

--- a/src/utils/xml_validate.py
+++ b/src/utils/xml_validate.py
@@ -31,13 +31,24 @@ else:
     BOLD = ''
     NOT_FOUND = ''
 
-# Get paths
-relaxng_path = os.path.abspath(options.relaxng)
-inputs_path = os.path.abspath(options.inputs)
+# Get absolute paths
+if options.relaxng is not None:
+    relaxng_path = os.path.abspath(options.relaxng)
+if options.inputs is not None:
+    inputs_path = os.path.abspath(options.inputs)
 
-# Check for RelaxNG path
-if not relaxng_path:
-    raise Exception("Must specify RelaxNG path.")
+# Search for relaxng path if not set
+if options.relaxng is None:
+    xml_validate_path = os.path.abspath(os.path.dirname(sys.argv[0]))
+    if "bin" in xml_validate_path:
+        relaxng_path = os.path.join(xml_validate_path, "..", "share", "relaxng")
+    elif os.path.join("src", "utils") in xml_validate_path:
+        relaxng_path = os.path.join(xml_validate_path, "..", "relaxng")
+    else:
+        raise Exception("Set RelaxNG path with -r command line option.")
+if not os.path.exists(relaxng_path):
+    raise Exception("RelaxNG path: {0} does not exist, set with -r "
+                    "command line option.".format(relaxng_path))
 
 # Make sure there are .rnc files in RelaxNG path
 rnc_files = glob.glob(os.path.join(relaxng_path, "*.rnc"))
@@ -48,7 +59,8 @@ if len(rnc_files) == 0:
 # Get list of xml input files
 xml_files = glob.glob(os.path.join(inputs_path, "*.xml"))
 if len(xml_files) == 0:
-    raise Exception("No .xml files found at input path: {0}.".format(inputs_path))
+    raise Exception("No .xml files found at input path: {0}"
+                    ".".format(inputs_path))
 
 # Begin loop around input files
 for xml_file in xml_files:


### PR DESCRIPTION
This PR addresses #248. This new script checks two features of OpenMC XML input files:
- Can it be parsed by an XML parser
- Does it match relaxng files that are in the source directory

It can be run with:
```
python xml_validate.py -r {path to relaxng files in OpenMC src} -i {path to input files, optional, assumes current working directory}
```

Play around with it and let me know if I can make it better, it is at least a start. It will not catch my most prevalent mistake which is messing up energy bins in tally filters, but that is because the RNC files say it should be a string and not a list of doubles. 