### PR TITLE
Polymorphic tallies

### DIFF
--- a/src/cmfd_data.F90
+++ b/src/cmfd_data.F90
@@ -79,7 +79,7 @@ contains
     integer :: i_filter_eout ! index for outgoing energy filter
     integer :: i_filter_surf ! index for surface filter
     real(8) :: flux          ! temp variable for flux
-    type(TallyObject),    pointer :: t => null() ! pointer for tally object
+    class(TallyObject),   pointer :: t => null() ! pointer for tally object
     type(StructuredMesh), pointer :: m => null() ! pointer for mesh object
 
     ! Extract spatial and energy indices from object
@@ -93,7 +93,7 @@ contains
     cmfd % openmc_src = ZERO
 
     ! Associate tallies and mesh
-    t => cmfd_tallies(1)
+    t => cmfd_tallies(1) % obj
     i_mesh = t % filters(t % find_filter(FILTER_MESH)) % int_bins(1)
     m => meshes(i_mesh)
 
@@ -108,7 +108,7 @@ contains
    TAL: do ital = 1, n_cmfd_tallies
 
      ! Associate tallies and mesh
-     t => cmfd_tallies(ital)
+     t => cmfd_tallies(ital) % obj
      i_mesh = t % filters(t % find_filter(FILTER_MESH)) % int_bins(1)
      m => meshes(i_mesh)
 

--- a/src/cmfd_execute.F90
+++ b/src/cmfd_execute.F90
@@ -418,8 +418,8 @@ contains
     do i = 1, n_cmfd_tallies
 
       ! Reset that tally
-      cmfd_tallies(i) % n_realizations = 0
-      call reset_result(cmfd_tallies(i) % results)
+      cmfd_tallies(i) % obj % n_realizations = 0
+      call reset_result(cmfd_tallies(i) % obj % results)
 
     end do
 

--- a/src/cmfd_input.F90
+++ b/src/cmfd_input.F90
@@ -303,7 +303,7 @@ contains
     integer :: i_filter_mesh ! index for mesh filter
     integer :: iarray3(3) ! temp integer array
     real(8) :: rarray3(3) ! temp double array
-    type(TallyObject),    pointer :: t => null()
+    class(TallyObject),   pointer :: t => null()
     type(StructuredMesh), pointer :: m => null()
     type(TallyFilter) :: filters(N_FILTER_TYPES) ! temporary filters
     type(Node), pointer :: node_mesh => null()
@@ -420,7 +420,8 @@ contains
     do i = 1, n_cmfd_tallies
 
       ! Point t to tally variable
-      t => cmfd_tallies(i)
+      allocate(TallyObject :: cmfd_tallies(i) % obj)
+      t => cmfd_tallies(i) % obj
 
       ! Set reset property
       if (check_for_node(doc, "reset")) then

--- a/src/global.F90
+++ b/src/global.F90
@@ -12,7 +12,7 @@ module global
   use plot_header,      only: ObjectPlot
   use set_header,       only: SetInt
   use source_header,    only: ExtSource
-  use tally_header,     only: TallyObject, TallyMap, TallyResult
+  use tally_header,     only: TallyContainer, TallyMap, TallyResult
   use timer_header,     only: Timer
 
 #ifdef HDF5
@@ -89,13 +89,13 @@ module global
   ! ============================================================================
   ! TALLY-RELATED VARIABLES
 
-  type(StructuredMesh), allocatable, target :: meshes(:)
-  type(TallyObject),    allocatable, target :: tallies(:)
+  type(StructuredMesh),  allocatable, target :: meshes(:)
+  type(TallyContainer),  allocatable, target :: tallies(:)
   integer, allocatable :: matching_bins(:)
 
   ! Pointers for different tallies
-  type(TallyObject), pointer :: user_tallies(:) => null()
-  type(TallyObject), pointer :: cmfd_tallies(:) => null()
+  type(TallyContainer), pointer :: user_tallies(:) => null()
+  type(TallyContainer), pointer :: cmfd_tallies(:) => null()
 
   ! Starting index (minus 1) in tallies for each tally group
   integer :: i_user_tallies = -1

--- a/src/hdf5_summary.F90
+++ b/src/hdf5_summary.F90
@@ -492,7 +492,7 @@ contains
     integer           :: i, j
     integer, allocatable :: temp_array(:) ! nuclide bin array
     type(StructuredMesh), pointer :: m => null()
-    type(TallyObject), pointer :: t => null()
+    class(TallyObject), pointer :: t => null()
 
     ! Write total number of meshes
     call su % write_data(n_meshes, "n_meshes", group="tallies")
@@ -529,7 +529,7 @@ contains
 
     TALLY_METADATA: do i = 1, n_tallies
       ! Get pointer to tally
-      t => tallies(i)
+      t => tallies(i) % obj
 
       ! Write size of each tally
       call su % write_data(t % total_score_bins, "total_score_bins", &

--- a/src/initialize.F90
+++ b/src/initialize.F90
@@ -560,9 +560,9 @@ contains
     integer :: lid                    ! lattice IDs
     integer :: i_array                ! index in surfaces/materials array 
     integer :: id                     ! user-specified id
-    type(Cell),        pointer :: c => null()
-    class(Lattice),    pointer :: lat => null()
-    type(TallyObject), pointer :: t => null()
+    type(Cell),         pointer :: c => null()
+    class(Lattice),     pointer :: lat => null()
+    class(TallyObject), pointer :: t => null()
 
     do i = 1, n_cells
       ! =======================================================================
@@ -683,7 +683,7 @@ contains
     end do
 
     TALLY_LOOP: do i = 1, n_tallies
-      t => tallies(i)
+      t => tallies(i) % obj
 
       ! =======================================================================
       ! ADJUST INDICES FOR EACH TALLY FILTER

--- a/src/input_xml.F90
+++ b/src/input_xml.F90
@@ -1966,7 +1966,8 @@ contains
     integer :: n_words       ! number of words read
     integer :: n_filters     ! number of filters
     integer :: n_new         ! number of new scores to add based on Yn/Pn tally
-    integer :: n_scores      ! number of tot scores after adjusting for Yn/Pn tally
+    integer :: n_scores      ! number of tot scores after adjusting for Yn/Pn
+                             ! tally
     integer :: n_bins        ! Total new bins for this score
     integer :: n_order       ! Moment order requested
     integer :: n_order_pos   ! Position of Scattering order in score name string
@@ -1981,7 +1982,7 @@ contains
     character(MAX_WORD_LEN) :: temp_str
     character(MAX_WORD_LEN), allocatable :: sarray(:)
     type(ElemKeyValueCI), pointer :: pair_list => null()
-    type(TallyObject),    pointer :: t => null()
+    class(TallyObject),   pointer :: t => null()
     type(StructuredMesh), pointer :: m => null()
     type(TallyFilter), allocatable :: filters(:) ! temporary filters
     type(Node), pointer :: doc => null()
@@ -2176,11 +2177,12 @@ contains
     ! READ TALLY DATA
 
     READ_TALLIES: do i = 1, n_user_tallies
-      ! Get pointer to tally
-      t => tallies(i)
-
       ! Get pointer to tally xml node
       call get_list_item(node_tal_list, i, node_tal)
+
+      ! Get pointer to tally
+      allocate(TallyObject :: tallies(i) % obj)
+      t => tallies(i) % obj
 
       ! Set tally type to volume by default
       t % type = TALLY_VOLUME
@@ -2597,6 +2599,7 @@ contains
               call fatal_error("Cannot tally flux with an outgoing energy &
                    &filter.")
             end if
+
           case ('flux-yn')
             ! Prohibit user from tallying flux for an individual nuclide
             if (.not. (t % n_nuclide_bins == 1 .and. &
@@ -3195,8 +3198,8 @@ contains
                      &meshlines on plot " // trim(to_str(pl % id)))
               end if
 
-              i_mesh = cmfd_tallies(1) % &
-                  filters(cmfd_tallies(1) % find_filter(FILTER_MESH)) % &
+              i_mesh = cmfd_tallies(1) % obj % &
+                  filters(cmfd_tallies(1) % obj % find_filter(FILTER_MESH)) % &
                   int_bins(1)
               pl % meshlines_mesh => meshes(i_mesh)
 

--- a/src/output.F90
+++ b/src/output.F90
@@ -700,8 +700,8 @@ contains
 
   subroutine print_tally(t, unit)
 
-    type(TallyObject), pointer :: t
-    integer,          optional :: unit
+    class(TallyObject), pointer :: t
+    integer,           optional :: unit
 
     integer :: i     ! index for filter or score bins
     integer :: j     ! index in filters array
@@ -1197,8 +1197,8 @@ contains
 
     integer                 :: i      ! loop index
     character(MAX_FILE_LEN) :: path   ! path of summary file
-    type(Material),    pointer :: m => null()
-    type(TallyObject), pointer :: t => null()
+    type(Material),     pointer :: m => null()
+    class(TallyObject), pointer :: t => null()
 
     ! Create filename for log file
     path = trim(path_output) // "summary.out"
@@ -1256,7 +1256,7 @@ contains
     if (n_tallies > 0) then
       call header("TALLY SUMMARY", unit=UNIT_SUMMARY)
       do i = 1, n_tallies
-        t=> tallies(i)
+        t => tallies(i) % obj
         call print_tally(t, unit=UNIT_SUMMARY)
       end do
     end if
@@ -1704,7 +1704,7 @@ contains
     character(36)           :: score_names(N_SCORE_TYPES)  ! names of scoring function
     character(36)           :: score_name                  ! names of scoring function
                                                            ! to be applied at write-time
-    type(TallyObject), pointer :: t
+    class(TallyObject), pointer :: t
 
     ! Skip if there are no tallies
     if (n_tallies == 0) return
@@ -1753,7 +1753,7 @@ contains
     end if
 
     TALLY_LOOP: do i = 1, n_tallies
-      t => tallies(i)
+      t => tallies(i) % obj
 
       if (confidence_intervals) then
         ! Calculate t-value for confidence intervals
@@ -1934,7 +1934,7 @@ contains
 
   subroutine write_surface_current(t)
 
-    type(TallyObject), pointer :: t
+    class(TallyObject), pointer :: t
 
     integer :: i                    ! mesh index for x
     integer :: j                    ! mesh index for y
@@ -2106,9 +2106,9 @@ contains
 
   function get_label(t, i_filter) result(label)
 
-    type(TallyObject), pointer :: t        ! tally object
-    integer, intent(in)        :: i_filter ! index in filters array
-    character(30)              :: label    ! user-specified identifier
+    class(TallyObject), pointer :: t        ! tally object
+    integer, intent(in)         :: i_filter ! index in filters array
+    character(30)               :: label    ! user-specified identifier
 
     integer :: i      ! index in cells/surfaces/etc array
     integer :: bin

--- a/src/state_point.F90
+++ b/src/state_point.F90
@@ -43,7 +43,7 @@ contains
     integer, allocatable          :: id_array(:)
     integer, allocatable          :: key_array(:)
     type(StructuredMesh), pointer :: mesh
-    type(TallyObject), pointer    :: tally
+    class(TallyObject),   pointer :: tally
     type(ElemKeyValueII), pointer :: current
     type(ElemKeyValueII), pointer :: next
     character(8)                  :: moment_name  ! name of moment (e.g, P3)
@@ -218,7 +218,7 @@ contains
 
         ! Write all tally information except results
         do i = 1, n_tallies
-          tally => tallies(i)
+          tally => tallies(i) % obj
           key_array(i) = tally % id
           id_array(i) = i
         end do
@@ -234,7 +234,7 @@ contains
         TALLY_METADATA: do i = 1, n_tallies
 
           ! Get pointer to tally
-          tally => tallies(i)
+          tally => tallies(i) % obj
 
           call sp % write_data(len(tally % label), "label_size", &
                group="tallies/tally " // trim(to_str(tally % id)))
@@ -368,7 +368,7 @@ contains
         TALLY_RESULTS: do i = 1, n_tallies
 
           ! Set point to current tally
-          tally => tallies(i)
+          tally => tallies(i) % obj
 
           ! Write sum and sum_sq for each bin
           call sp % write_tally_result(tally % results, "results", &
@@ -502,7 +502,7 @@ contains
     integer, allocatable       :: id_array(:)
     type(ElemKeyValueII), pointer :: current
     type(ElemKeyValueII), pointer :: next
-    type(TallyObject), pointer :: tally
+    class(TallyObject), pointer   :: tally
     type(TallyResult), allocatable :: tallyresult_temp(:,:)
 
     ! ==========================================================================
@@ -579,7 +579,7 @@ contains
       ! Write all tally results
       TALLY_RESULTS: do i = 1, n_tallies
 
-        tally => tallies(i)
+        tally => tallies(i) % obj
 
         ! Determine size of tally results array
         m = size(tally % results, 1)
@@ -660,7 +660,7 @@ contains
     logical                    :: source_present
     real(8)                    :: real_array(3)
     type(StructuredMesh), pointer :: mesh
-    type(TallyObject), pointer :: tally
+    class(TallyObject), pointer :: tally
     integer                    :: n_order      ! loop index for moment orders
     integer                    :: nm_order     ! loop index for Ynm moment orders
     character(8)               :: moment_name  ! name of moment (e.g, P3, Y-1,1)
@@ -823,7 +823,7 @@ contains
     TALLY_METADATA: do i = 1, n_tallies
 
       ! Get pointer to tally
-      tally => tallies(i)
+      tally => tallies(i) % obj
       curr_key = key_array(id_array(i))
 
       call sp % read_data(j, "label_size", group="tallies/tally " // &
@@ -955,7 +955,7 @@ contains
         TALLY_RESULTS: do i = 1, n_tallies
 
           ! Set pointer to tally
-          tally => tallies(i)
+          tally => tallies(i) % obj
           curr_key = key_array(id_array(i))
 
           ! Read sum and sum_sq for each bin

--- a/src/tally_header.F90
+++ b/src/tally_header.F90
@@ -128,6 +128,16 @@ module tally_header
       procedure :: clear => tallyobject_clear ! Deallocates TallyObject
   end type TallyObject
 
+!===============================================================================
+! TALLYCONTAINER polymorphic object that stores a class(TallyObject)
+!===============================================================================
+
+  type TallyContainer
+    class(TallyObject), allocatable :: obj
+    contains
+    procedure :: clear => tallycontainer_clear
+  end type TallyContainer
+
   contains
 
 !===============================================================================
@@ -193,5 +203,16 @@ module tally_header
       this % n_realizations = 0
 
     end subroutine tallyobject_clear
+
+!===============================================================================
+! TALLYCONTAINER_CLEAR deallocates a TallyContainer element and sets it to its
+! as initialized state.
+!===============================================================================
+
+    subroutine tallycontainer_clear(this)
+      class(TallyContainer), intent(inout) :: this
+      call this % obj % clear()
+      deallocate(this % obj)
+    end subroutine tallycontainer_clear
 
 end module tally_header

--- a/src/tally_initialize.F90
+++ b/src/tally_initialize.F90
@@ -2,7 +2,8 @@ module tally_initialize
 
   use constants
   use global
-  use tally_header, only: TallyObject, TallyMapElement, TallyMapItem
+  use tally_header, only: TallyObject, TallyMapElement, TallyMapItem, &
+                          TallyContainer
 
   implicit none
   private
@@ -38,11 +39,11 @@ contains
     integer :: j                 ! loop index for filters
     integer :: n                 ! temporary stride
     integer :: max_n_filters = 0 ! maximum number of filters
-    type(TallyObject), pointer :: t => null()
+    class(TallyObject), pointer :: t => null()
 
     TALLY_LOOP: do i = 1, n_tallies
       ! Get pointer to tally
-      t => tallies(i)
+      t => tallies(i) % obj
 
       ! Allocate stride and matching_bins arrays
       allocate(t % stride(t % n_filters))
@@ -88,7 +89,7 @@ contains
     integer :: k    ! loop index for bins
     integer :: bin  ! filter bin entries
     integer :: type ! type of tally filter
-    type(TallyObject), pointer :: t => null()
+    class(TallyObject), pointer :: t => null()
 
     ! allocate tally map array -- note that we don't need a tally map for the
     ! energy_in and energy_out filters
@@ -103,7 +104,7 @@ contains
 
     TALLY_LOOP: do i = 1, n_tallies
       ! Get pointer to tally
-      t => tallies(i)
+      t => tallies(i) % obj
 
       ! No need to set up tally maps for surface current tallies
       if (t % type == TALLY_SURFACE_CURRENT) cycle
@@ -176,7 +177,7 @@ contains
     character(*), intent(in) :: tally_group ! name of tally group
     integer,      intent(in) :: n           ! number of tallies to add
 
-    type(TallyObject), allocatable :: temp(:) ! temporary tallies array
+    type(TallyContainer), allocatable :: temp(:) ! temporary tallies array
 
     if (n_tallies == 0) then
       ! Allocate tallies array


### PR DESCRIPTION
This PR adds the `TallyContainer` class which contains objects of the class `TallyObject`.  This will allow us to more easily add new tally functionality that requires extending `TallyObject`.  This is analogous to the `Lattice` and `LatticeContainer` types.

In the near future, I plan to implement differential tallies using an extension of `TallyObject`.  I also expect that a polymorphic `TallyObject` will be helpful over the course of the tally refactoring.

This PR doesn't actually change any functionality so I'll understand if you'd rather not review it now and wait until I've added more, but I would prefer to implement differential tallies and the tally refactor through a bunch of smaller, incremental PRs like this one rather than with a big, monolithic PR.  I think the small PRs will make it easy for me to keep up with the develop branch and make it easier for you guys to review my work.  Do you agree with this thinking?