### PR TITLE
Fixed trigger_scores memory leak in input_xml.F90

### DIFF
--- a/src/input_xml.F90
+++ b/src/input_xml.F90
@@ -2920,7 +2920,7 @@ contains
           end select
 
           ! Append the score to the list of possible trigger scores
-          call trigger_scores % add_key(trim(score_name), l)
+          if (trigger_on) call trigger_scores % add_key(trim(score_name), l)
 
         end do
         t % n_score_bins = n_scores


### PR DESCRIPTION
This fixes the memory leak introduced by #264 as noticed by @bhermanmit in #380.