### PR TITLE
Fix CTest coverage runs for test_filter_distribcell

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,6 +287,22 @@ foreach(test ${TESTS})
         WORKING_DIRECTORY ${TEST_PATH}
         COMMAND $<TARGET_FILE:openmc> -p ${TEST_PATH})
 
+    elseif(${test} MATCHES "test_filter_distribcell")
+
+      # Add each case for distribcell tests
+      add_test(NAME ${TEST_NAME}_case-1
+        WORKING_DIRECTORY ${TEST_PATH}/case-1
+        COMMAND $<TARGET_FILE:openmc> ${TEST_PATH}/case-1)
+      add_test(NAME ${TEST_NAME}_case-2
+        WORKING_DIRECTORY ${TEST_PATH}/case-2
+        COMMAND $<TARGET_FILE:openmc> ${TEST_PATH}/case-2)
+      add_test(NAME ${TEST_NAME}_case-3
+        WORKING_DIRECTORY ${TEST_PATH}/case-3
+        COMMAND $<TARGET_FILE:openmc> ${TEST_PATH}/case-3)
+      add_test(NAME ${TEST_NAME}_case-4
+        WORKING_DIRECTORY ${TEST_PATH}/case-4
+        COMMAND $<TARGET_FILE:openmc> ${TEST_PATH}/case-4)
+
     # If a restart test is encounted, need to run with -r and restart file(s)
     elseif(${test} MATCHES "restart")
 


### PR DESCRIPTION
The CTest coverage run for test_filter_distribcell currently [fails](http://openmc.mit.edu/cdash/viewTest.php?onlyfailed&buildid=21202) because the input files are not directly in tests/test_filter_distribcell, but rather in four subdirectories. This pull request adds some special  logic in CMakeLists.txt to handle this case.

@bhermanmit Assigning you since you are the CMake/CTest guru.