### PR TITLE
Fixed deprecated NumPy warning in MGXS.get_xs(...)

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -193,7 +193,7 @@ class Material(object):
                        name, basestring)
             self._name = name
         else:
-            self._name = None
+            self._name = ''
 
     def set_density(self, units, density=NO_DENSITY):
         """Set the density of the material

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -155,7 +155,7 @@ class Mesh(object):
                        name, basestring)
             self._name = name
         else:
-            self._name = None
+            self._name = ''
 
     @type.setter
     def type(self, meshtype):

--- a/openmc/mgxs/mgxs.py
+++ b/openmc/mgxs/mgxs.py
@@ -673,7 +673,7 @@ class MGXS(object):
                 num_groups = len(groups)
 
             # Reshape tally data array with separate axes for domain and energy
-            num_subdomains = xs.shape[0] / num_groups
+            num_subdomains = int(xs.shape[0] / num_groups)
             new_shape = (num_subdomains, num_groups) + xs.shape[1:]
             xs = np.reshape(xs, new_shape)
 
@@ -1844,7 +1844,7 @@ class ScatterMatrixXS(MGXS):
                 num_out_groups = len(out_groups)
 
             # Reshape tally data array with separate axes for domain and energy
-            num_subdomains = xs.shape[0] / (num_in_groups * num_out_groups)
+            num_subdomains = int(xs.shape[0] / (num_in_groups * num_out_groups))
             new_shape = (num_subdomains, num_in_groups, num_out_groups)
             new_shape += xs.shape[1:]
             xs = np.reshape(xs, new_shape)
@@ -2194,7 +2194,7 @@ class Chi(MGXS):
                 num_groups = self.num_groups
             else:
                 num_groups = len(groups)
-            num_subdomains = xs.shape[0] / num_groups
+            num_subdomains = int(xs.shape[0] / num_groups)
             new_shape = (num_subdomains, num_groups) + xs.shape[1:]
             xs = np.reshape(xs, new_shape)
 

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -128,7 +128,7 @@ class Surface(object):
             check_type('surface name', name, basestring)
             self._name = name
         else:
-            self._name = None
+            self._name = ''
 
     @boundary_type.setter
     def boundary_type(self, boundary_type):

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -420,7 +420,7 @@ class Tally(object):
             cv.check_type('tally name', name, basestring)
             self._name = name
         else:
-            self._name = None
+            self._name = ''
 
     def add_filter(self, filter):
         """Add a filter to the tally

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -153,7 +153,7 @@ class Cell(object):
             cv.check_type('cell name', name, basestring)
             self._name = name
         else:
-            self._name = None
+            self._name = ''
 
     @fill.setter
     def fill(self, fill):
@@ -472,7 +472,7 @@ class Universe(object):
             cv.check_type('universe name', name, basestring)
             self._name = name
         else:
-            self._name = None
+            self._name = ''
 
     def add_cell(self, cell):
         """Add a cell to the universe.
@@ -732,7 +732,7 @@ class Lattice(object):
             cv.check_type('lattice name', name, basestring)
             self._name = name
         else:
-            self._name = None
+            self._name = ''
 
     @outer.setter
     def outer(self, outer):

--- a/tests/test_track_output/results_test.dat
+++ b/tests/test_track_output/results_test.dat
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<VTKFile type="PPolyData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <PPolyData GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Points" NumberOfComponents="3"/>
+    </PPoints>
+    <Piece Source="poly_0.vtp"/>
+  </PPolyData>
+</VTKFile>

--- a/tests/test_track_output/results_test.dat
+++ b/tests/test_track_output/results_test.dat
@@ -1,9 +1,0 @@
-<?xml version="1.0"?>
-<VTKFile type="PPolyData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
-  <PPolyData GhostLevel="0">
-    <PPoints>
-      <PDataArray type="Float32" Name="Points" NumberOfComponents="3"/>
-    </PPoints>
-    <Piece Source="poly_0.vtp"/>
-  </PPolyData>
-</VTKFile>


### PR DESCRIPTION
This short PR eliminates the following deprecated warning from NumPy in the `openmc.mgxs` module:

```bash
/usr/local/lib/python2.7/dist-packages/numpy/core/fromnumeric.py:221: DeprecationWarning: using a non-integer number instead of an integer will result in an error in the future
  return reshape(newshape, order=order)
```

This warning resulted from the use of floating point values used to reshape the array of multi-group cross sections in the `MGXS.get_xs(...)` routines. In particular, the number of domains is used as the first value in the new shape. Since the number of domains is computed by dividing two quantities, and since we now use division from the `__future__``, this value was a floating point value. It is now cast to an `int` to eliminate the deprecation warning.

In addition, this PR modifies the `name` attributes for all of the objects in the Python API to be a n empty string `''` rather than `None` by default.