### PR TITLE
Use "Tally.get_values(...)" in Python utility scripts

### DIFF
--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -823,10 +823,10 @@ class Tally(object):
             A list of filter type strings
             (e.g., ['mesh', 'energy']; default is [])
 
-        filter_bins : list
+        filter_bins : list of Iterables
             A list of the filter bins corresponding to the filter_types
-            parameter (e.g., [1, (0., 0.625e-6)]; default is []). Each bin in
-            the list is the integer ID for 'material', 'surface', 'cell',
+            parameter (e.g., [(1,), (0., 0.625e-6)]; default is []). Each bin
+            in the list is the integer ID for 'material', 'surface', 'cell',
             'cellborn', and 'universe' Filters. Each bin is an integer for the
             cell instance ID for 'distribcell Filters. Each bin is a 2-tuple of
             floats for 'energy' and 'energyout' filters corresponding to the
@@ -2099,10 +2099,10 @@ class Tally(object):
             A list of filter type strings
             (e.g., ['mesh', 'energy']; default is [])
 
-        filter_bins : list
+        filter_bins : list of Iterables
             A list of the filter bins corresponding to the filter_types
-            parameter (e.g., [1, (0., 0.625e-6)]; default is []). Each bin in
-            the list is the integer ID for 'material', 'surface', 'cell',
+            parameter (e.g., [(1,), (0., 0.625e-6)]; default is []). Each bin
+            in the list is the integer ID for 'material', 'surface', 'cell',
             'cellborn', and 'universe' Filters. Each bin is an integer for the
             cell instance ID for 'distribcell Filters. Each bin is a 2-tuple of
             floats for 'energy' and 'energyout' filters corresponding to the

--- a/scripts/openmc-plot-mesh-tally
+++ b/scripts/openmc-plot-mesh-tally
@@ -210,7 +210,7 @@ class MeshPlotter(tk.Frame):
                 mesh_filter = f
                 continue
             index = self.filterBoxes[f.type].current()
-            spec_list.append((f, index))
+            spec_list.append((f.type, (index,)))
 
         text = self.basisBox.get()
         if text == 'xy':
@@ -229,11 +229,11 @@ class MeshPlotter(tk.Frame):
                 else:
                     meshtuple = (i + 1, axial_level, j + 1)
                 filters, filter_bins = zip(*spec_list + [
-                    (mesh_filter, meshtuple)])
+                    (mesh_filter.type, (meshtuple,))])
                 mean = selectedTally.get_values(
-                    self.scoreBox.get(), filters, filter_bins)
+                    [self.scoreBox.get()], filters, filter_bins)
                 stdev = selectedTally.get_values(
-                    self.scoreBox.get(), filters, filter_bins,
+                    [self.scoreBox.get()], filters, filter_bins,
                     value='std_dev')
                 if mbvalue == 'Mean':
                     matrix[i, j] = mean

--- a/scripts/openmc-plot-mesh-tally
+++ b/scripts/openmc-plot-mesh-tally
@@ -133,7 +133,11 @@ class MeshPlotter(tk.Frame):
         self.mesh = selectedTally.filters_by_name['mesh'].mesh
 
         # Get mesh dimensions
-        self.nx, self.ny, self.nz = self.mesh.dimension
+        if len(self.mesh.dimension) == 2:
+            self.nx, self.ny = self.mesh.dimension
+            self.nz = 1
+        else:
+            self.nx, self.ny, self.nz = self.mesh.dimension
 
         # Repopulate comboboxes baesd on current basis selection
         text = self.basisBox.get()

--- a/scripts/openmc-plot-mesh-tally
+++ b/scripts/openmc-plot-mesh-tally
@@ -230,9 +230,9 @@ class MeshPlotter(tk.Frame):
                     meshtuple = (i + 1, axial_level, j + 1)
                 filters, filter_bins = zip(*spec_list + [
                     (mesh_filter, meshtuple)])
-                mean = selectedTally.get_value(
+                mean = selectedTally.get_values(
                     self.scoreBox.get(), filters, filter_bins)
-                stdev = selectedTally.get_value(
+                stdev = selectedTally.get_values(
                     self.scoreBox.get(), filters, filter_bins,
                     value='std_dev')
                 if mbvalue == 'Mean':

--- a/scripts/openmc-statepoint-3d
+++ b/scripts/openmc-statepoint-3d
@@ -219,7 +219,7 @@ def main(file_, o):
           for y in range(1,ny+1):
             for z in range(1,nz+1):
               filterspec[0][1] = (x,y,z)
-              val = sp.get_value(tally.id-1, filterspec, sid)[o.valerr]
+              val = sp.get_values(tally.id-1, filterspec, sid)[o.valerr]
               if o.vtk:
                 # vtk cells go z, y, x, so we store it now and enter it later
                 i = (z-1)*nx*ny + (y-1)*nx + x-1


### PR DESCRIPTION
This changes the call to ``Tally.get_value(...)`` to ``Tally.get_values(...)`` in the Python utility scripts to reflect the name change I made in a commit when vectorizing this routine. This should resolve [this](https://groups.google.com/forum/#!topic/openmc-users/3t8_9LiUeVg) recent issue mentioned on the OpenMC users forum.