### PR TITLE
fix a bug bug with VERIFY MD5 CHECKSUMS

### DIFF
--- a/data/get_nndc_data.py
+++ b/data/get_nndc_data.py
@@ -79,7 +79,7 @@ for f in files:
 
 print('Verifying MD5 checksums...')
 for f, checksum in zip(files, checksums):
-    downloadsum = hashlib.md5(open(f, 'r').read()).hexdigest()
+    downloadsum = hashlib.md5(open(f, 'rb').read()).hexdigest()
     if downloadsum != checksum:
         raise IOError("MD5 checksum for {} does not match. If this is your first "
                       "time receiving this message, please re-run the script. "


### PR DESCRIPTION
Datas should be opened with option 'rb' otherwise it will cause a decode problem.