### PR TITLE
Allow Python API to be used without h5py

### DIFF
--- a/openmc/summary.py
+++ b/openmc/summary.py
@@ -3,20 +3,14 @@ import numpy as np
 import openmc
 
 
-_h5_imported = False
-
-
 class Summary(object):
 
     def __init__(self, filename):
 
-        if not _h5_imported:
-            try:
-                import h5py
-                _h5_imported = True
-            except ImportError:
-                msg = 'Unable to import h5py which is needed by openmc.summary'
-                raise ImportError(msg)
+        # A user may not have h5py, but they can still use the rest of the
+        # Python API so we'll only try to import h5py if the user actually inits
+        # a Summary object.
+        import h5py
 
         openmc.reset_auto_ids()
 

--- a/openmc/summary.py
+++ b/openmc/summary.py
@@ -2,16 +2,21 @@ import numpy as np
 
 import openmc
 
-try:
-    import h5py
-except ImportError:
-    msg = 'Unable to import h5py which is needed by openmc.summary'
-    raise ImportError(msg)
+
+_h5_imported = False
 
 
 class Summary(object):
 
     def __init__(self, filename):
+
+        if not _h5_imported:
+            try:
+                import h5py
+                _h5_imported = True
+            except ImportError:
+                msg = 'Unable to import h5py which is needed by openmc.summary'
+                raise ImportError(msg)
 
         openmc.reset_auto_ids()
 


### PR DESCRIPTION
Importing openmc in turn imports h5py through openmc.summary.  This PR makes it so that h5py isn't imported unless a user actually inits a `Summary`