### PR TITLE
Trivial fix for region specification

### DIFF
--- a/openmc/region.py
+++ b/openmc/region.py
@@ -84,7 +84,7 @@ class Region(object):
                 i_start = -1
             else:
                 # Check for invalid characters
-                if expression[i] not in '-0123456789':
+                if expression[i] not in '-+0123456789':
                     raise SyntaxError("Invalid character '{}' in expression"
                                       .format(expression[i]))
 

--- a/src/string.F90
+++ b/src/string.F90
@@ -136,7 +136,7 @@ contains
         i_start = 0
       else
         ! Check for invalid characters
-        if (index('-0123456789', string_(i:i)) == 0) then
+        if (index('-+0123456789', string_(i:i)) == 0) then
           call fatal_error("Invalid character '" // string_(i:i) // "' in &
                &region specification.")
         end if


### PR DESCRIPTION
The first time around, I didn't anticipate the possibility that someone might want to give a region specification like the following:
```xml
<cell ... region="-5 +4 -3 +6" />
```
This pull request simply makes '+' an allowed character.