### PR TITLE
Bugfix for out-of-bounds issues with logarithm grid

### DIFF
--- a/src/energy_grid.F90
+++ b/src/energy_grid.F90
@@ -92,20 +92,17 @@ contains
       ! Determine corresponding indices in nuclide grid to energies on
       ! equal-logarithmic grid
       j = 1
-      do k = 0, M - 1
+      do k = 0, M
         do while (log(nuc%energy(j + 1)/E_min) <= umesh(k))
           ! Ensure that for isotopes where maxval(nuc % energy) << E_max
           ! that there are no out-of-bounds issues.
-          if(j + 1 == nuc % n_grid) then
+          if (j + 1 == nuc % n_grid) then
             exit
           end if
           j = j + 1
         end do
         nuc % grid_index(k) = j
       end do
-
-      ! Set the last point explicitly so that we don't have out-of-bounds issues
-      nuc % grid_index(M) = size(nuc % energy) - 1
     end do
 
     deallocate(umesh)

--- a/src/energy_grid.F90
+++ b/src/energy_grid.F90
@@ -94,6 +94,11 @@ contains
       j = 1
       do k = 0, M - 1
         do while (log(nuc%energy(j + 1)/E_min) <= umesh(k))
+          ! Ensure that for isotopes where maxval(nuc % energy) << E_max
+          ! that there are no out-of-bounds issues.
+          if(j + 1 == nuc % n_grid) then
+            exit
+          end if
           j = j + 1
         end do
         nuc % grid_index(k) = j


### PR DESCRIPTION
This is a bug fix that addresses the uncommon case where an isotope has a final energy below 20 MeV, such as when beryllium 7 ENDF-B/VII.1 data is used.  This is the case in the Hoogenboom-Martin large test case.  Without this change, out-of-bounds memory accesses will occur in the formation of the logarithm energy grid.  This sometimes will cause the simulation to fail.

I'm also pretty sure that with this change, energy_grid.F90::108 could be deleted and energy_grid.F90::95 modified to compensate.  I'm not entirely sure though.

Secondly, as was implemented prior, cross sections for such isotopes are extrapolated from the last two points.  For Be-7, this will cause negative cross sections past 26.7 MeV.  Not necessarily relevant or important, but I thought I'd also bring it up.