### PR TITLE
Fix use of energy filters in openmc-plot-mesh-tally

### DIFF
--- a/scripts/openmc-plot-mesh-tally
+++ b/scripts/openmc-plot-mesh-tally
@@ -33,7 +33,7 @@ class MeshPlotter(tk.Frame):
 
         self.labels = {'cell': 'Cell:', 'cellborn': 'Cell born:',
                        'surface': 'Surface:', 'material': 'Material:',
-                       'universe': 'Universe:', 'energyin': 'Energy in:',
+                       'universe': 'Universe:', 'energy': 'Energy in:',
                        'energyout': 'Energy out:'}
 
         self.filterBoxes = {}
@@ -180,9 +180,9 @@ class MeshPlotter(tk.Frame):
             self.filterBoxes[filterType] = combobox
 
             # Set combobox items
-            if filterType in ['energyin', 'energyout']:
+            if filterType in ['energy', 'energyout']:
                 combobox['values'] = ['{0} to {1}'.format(*f.bins[i:i+2])
-                                      for i in range(f.length)]
+                                      for i in range(len(f.bins) - 1)]
             else:
                 combobox['values'] = [str(i) for i in f.bins]
 
@@ -213,8 +213,13 @@ class MeshPlotter(tk.Frame):
             if f.type == 'mesh':
                 mesh_filter = f
                 continue
-            index = self.filterBoxes[f.type].current()
-            spec_list.append((f.type, (index,)))
+            elif f.type in ['energy', 'energyout']:
+                index = self.filterBoxes[f.type].current()
+                ebin = (f.bins[index], f.bins[index + 1])
+                spec_list.append((f.type, (ebin,)))
+            else:
+                index = self.filterBoxes[f.type].current()
+                spec_list.append((f.type, (index,)))
 
         text = self.basisBox.get()
         if text == 'xy':


### PR DESCRIPTION
As discussed on the [openmc-users](https://groups.google.com/forum/#!topic/openmc-users/3t8_9LiUeVg) list, there was still in problem in openmc-plot-mesh-tally relating to energy filters even after #446 was merged. This pull request should fix the remaining issues. The user who brought up the issue has confirmed that the modified script now works for his use-case.