### PR TITLE
Named OpenMP Critical Regions

### DIFF
--- a/src/particle_restart_write.F90
+++ b/src/particle_restart_write.F90
@@ -38,7 +38,7 @@ contains
     filename = trim(filename) // '.binary'
 #endif
 
-!$omp critical
+!$omp critical (write_particle_restart)
     ! Create file
     call pr % file_create(filename)
 
@@ -66,7 +66,7 @@ contains
 
     ! Close file
     call pr % file_close()
-!$omp end critical
+!$omp end critical (write_particle_restart)
 
   end subroutine write_particle_restart
 

--- a/src/tally.F90
+++ b/src/tally.F90
@@ -470,13 +470,13 @@ contains
           num_nm = 2 * n + 1
 
           ! multiply score by the angular flux moments and store
-!$omp critical
+!$omp critical (score_general_scatt_yn)
           t % results(score_index: score_index + num_nm - 1, filter_index) &
                % value = t &
                % results(score_index: score_index + num_nm - 1, filter_index)&
                % value &
                + score * calc_pn(n, p % mu) * calc_rn(n, p % last_uvw)
-!$omp end critical
+!$omp end critical (score_general_scatt_yn)
         end do
         i = i + (t % moment_order(i) + 1)**2 - 1
 
@@ -498,13 +498,13 @@ contains
           num_nm = 2 * n + 1
 
           ! multiply score by the angular flux moments and store
-!$omp critical
+!$omp critical (score_general_flux_tot_yn)
           t % results(score_index: score_index + num_nm - 1, filter_index) &
                % value = t &
                % results(score_index: score_index + num_nm - 1, filter_index)&
                % value &
                + score * calc_rn(n, uvw)
-!$omp end critical
+!$omp end critical (score_general_flux_tot_yn)
         end do
         i = i + (t % moment_order(i) + 1)**2 - 1
 

--- a/src/track_output.F90
+++ b/src/track_output.F90
@@ -69,12 +69,12 @@ contains
          // '_' // trim(to_str(current_gen)) // '_' // trim(to_str(p % id)) &
          // '.binary'
 #endif
-!$omp critical
+!$omp critical (finalize_particle_track)
     call binout % file_create(fname)
     length = [3, n_tracks]
     call binout % write_data(coords, 'coordinates', length=length)
     call binout % file_close()
-!$omp end critical
+!$omp end critical (finalize_particle_track)
     deallocate(coords)
   end subroutine finalize_particle_track
 


### PR DESCRIPTION
I learned today that OpenMP treats all unnamed critical regions as the same region.  So, if a thread is in one of these regions and another thread in another, only one will actually be executing, even if the regions exist in completely unrelated portions of OpenMC.  Naming the regions gets around this.  Technically this should result in a speedup, though I imagine we will never see it.