### PR TITLE
Fix for MGXS subdomain averaging

### DIFF
--- a/openmc/mgxs/mgxs.py
+++ b/openmc/mgxs/mgxs.py
@@ -824,9 +824,9 @@ class MGXS(object):
             mean = tally.get_reshaped_data(value='mean')
             std_dev = tally.get_reshaped_data(value='std_dev')
 
-            # Get the mean of the mean, std. dev. across requested subdomains
-            mean = np.mean(mean[subdomains, ...], axis=0)
-            std_dev = np.mean(std_dev[subdomains, ...]**2, axis=0)
+            # Get the mean, std. dev. across requested subdomains
+            mean = np.sum(mean[subdomains, ...], axis=0)
+            std_dev = np.sum(std_dev[subdomains, ...]**2, axis=0)
             std_dev = np.sqrt(std_dev)
 
             # If domain is distribcell, make subdomain-averaged a 'cell' domain


### PR DESCRIPTION
These tiny PR fixes an issue in the `openmc.mgxs.MGXS.get_subdomain_avg_xs(...)` routine. Presently, this routine computes a simple geometric average of the MGXS across multiple subdomains (*e.g.*, distribcell instances). Now, the average is scalar flux-weighted. This is accurate approach which can be confirmed if one creates a geometry with a distinct "cell" for the particular distribcell instances one wishes to average across. With this fix, the MGXS tallied in the distinct cell will match precisely those computed with scalar flux-weighted subdomain averaging of the corresponding distribcell instances in the original geometry. 