### PR TITLE
Check for gfortran version < 4.6 in CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,6 +56,13 @@ endif()
 #===============================================================================
 
 if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+  # Make sure version is sufficient
+  execute_process(COMMAND ${CMAKE_Fortran_COMPILER} -dumpversion
+    OUTPUT_VARIABLE GCC_VERSION)
+  if(GCC_VERSION VERSION_LESS 4.6)
+    message(FATAL_ERROR "gfortran version must be 4.6 or higher")
+  endif()
+
   # GNU Fortran compiler options
   set(f90flags  "-cpp -std=f2008 -fbacktrace")
   if(debug)


### PR DESCRIPTION
This pull request checks at configure-time whether the version of gfortran is sufficient, if gfortran is being used as the Fortran compiler. @scopatz Care to test this fix on your ancient machine?