### PR TITLE
Fix bugs related to track files

### DIFF
--- a/scripts/openmc-track-to-vtk
+++ b/scripts/openmc-track-to-vtk
@@ -49,7 +49,7 @@ def main():
     if not args.out:
         args.out = 'tracks.pvtp'
     elif os.path.splitext(args.out)[1] != '.pvtp':
-        args.out = ''.join([args.out, '.pvtp'])
+        args.out += '.pvtp'
 
     # Import HDF library if HDF files are present
     for fname in args.input:
@@ -65,7 +65,7 @@ def main():
         # Write coordinate values to points array.
         if fname.endswith('.binary'):
             track = open(fname, 'rb').read()
-            coords = [struct.unpack("ddd", track[24*i : 24*(i+1)])
+            coords = [struct.unpack("ddd", track[24*i:24*(i+1)])
                       for i in range(len(track)/24)]
             n_points = len(coords)
             for triplet in coords:
@@ -74,7 +74,7 @@ def main():
             coords = h5py.File(fname).get('coordinates')
             n_points = coords.shape[0]
             for i in range(n_points):
-                points.InsertNextPoint(coords[i,:])
+                points.InsertNextPoint(coords[i, :])
 
         # Create VTK line and assign points to line.
         line = vtk.vtkPolyLine()
@@ -92,7 +92,6 @@ def main():
     writer.SetInputData(data)
     writer.SetFileName(args.out)
     writer.Write()
-
 
 
 if __name__ == '__main__':

--- a/scripts/openmc-track-to-vtk
+++ b/scripts/openmc-track-to-vtk
@@ -48,7 +48,7 @@ def main():
     # Make sure that the output filename ends with '.pvtp'.
     if not args.out:
         args.out = 'tracks.pvtp'
-    elif os.path.splitext(args.out)[1] != '.pvtp':
+    elif not args.out.endswith('.pvtp'):
         args.out += '.pvtp'
 
     # Import HDF library if HDF files are present

--- a/scripts/openmc-track-to-vtk
+++ b/scripts/openmc-track-to-vtk
@@ -65,7 +65,7 @@ def main():
         # Write coordinate values to points array.
         if fname.endswith('.binary'):
             track = open(fname, 'rb').read()
-            coords = [struct.unpack("ddd", track[24*i:24*(i+1)])
+            coords = [struct.unpack("ddd", track[24*i : 24*(i+1)])
                       for i in range(len(track)/24)]
             n_points = len(coords)
             for triplet in coords:

--- a/scripts/openmc-track-to-vtk
+++ b/scripts/openmc-track-to-vtk
@@ -44,7 +44,7 @@ def main():
         if not (fname.endswith('.h5') or fname.endswith('.binary')):
             raise ValueError("Input file names must either end with '.h5' or"
                              "'.binary'.")
-    
+
     # Make sure that the output filename ends with '.pvtp'.
     if not args.out:
         args.out = 'tracks.pvtp'
@@ -75,21 +75,21 @@ def main():
             n_points = coords.shape[0]
             for i in range(n_points):
                 points.InsertNextPoint(coords[i,:])
-                
+
         # Create VTK line and assign points to line.
         line = vtk.vtkPolyLine()
         line.GetPointIds().SetNumberOfIds(n_points)
         for i in range(n_points):
             line.GetPointIds().SetId(i, point_offset+i)
-        
+
         cells.InsertNextCell(line)
         point_offset += n_points
     data = vtk.vtkPolyData()
     data.SetPoints(points)
     data.SetLines(cells)
-    
+
     writer = vtk.vtkXMLPPolyDataWriter()
-    writer.SetInput(data)
+    writer.SetInputData(data)
     writer.SetFileName(args.out)
     writer.Write()
 

--- a/scripts/openmc-track-to-vtk
+++ b/scripts/openmc-track-to-vtk
@@ -89,7 +89,10 @@ def main():
     data.SetLines(cells)
 
     writer = vtk.vtkXMLPPolyDataWriter()
-    writer.SetInputData(data)
+    if vtk.vtkVersion.GetVTKMajorVersion() > 5:
+        writer.SetInputData(data)
+    else:
+        writer.SetInput(data)
     writer.SetFileName(args.out)
     writer.Write()
 

--- a/scripts/openmc-voxel-to-silovtk
+++ b/scripts/openmc-voxel-to-silovtk
@@ -62,7 +62,7 @@ def main(file_, o):
     grid.GetCellData().AddArray(data)
 
     writer = vtk.vtkXMLImageDataWriter()
-    writer.SetInput(grid)
+    writer.SetInputData(grid)
     if not o.output[-4:] == ".vti": o.output += ".vti"
     writer.SetFileName(o.output)
     writer.Write()

--- a/scripts/openmc-voxel-to-silovtk
+++ b/scripts/openmc-voxel-to-silovtk
@@ -62,7 +62,10 @@ def main(file_, o):
         grid.GetCellData().AddArray(data)
 
         writer = vtk.vtkXMLImageDataWriter()
-        writer.SetInputData(grid)
+        if vtk.vtkVersion.GetVTKMajorVersion() > 5:
+            writer.SetInputData(grid)
+        else:
+            writer.SetInput(grid)
         if not o.output.endswith(".vti"):
             o.output += ".vti"
         writer.SetFileName(o.output)

--- a/scripts/openmc-voxel-to-silovtk
+++ b/scripts/openmc-voxel-to-silovtk
@@ -24,25 +24,27 @@ def parse_options():
 
 def main(file_, o):
     print(file_)
-    fh = open(file_,'rb')
+    fh = open(file_, 'rb')
     header = get_header(fh)
-    meshparms = header['dimension'] + header['lower_left'] + header['upper_right']
-    nx,ny,nz = meshparms[0], meshparms[1], meshparms[2]
+    meshparms = (header['dimension'] + header['lower_left'] +
+                 header['upper_right'])
+    nx, ny, nz = meshparms[:3]
     ll = header['lower_left']
 
     if o.vtk:
         try:
             import vtk
         except:
-            print('The vtk python bindings do not appear to be installed properly.\n'
-                  'On Ubuntu: sudo apt-get install python-vtk\n'
+            print('The vtk python bindings do not appear to be installed '
+                  'properly.\nOn Ubuntu: sudo apt-get install python-vtk\n'
                   'See: http://www.vtk.org/')
             return
 
-        origin = [(l+w*n/2.) for n,l,w in zip((nx,ny,nz),ll,header['width'])]
+        origin = [(l + w*n/2.) for n, l, w in
+                  zip((nx, ny, nz), ll, header['width'])]
 
         grid = vtk.vtkImageData()
-        grid.SetDimensions(nx+1,ny+1,nz+1)
+        grid.SetDimensions(nx+1, ny+1, nz+1)
         grid.SetOrigin(*ll)
         grid.SetSpacing(*header['width'])
 
@@ -61,7 +63,8 @@ def main(file_, o):
 
         writer = vtk.vtkXMLImageDataWriter()
         writer.SetInputData(grid)
-        if not o.output[-4:] == ".vti": o.output += ".vti"
+        if not o.output.endswith(".vti"):
+            o.output += ".vti"
         writer.SetFileName(o.output)
         writer.Write()
 
@@ -69,18 +72,19 @@ def main(file_, o):
         try:
             import silomesh
         except:
-            print('The silomesh package does not appear to be installed properly.\n'
-                  'See: https://github.com/nhorelik/silomesh/')
+            print('The silomesh package does not appear to be installed '
+                  'properly.\nSee: https://github.com/nhorelik/silomesh/')
             return
-        if not o.output[-5:] == ".silo": o.output += ".silo"
+        if not o.output.endswith(".silo"):
+            o.output += ".silo"
         silomesh.init_silo(o.output)
         silomesh.init_mesh('plot', *meshparms)
         silomesh.init_var("id")
-        for x in range(1,nx+1):
+        for x in range(1, nx+1):
             sys.stdout.write(" {0}%\r".format(int(x/nx*100)))
             sys.stdout.flush()
-            for y in range(1,ny+1):
-                for z in range(1,nz+1):
+            for y in range(1, ny+1):
+                for z in range(1, nz+1):
                     id_ = get_int(fh)[0]
                     silomesh.set_value(float(id_), x, y, z)
         print()
@@ -90,16 +94,17 @@ def main(file_, o):
 
 
 def get_header(file_):
-    nx,ny,nz = get_int(file_, 3)
-    wx,wy,wz = get_double(file_, 3)
-    lx,ly,lz = get_double(file_, 3)
-    header = {'dimension':[nx,ny,nz], 'width':[wx,wy,wz], 'lower_left':[lx,ly,lz],
-              'upper_right': [lx+wx*nx,ly+wy*ny,lz+wz*nz]}
+    nx, ny, nz = get_int(file_, 3)
+    wx, wy, wz = get_double(file_, 3)
+    lx, ly, lz = get_double(file_, 3)
+    header = {'dimension': [nx, ny, nz], 'width': [wx, wy, wz],
+              'lower_left': [lx, ly, lz],
+              'upper_right': [lx+wx*nx, ly+wy*ny, lz+wz*nz]}
     return header
 
 
 def get_data(file_, n, typeCode, size):
-    return list(struct.unpack('={0}{1}'.format(n,typeCode),
+    return list(struct.unpack('={0}{1}'.format(n, typeCode),
                               file_.read(n*size)))
 
 
@@ -114,4 +119,4 @@ def get_double(file_, n=1, path=None):
 if __name__ == '__main__':
     (options, args) = parse_options()
     if args:
-        main(args[0],options)
+        main(args[0], options)

--- a/scripts/openmc-voxel-to-silovtk
+++ b/scripts/openmc-voxel-to-silovtk
@@ -1,120 +1,117 @@
 #!/usr/bin/env python2
 
 from __future__ import division, print_function
-
 import struct
 import sys
 
-################################################################################
+
 def parse_options():
-  """Process command line arguments"""
+    """Process command line arguments"""
 
-  from optparse import OptionParser
-  usage = r"""%prog [options] <voxel_file>"""
-  p = OptionParser(usage=usage)
-  p.add_option('-o', '--output', action='store', dest='output',
-             default='plot', help='Path to output SILO or VTK file.')
-  p.add_option('-v', '--vtk', action='store_true', dest='vtk',
-           default=False, help='Flag to convert to VTK instead of SILO.')
-  parsed = p.parse_args()
-  if not parsed[1]:
-    p.print_help()
+    from optparse import OptionParser
+    usage = r"""%prog [options] <voxel_file>"""
+    p = OptionParser(usage=usage)
+    p.add_option('-o', '--output', action='store', dest='output',
+                 default='plot', help='Path to output SILO or VTK file.')
+    p.add_option('-v', '--vtk', action='store_true', dest='vtk',
+                 default=False, help='Flag to convert to VTK instead of SILO.')
+    parsed = p.parse_args()
+    if not parsed[1]:
+        p.print_help()
+        return parsed
     return parsed
-  return parsed
 
-################################################################################
+
 def main(file_, o):
+    print(file_)
+    fh = open(file_,'rb')
+    header = get_header(fh)
+    meshparms = header['dimension'] + header['lower_left'] + header['upper_right']
+    nx,ny,nz = meshparms[0], meshparms[1], meshparms[2]
+    ll = header['lower_left']
 
-  print(file_)
-  fh = open(file_,'rb')
-  header = get_header(fh)
-  meshparms = header['dimension'] + header['lower_left'] + header['upper_right']
-  nx,ny,nz = meshparms[0], meshparms[1], meshparms[2]
-  ll = header['lower_left']
+    if o.vtk:
+        try:
+            import vtk
+        except:
+            print('The vtk python bindings do not appear to be installed properly.\n'
+                  'On Ubuntu: sudo apt-get install python-vtk\n'
+                  'See: http://www.vtk.org/')
+            return
 
-  if o.vtk:
-    try:
-      import vtk
-    except:
-      print('The vtk python bindings do not appear to be installed properly.\n'
-            'On Ubuntu: sudo apt-get install python-vtk\n'
-            'See: http://www.vtk.org/')
-      return
+        origin = [(l+w*n/2.) for n,l,w in zip((nx,ny,nz),ll,header['width'])]
 
-    origin = [(l+w*n/2.) for n,l,w in zip((nx,ny,nz),ll,header['width'])]
+        grid = vtk.vtkImageData()
+        grid.SetDimensions(nx+1,ny+1,nz+1)
+        grid.SetOrigin(*ll)
+        grid.SetSpacing(*header['width'])
 
-    grid = vtk.vtkImageData()
-    grid.SetDimensions(nx+1,ny+1,nz+1)
-    grid.SetOrigin(*ll)
-    grid.SetSpacing(*header['width'])
+        data = vtk.vtkDoubleArray()
+        data.SetName("id")
+        data.SetNumberOfTuples(nx*ny*nz)
+        for x in range(nx):
+            sys.stdout.write(" {0}%\r".format(int(x/nx*100)))
+            sys.stdout.flush()
+            for y in range(ny):
+                for z in range(nz):
+                    i = z*nx*ny + y*nx + x
+                    id_ = get_int(fh)[0]
+                    data.SetValue(i, id_)
+        grid.GetCellData().AddArray(data)
 
-    data = vtk.vtkDoubleArray()
-    data.SetName("id")
-    data.SetNumberOfTuples(nx*ny*nz)
-    for x in range(nx):
-      sys.stdout.write(" {0}%\r".format(int(x/nx*100)))
-      sys.stdout.flush()
-      for y in range(ny):
-        for z in range(nz):
-          i = z*nx*ny + y*nx + x
-          id_ = get_int(fh)[0]
-          data.SetValue(i, id_)
-    grid.GetCellData().AddArray(data)
+        writer = vtk.vtkXMLImageDataWriter()
+        writer.SetInputData(grid)
+        if not o.output[-4:] == ".vti": o.output += ".vti"
+        writer.SetFileName(o.output)
+        writer.Write()
 
-    writer = vtk.vtkXMLImageDataWriter()
-    writer.SetInputData(grid)
-    if not o.output[-4:] == ".vti": o.output += ".vti"
-    writer.SetFileName(o.output)
-    writer.Write()
+    else:
+        try:
+            import silomesh
+        except:
+            print('The silomesh package does not appear to be installed properly.\n'
+                  'See: https://github.com/nhorelik/silomesh/')
+            return
+        if not o.output[-5:] == ".silo": o.output += ".silo"
+        silomesh.init_silo(o.output)
+        silomesh.init_mesh('plot', *meshparms)
+        silomesh.init_var("id")
+        for x in range(1,nx+1):
+            sys.stdout.write(" {0}%\r".format(int(x/nx*100)))
+            sys.stdout.flush()
+            for y in range(1,ny+1):
+                for z in range(1,nz+1):
+                    id_ = get_int(fh)[0]
+                    silomesh.set_value(float(id_), x, y, z)
+        print()
+        silomesh.finalize_var()
+        silomesh.finalize_mesh()
+        silomesh.finalize_silo()
 
-  else:
 
-    try:
-      import silomesh
-    except:
-      print('The silomesh package does not appear to be installed properly.\n'
-            'See: https://github.com/nhorelik/silomesh/')
-      return
-    if not o.output[-5:] == ".silo": o.output += ".silo"
-    silomesh.init_silo(o.output)
-    silomesh.init_mesh('plot', *meshparms)
-    silomesh.init_var("id")
-    for x in range(1,nx+1):
-      sys.stdout.write(" {0}%\r".format(int(x/nx*100)))
-      sys.stdout.flush()
-      for y in range(1,ny+1):
-        for z in range(1,nz+1):
-          id_ = get_int(fh)[0]
-          silomesh.set_value(float(id_), x, y, z)
-    print()
-    silomesh.finalize_var()
-    silomesh.finalize_mesh()
-    silomesh.finalize_silo()
-
-################################################################################
 def get_header(file_):
-  nx,ny,nz = get_int(file_, 3)
-  wx,wy,wz = get_double(file_, 3)
-  lx,ly,lz = get_double(file_, 3)
-  header = {'dimension':[nx,ny,nz], 'width':[wx,wy,wz], 'lower_left':[lx,ly,lz],
-            'upper_right': [lx+wx*nx,ly+wy*ny,lz+wz*nz]}
-  return header
+    nx,ny,nz = get_int(file_, 3)
+    wx,wy,wz = get_double(file_, 3)
+    lx,ly,lz = get_double(file_, 3)
+    header = {'dimension':[nx,ny,nz], 'width':[wx,wy,wz], 'lower_left':[lx,ly,lz],
+              'upper_right': [lx+wx*nx,ly+wy*ny,lz+wz*nz]}
+    return header
 
-################################################################################
+
 def get_data(file_, n, typeCode, size):
-  return list(struct.unpack('={0}{1}'.format(n,typeCode),
-                            file_.read(n*size)))
+    return list(struct.unpack('={0}{1}'.format(n,typeCode),
+                              file_.read(n*size)))
 
-################################################################################
+
 def get_int(file_, n=1, path=None):
-  return get_data(file_, n, 'i', 4)
+    return get_data(file_, n, 'i', 4)
 
-################################################################################
+
 def get_double(file_, n=1, path=None):
-  return get_data(file_, n, 'd', 8)
+    return get_data(file_, n, 'd', 8)
 
-################################################################################
+
 if __name__ == '__main__':
-  (options, args) = parse_options()
-  if args:
-    main(args[0],options)
+    (options, args) = parse_options()
+    if args:
+        main(args[0],options)

--- a/src/fixed_source.F90
+++ b/src/fixed_source.F90
@@ -126,7 +126,7 @@ contains
     if (master) call check_triggers()
 #ifdef MPI
     call MPI_BCAST(satisfy_triggers, 1, MPI_LOGICAL, 0, &
-         MPI_COMM_WORLD, mpi_err)              
+         MPI_COMM_WORLD, mpi_err)
 #endif
     if (satisfy_triggers .or. &
          (trigger_on .and. current_batch == n_max_batches)) then
@@ -156,6 +156,9 @@ contains
 
     ! Copy source attributes to the particle
     call copy_source_attributes(p, source_site)
+
+    ! Determine whether to create track file
+    if (write_all_tracks) p % write_track = .true.
 
   end subroutine sample_source_particle
 

--- a/src/track_output.F90
+++ b/src/track_output.F90
@@ -69,10 +69,12 @@ contains
          // '_' // trim(to_str(current_gen)) // '_' // trim(to_str(p % id)) &
          // '.binary'
 #endif
+!$omp critical
     call binout % file_create(fname)
     length = [3, n_tracks]
     call binout % write_data(coords, 'coordinates', length=length)
     call binout % file_close()
+!$omp end critical
     deallocate(coords)
   end subroutine finalize_particle_track
 

--- a/tests/test_track_output/results.py
+++ b/tests/test_track_output/results.py
@@ -17,7 +17,7 @@ except ImportError:
     exit()
 
 # Run track processing script
-call(['../../track.py', '-o', 'poly'] +
+call(['../../scripts/openmc-track-to-vtk', '-o', 'poly'] +
      glob.glob(''.join((cwd, '/track*'))))
 poly = ''.join((cwd, '/poly.pvtp'))
 assert os.path.isfile(poly), 'poly.pvtp file not found.'


### PR DESCRIPTION
This pull request fixes a few issues I ran into recently when trying to generate a plot of neutron tracks from a fixed source problem:

- The `-t` command-line flag didn't work for fixed source problems.
- Creating particle track files would fail when threading was turned on. I've fixed this by adding `!$omp critical` around the file writing.
- The openmc-track-to-vtk and openmc-voxel-to-silovtk scripts (recently renamed) failed when trying to generate VTK files. The cause was a change in the VTK 6 API (vtkXMLImageDataWriter.SetInput --> vtkXMLImageDataWriter.SetInputData) as described [here](http://www.vtk.org/Wiki/VTK/VTK_6_Migration/Replacement_of_SetInput).
- I've also cleaned up those two scripts (PEP8 compliance) and made a few changes in the interest of being more Pythonic.