### PR TITLE
Improvements to XS calculation performance

### DIFF
--- a/src/search.F90
+++ b/src/search.F90
@@ -41,10 +41,9 @@ contains
     do while (R - L > 1)
       ! Find values at midpoint
       array_index = L + (R - L)/2
-      testval = array(array_index)
-      if (val >= testval) then
+      if (val >= array(array_index)) then
         L = array_index
-      elseif (val < testval) then
+      else
         R = array_index
       end if
 
@@ -83,10 +82,9 @@ contains
     do while (R - L > 1)
       ! Find values at midpoint
       array_index = L + (R - L)/2
-      testval = array(array_index)
-      if (val >= testval) then
+      if (val >= array(array_index)) then
         L = array_index
-      elseif (val < testval) then
+      else
         R = array_index
       end if
 
@@ -125,10 +123,9 @@ contains
     do while (R - L > 1)
       ! Find values at midpoint
       array_index = L + (R - L)/2
-      testval = array(array_index)
-      if (val >= testval) then
+      if (val >= array(array_index)) then
         L = array_index
-      elseif (val < testval) then
+      else
         R = array_index
       end if
 

--- a/src/search.F90
+++ b/src/search.F90
@@ -28,7 +28,6 @@ contains
     integer :: L
     integer :: R
     integer :: n_iteration
-    real(8) :: testval
 
     L = 1
     R = n
@@ -69,7 +68,6 @@ contains
     integer :: L
     integer :: R
     integer :: n_iteration
-    real(8) :: testval
 
     L = 1
     R = n
@@ -110,7 +108,6 @@ contains
     integer :: L
     integer :: R
     integer :: n_iteration
-    real(8) :: testval
 
     L = 1
     R = n

--- a/src/search.F90
+++ b/src/search.F90
@@ -39,16 +39,6 @@ contains
 
     n_iteration = 0
     do while (R - L > 1)
-
-      ! Check boundaries
-      if (val > array(L) .and. val < array(L+1)) then
-        array_index = L
-        return
-      elseif (val > array(R-1) .and. val < array(R)) then
-        array_index = R - 1
-        return
-      end if
-
       ! Find values at midpoint
       array_index = L + (R - L)/2
       testval = array(array_index)
@@ -91,16 +81,6 @@ contains
 
     n_iteration = 0
     do while (R - L > 1)
-
-      ! Check boundaries
-      if (val > array(L) .and. val < array(L+1)) then
-        array_index = L
-        return
-      elseif (val > array(R-1) .and. val < array(R)) then
-        array_index = R - 1
-        return
-      end if
-
       ! Find values at midpoint
       array_index = L + (R - L)/2
       testval = array(array_index)
@@ -143,16 +123,6 @@ contains
 
     n_iteration = 0
     do while (R - L > 1)
-
-      ! Check boundaries
-      if (val > array(L) .and. val < array(L+1)) then
-        array_index = L
-        return
-      elseif (val > array(R-1) .and. val < array(R)) then
-        array_index = R - 1
-        return
-      end if
-
       ! Find values at midpoint
       array_index = L + (R - L)/2
       testval = array(array_index)


### PR DESCRIPTION
This PR moves the calculation of the logarithm out of the nuclide loop and improves performance in general of the binary search algorithm.  In theory, this closes #444.

I ran a very short run BEAVRS HZP, using MCNP6 data on my 6 core i7-920 computer. I reran the simulation 30 times and took the highest results to reduce the impact of random hardware fluctuations.  The results are as follows:

Energy Grid | NPS before | NPS after | % improvement
----------- | ------- | ------- | -------------
Nuclide | 20587 | 21436 | 4.1%
Logarithm | 23952 | 25396 | 6.0%
Nuc-Union | 26195 | 26367 | 0.6%

This modification does add one possible issue, in that if the value searched for is ``NaN`` or the array is unsorted, it will no longer fall through and output "Reached maximum number of iterations on binary search."

Further improvement can be had by removing the bounds checks, but on branch predicting architectures (like anything other than a Xeon Phi), the performance improvement is nearly zero.  On non-predicting architectures, the improvement is quite substantial, but I'm not sure of a clean way to bring it in, as these error checks can actually be useful.