### PR TITLE
Test Python 2.7 and 3.4 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,34 @@
+language: python
+python:
+  - "2.7"
+  - "3.4"
+
 before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq -y python-numpy
-  - sudo apt-get install -qq -y python-scipy
-  - sudo apt-get install -qq -y python-h5py
-  - sudo apt-get install -qq -y gfortran
-  - sudo apt-get install -qq -y g++
+  # ============== Handle Python third-party packages ==============
+  - sudo apt-get update
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+    else
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    fi
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  - conda info -a
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy h5py
+  - source activate test-environment
+
+  # ============== Install GCC, MPICH, HDF5, PHDF5 ==============
+  - sudo apt-get install -qq -y gfortran g++
   - ./tests/travis_install.sh
   - export FC=gfortran
   - export MPI_DIR=$PWD/mpich_install
   - export PHDF5_DIR=$PWD/phdf5_install
   - export HDF5_DIR=$PWD/hdf5_install
+
+install: true
 
 before_script:
   - cd data

--- a/tests/test_trace/test_trace.py
+++ b/tests/test_trace/test_trace.py
@@ -23,7 +23,7 @@ def test_run():
     print(stdout)
     returncode = proc.returncode
     assert returncode == 0, 'OpenMC did not exit successfully.'
-    assert stdout.find('Simulating Particle 453') != -1
+    assert stdout.find(b'Simulating Particle 453') != -1
 
 def test_created_statepoint():
     statepoint = glob.glob(os.path.join(cwd, 'statepoint.10.*'))


### PR DESCRIPTION
This pull request changes .travis.yml to do concurrent runs with both Python 2.7 and Python 3.4 (Thanks to @scopatz for the suggestion!). The older approach of installing Python packages via apt-get wouldn't work for Python 3 because there's no python3-h5py package in Ubuntu 12.04. I've adopted an approach now used by many projects, i.e. using miniconda to install Python packages. That way we are not limited by what's available in the system packages.

Running the test suite with Python 3 did uncover one bug in a test which I've fixed.

@bhermanmit You are the logical choice for reviewer.