### PR TITLE
Doubled string name length

### DIFF
--- a/src/geometry_header.F90
+++ b/src/geometry_header.F90
@@ -24,7 +24,7 @@ module geometry_header
 
   type, abstract :: Lattice
     integer              :: id               ! Universe number for lattice
-    character(len=52) :: name = ""          ! User-defined name
+    character(len=104)   :: name = ""        ! User-defined name
     real(8), allocatable :: pitch(:)         ! Pitch along each axis
     integer, allocatable :: universes(:,:,:) ! Specified universes
     integer              :: outside          ! Material to fill area outside
@@ -119,7 +119,7 @@ module geometry_header
 
   type Cell
     integer :: id                          ! Unique ID
-    character(len=52) :: name = ""         ! User-defined name
+    character(len=104) :: name = ""        ! User-defined name
     integer :: type                        ! Type of cell (normal, universe,
                                            !  lattice)
     integer :: universe                    ! universe # this cell is in

--- a/src/material_header.F90
+++ b/src/material_header.F90
@@ -8,7 +8,7 @@ module material_header
 
   type Material
     integer              :: id              ! unique identifier
-    character(len=52) :: name = ""         ! User-defined name
+    character(len=104) :: name = ""         ! User-defined name
     integer              :: n_nuclides      ! number of nuclides
     integer, allocatable :: nuclide(:)      ! index in nuclides array
     real(8)              :: density         ! total atom density in atom/b-cm

--- a/src/surface_header.F90
+++ b/src/surface_header.F90
@@ -15,7 +15,7 @@ module surface_header
          neighbor_pos(:), &           ! List of cells on positive side
          neighbor_neg(:)              ! List of cells on negative side
     integer :: bc                     ! Boundary condition
-    character(len=52) :: name = ""    ! User-defined name
+    character(len=104) :: name = ""    ! User-defined name
   contains
     procedure :: sense
     procedure :: reflect

--- a/src/tally_header.F90
+++ b/src/tally_header.F90
@@ -74,7 +74,7 @@ module tally_header
     ! Basic data
 
     integer :: id                   ! user-defined identifier
-    character(len=52) :: name = "" ! user-defined name
+    character(len=104) :: name = "" ! user-defined name
     integer :: type                 ! volume, surface current
     integer :: estimator            ! collision, track-length
     real(8) :: volume               ! volume of region


### PR DESCRIPTION
I recently noticed that some of the string names used in our BEAVRS builder were being chopped off by OpenMC in the "summary.h5" files. The reason is that some names are longer than the maximum size of 52, such as "Fuel rod active region - 2.4% enr radial outer: water". This PR doubles the maximum size of string names for cells, materials, universes and tallies to 104 to avoid issues like this.