### PR TITLE
Strings in Python API add_nuclide

### DIFF
--- a/src/utils/openmc/material.py
+++ b/src/utils/openmc/material.py
@@ -189,23 +189,27 @@ class Material(object):
 
     def add_nuclide(self, nuclide, percent, percent_type='ao'):
 
-        if not isinstance(nuclide, openmc.Nuclide):
-            msg = 'Unable to add an Nuclide to Material ID={0} with a ' \
+        if not isinstance(nuclide, (openmc.Nuclide, str)):
+            msg = 'Unable to add a Nuclide to Material ID={0} with a ' \
                   'non-Nuclide value {1}'.format(self._id, nuclide)
             raise ValueError(msg)
 
         elif not is_float(percent):
-            msg = 'Unable to add an Nuclide to Material ID={0} with a ' \
+            msg = 'Unable to add a Nuclide to Material ID={0} with a ' \
                   'non-floating point value {1}'.format(self._id, percent)
             raise ValueError(msg)
 
         elif not percent_type in ['ao', 'wo', 'at/g-cm']:
-            msg = 'Unable to add an Nuclide to Material ID={0} with a ' \
+            msg = 'Unable to add a Nuclide to Material ID={0} with a ' \
                   'percent type {1}'.format(self._id, percent_type)
             raise ValueError(msg)
 
-        # Copy this Nuclide to separate it from the Nuclide in other Materials
-        nuclide = deepcopy(nuclide)
+        if isinstance(nuclide, openmc.Nuclide):
+            # Copy this Nuclide to separate it from the Nuclide in
+            # other Materials
+            nuclide = deepcopy(nuclide)
+        else:
+            nuclide = openmc.Nuclide(nuclide)
 
         self._nuclides[nuclide._name] = (nuclide, percent, percent_type)
 


### PR DESCRIPTION
This PR gives users a quick short-cut when adding nuclides to materials in the Python API.  Rather than typing

```python
h1 = openmc.Nuclide('H-1')
o16 = openmc.Nuclide('O-16')
water.add_nuclide(h1, 2.0)
water.add_nuclide(o16, 1.0)
```

this PR will allow the more compact

```python
water.add_nuclide('H-1', 2.0)
water.add_nuclide('O-16', 1.0)
```