### PR TITLE
Add Material.__deepcopy__ method

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -115,6 +115,30 @@ class Material(object):
 
         return string
 
+    def __deepcopy__(self, memo):
+        existing = memo.get(id(self))
+
+        if existing is None:
+            # If this is the first time we have tried to copy this object, create a copy
+            clone = type(self).__new__(type(self))
+            clone._id = self._id
+            clone._name = self._name
+            clone._density = self._density
+            clone._density_units = self._density_units
+            clone._nuclides = deepcopy(self._nuclides, memo)
+            clone._elements = deepcopy(self._elements, memo)
+            clone._sab = deepcopy(self._sab, memo)
+            clone._convert_to_distrib_comps = self._convert_to_distrib_comps
+            clone._distrib_otf_file = self._distrib_otf_file
+
+            memo[id(self)] = clone
+
+            return clone
+
+        else:
+            # If this object has been copied before, return the first copy made
+            return existing
+
     @property
     def id(self):
         return self._id


### PR DESCRIPTION
I needed the ability to copy Materials in some scripting I'm doing and found this missing. Should be pretty straightforward.