### PR TITLE
Allow run_tests.py to work without MPI installed

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -128,10 +128,8 @@ class Test(object):
         if self.mpi:
             if os.path.exists(os.path.join(MPI_DIR, 'bin', 'mpifort')):
                 self.fc = os.path.join(MPI_DIR, 'bin', 'mpifort')
-            elif os.path.exists(os.path.join(MPI_DIR, 'bin', 'mpif90')):
-                self.fc = os.path.join(MPI_DIR, 'bin', 'mpif90')
             else:
-                raise RuntimeError('Cannot find an MPI Fortran compiler')
+                self.fc = os.path.join(MPI_DIR, 'bin', 'mpif90')
         else:
             self.fc = FC
 


### PR DESCRIPTION
@smharper Your pull request #468 made it such that if a one does not have MPI installed, they cannot run run_tests.py at all because it will fail searching for an MPI compiler wrapper. I've changed it to look for mpifort, and then if that's not found just default to mpif90. Note that there is a check later when each test configuration is run that the compiler actually exists, so if mpif90 is not there, you'll still get an informative error message.