### PR TITLE
Fixed filter indexing issue in Tally.get_values(...) introduced in #426

### DIFF
--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -914,7 +914,8 @@ class Tally(object):
                     filter_indices[i][j] = filter_index
 
                 # Account for stride in each of the previous filters
-                filter_indices[:i] *= filter.num_bins
+                for indices in filter_indices[:i]:
+                    indices *= filter.num_bins
 
             # Apply outer product sum between all filter bin indices
             filter_indices = list(map(sum, itertools.product(*filter_indices)))


### PR DESCRIPTION
This fixes the issue for the mesh tally data access mentioned in #434. This was a bug introduced in #426.