### PR TITLE
Assume unspecified surface coeffs = 0 in PyAPI

### DIFF
--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -134,7 +134,7 @@ class Surface(object):
 
         element.set("type", self._type)
         element.set("boundary", self._boundary_type)
-        element.set("coeffs", ' '.join([str(self._coeffs[key])
+        element.set("coeffs", ' '.join([str(self._coeffs.setdefault(key, 0.0))
                                         for key in self._coeff_keys]))
 
         return element


### PR DESCRIPTION
The PythonAPI will fail with a rather obscure error if you don't specify all of the coefficients for a surface.  For example,
```python
    surf = openmc.ZCylinder(R=0.41)
```
will cause
```
  File "/home/sterling/openmc/openmc/geometry.py", line 202, in export_to_xml
    root_universe.create_xml_subelement(self._geometry_file)
  File "/home/sterling/openmc/openmc/universe.py", line 602, in create_xml_subelement
    cell_subelement = cell.create_xml_subelement(xml_element)
  File "/home/sterling/openmc/openmc/universe.py", line 332, in create_xml_subelement
    self._fill.create_xml_subelement(xml_element)
  File "/home/sterling/openmc/openmc/universe.py", line 990, in create_xml_subelement
    universe.create_xml_subelement(xml_element)
  File "/home/sterling/openmc/openmc/universe.py", line 602, in create_xml_subelement
    cell_subelement = cell.create_xml_subelement(xml_element)
  File "/home/sterling/openmc/openmc/universe.py", line 353, in create_xml_subelement
    surface_subelement = surface.create_xml_subelement()
  File "/home/sterling/openmc/openmc/surface.py", line 138, in create_xml_subelement
    for key in self._coeff_keys]))
KeyError: 'x0'
```
This PR fixes that error by assuming that all unspecified surface coefficients are equal to zero.