### PR TITLE
fix Shannon Entropy PDF link

### DIFF
--- a/docs/source/methods/eigenvalue.rst
+++ b/docs/source/methods/eigenvalue.rst
@@ -142,7 +142,7 @@ than unity. By ensuring that the expected number of fission sites in each mesh
 cell is constant, the collision density across all cells, and hence the variance
 of tallies, is more uniform than it would be otherwise.
 
-.. _Shannon entropy: https://laws.lanl.gov/vhosts/mcnp.lanl.gov/pdf_files/la-ur-06-3737_entropy.pdf
+.. _Shannon entropy: https://laws.lanl.gov/vhosts/mcnp.lanl.gov/pdf_files/la-ur-06-3737.pdf
 
 .. [Lieberoth] J. Lieberoth, "A Monte Carlo Technique to Solve the Static
    Eigenvalue Problem of the Boltzmann Transport Equation," *Nukleonik*, **11**,


### PR DESCRIPTION
Hi,

I was reading through the documentation and noticed that the link to the Shannon Entropy PDF is broken. This PR fixes the link.