### PR TITLE
Fix clean_xml.py indentation

### DIFF
--- a/openmc/clean_xml.py
+++ b/openmc/clean_xml.py
@@ -82,11 +82,11 @@ def clean_xml_indentation(element, level=0):
         if not element.tail or not element.tail.strip():
             element.tail = i
 
-        for element in element:
-            clean_xml_indentation(element, level+1)
+        for sub_element in element:
+            clean_xml_indentation(sub_element, level+1)
 
-            if not element.tail or not element.tail.strip():
-                element.tail = i
+        if not sub_element.tail or not sub_element.tail.strip():
+            sub_element.tail = i
 
     else:
         if level and (not element.tail or not element.tail.strip()):


### PR DESCRIPTION
Before:
```xml
<materials>
    <default_xs>71c</default_xs>
<material id="10000" name="water">
        <density units="sum" />
    <nuclide ao="9.3982e-06" name="O-17" />
    <nuclide ao="0.024672" name="O-16" />
    <nuclide ao="8.0042e-06" name="B-10" />
    <nuclide ao="3.2218e-05" name="B-11" />
    <nuclide ao="0.049457" name="H-1" />
    <nuclide ao="7.4196e-06" name="H-2" />
    </material>
```

After:
```xml
<materials>
    <default_xs>71c</default_xs>
    <material id="10000" name="water">
        <density units="sum" />
        <nuclide ao="9.3982e-06" name="O-17" />
        <nuclide ao="0.024672" name="O-16" />
        <nuclide ao="8.0042e-06" name="B-10" />
        <nuclide ao="3.2218e-05" name="B-11" />
        <nuclide ao="0.049457" name="H-1" />
        <nuclide ao="7.4196e-06" name="H-2" />
    </material>
```