### PR TITLE
Avoid hard-coded checks against 20 MeV 

### DIFF
--- a/src/ace.F90
+++ b/src/ace.F90
@@ -215,6 +215,16 @@ contains
 
     end do MATERIAL_LOOP3
 
+    ! Show which nuclide results in lowest energy for neutron transport
+    do i = 1, n_nuclides_total
+      if (nuclides(i)%energy(nuclides(i)%n_grid) == energy_max_neutron) then
+        call write_message("Maximum neutron transport energy: " // &
+             trim(to_str(energy_max_neutron)) // " MeV for " // &
+             trim(adjustl(nuclides(i)%name)), 6)
+        exit
+      end if
+    end do
+
   end subroutine read_xs
 
 !===============================================================================
@@ -486,11 +496,6 @@ contains
       ! than the previous
       energy_min_neutron = max(energy_min_neutron, nuc%energy(1))
       energy_max_neutron = min(energy_max_neutron, nuc%energy(NE))
-      if (nuc%energy(NE) < 20.0_8) then
-        call warning("Maximum energy for " // trim(adjustl(nuc%name)) // &
-             " is " // trim(to_str(nuc%energy(NE))) // " MeV. Neutrons will &
-             &not be allowed to go above this energy.")
-      end if
     end if
 
   end subroutine read_esz

--- a/src/ace.F90
+++ b/src/ace.F90
@@ -482,6 +482,15 @@ contains
       ! Continue reading elastic scattering and heating
       nuc % elastic = get_real(NE)
 
+      ! Determine if minimum/maximum energy for this nuclide is greater/less
+      ! than the previous
+      energy_min_neutron = max(energy_min_neutron, nuc%energy(1))
+      energy_max_neutron = min(energy_max_neutron, nuc%energy(NE))
+      if (nuc%energy(NE) < 20.0_8) then
+        call warning("Maximum energy for " // trim(adjustl(nuc%name)) // &
+             " is " // trim(to_str(nuc%energy(NE))) // " MeV. Neutrons will &
+             &not be allowed to go above this energy.")
+      end if
     end if
 
   end subroutine read_esz

--- a/src/cross_section.F90
+++ b/src/cross_section.F90
@@ -56,7 +56,7 @@ contains
     if (grid_method == GRID_MAT_UNION) then
       call find_energy_index(p % E, p % material)
     else if (grid_method == GRID_LOGARITHM) then
-      u = int(log(p % E/1.0e-11_8)/log_spacing)
+      u = int(log(p % E/energy_min_neutron)/log_spacing)
     end if
 
     ! Determine if this material has S(a,b) tables

--- a/src/energy_grid.F90
+++ b/src/energy_grid.F90
@@ -73,8 +73,8 @@ contains
     type(Nuclide), pointer :: nuc
 
     ! Set minimum/maximum energies
-    E_max = 20.0_8
-    E_min = 1.0e-11_8
+    E_max = energy_max_neutron
+    E_min = energy_min_neutron
 
     ! Determine equal-logarithmic energy spacing
     M = n_log_bins

--- a/src/global.F90
+++ b/src/global.F90
@@ -74,6 +74,10 @@ module global
   integer :: n_sab_tables     ! Number of S(a,b) thermal scattering tables
   integer :: n_listings       ! Number of listings in cross_sections.xml
 
+  ! Minimum/maximum energies
+  real(8) :: energy_min_neutron = ZERO
+  real(8) :: energy_max_neutron = INFINITY
+
   ! Dictionaries to look up cross sections and listings
   type(DictCharInt) :: nuclide_dict
   type(DictCharInt) :: sab_dict

--- a/src/physics.F90
+++ b/src/physics.F90
@@ -1220,8 +1220,8 @@ contains
           call sample_energy(edist, E, E_out)
         end if
 
-        ! resample if energy is >= 20 MeV
-        if (E_out < 20) exit
+        ! resample if energy is greater than maximum neutron energy
+        if (E_out < energy_max_neutron) exit
 
         ! check for large number of resamples
         n_sample = n_sample + 1
@@ -1246,8 +1246,8 @@ contains
           call sample_energy(rxn%edist, E, E_out)
         end if
 
-        ! resample if energy is >= 20 MeV
-        if (E_out < 20) exit
+        ! resample if energy is greater than maximum neutron energy
+        if (E_out < energy_max_neutron) exit
 
         ! check for large number of resamples
         n_sample = n_sample + 1

--- a/src/source.F90
+++ b/src/source.F90
@@ -211,8 +211,9 @@ contains
     case (SRC_ENERGY_MONO)
       ! Monoenergtic source
       site%E = external_source%params_energy(1)
-      if (site%E >= 20) then
-        call fatal_error("Source energies above 20 MeV not allowed.")
+      if (site%E >= energy_max_neutron) then
+        call fatal_error("Source energy above range of energies of at least &
+             &one cross section table")
       end if
 
     case (SRC_ENERGY_MAXWELL)
@@ -221,8 +222,8 @@ contains
         ! Sample Maxwellian fission spectrum
         site%E = maxwell_spectrum(a)
 
-        ! resample if energy is >= 20 MeV
-        if (site%E < 20) exit
+        ! resample if energy is greater than maximum neutron energy
+        if (site%E < energy_max_neutron) exit
       end do
 
     case (SRC_ENERGY_WATT)
@@ -232,8 +233,8 @@ contains
         ! Sample Watt fission spectrum
         site%E = watt_spectrum(a, b)
 
-        ! resample if energy is >= 20 MeV
-        if (site%E < 20) exit
+        ! resample if energy is greater than maximum neutron energy
+        if (site%E < energy_max_neutron) exit
       end do
 
     case default


### PR DESCRIPTION
This pull request looks at the maximum energy for each ACE file as they're being read and prohibits neutrons from assuming energies above the lowest maximum. If ENDF/B-VII.1 Be-7 is included in a model, this means neutrons will get cut off around 8 MeV instead of 20 MeV. Otherwise, 20 MeV is usually the limit.

Merging of this pull request will close #406.