### PR TITLE
Fine-Grained MGXS Library Domain Control 

### DIFF
--- a/openmc/mgxs/library.py
+++ b/openmc/mgxs/library.py
@@ -166,7 +166,7 @@ class Library(object):
         if self._domains == 'all':
             if self.domain_type == 'material':
                 return self.openmc_geometry.get_all_materials()
-            elif self.domain_type == 'cell' or self.domain_type == 'distribcell':
+            elif self.domain_type in ['cell', 'distribcell']:
                 return self.openmc_geometry.get_all_material_cells()
             elif self.domain_type == 'universe':
                 return self.openmc_geometry.get_all_universes()
@@ -240,7 +240,7 @@ class Library(object):
         else:
             if self.domain_type == 'material':
                 cv.check_iterable_type('domain', domains, openmc.Material)
-            elif self.domain_type == 'cell':
+            elif self.domain_type in ['cell', 'distribcell']:
                 cv.check_iterable_type('domain', domains, openmc.Cell)
             elif self.domain_type == 'universe':
                 cv.check_iterable_type('domain', domains, openmc.Universe)

--- a/openmc/mgxs/library.py
+++ b/openmc/mgxs/library.py
@@ -53,6 +53,8 @@ class Library(object):
         The types of cross sections in the library (e.g., ['total', 'scatter'])
     domain_type : {'material', 'cell', 'distribcell', 'universe'}
         Domain type for spatial homogenization
+    domains : Iterable of Material, Cell or Universe
+        The spatial domain(s) for which MGXS in the Library are computed
     correction : 'P0' or None
         Apply the P0 correction to scattering matrices if set to 'P0'
     energy_groups : EnergyGroups
@@ -80,6 +82,7 @@ class Library(object):
         self._by_nuclide = None
         self._mgxs_types = []
         self._domain_type = None
+        self._domains = 'all'
         self._correction = 'P0'
         self._energy_groups = None
         self._tally_trigger = None
@@ -105,6 +108,7 @@ class Library(object):
             clone._by_nuclide = self.by_nuclide
             clone._mgxs_types = self.mgxs_types
             clone._domain_type = self.domain_type
+            clone._domains = self.domains
             clone._correction = self.correction
             clone._energy_groups = copy.deepcopy(self.energy_groups, memo)
             clone._tally_trigger = copy.deepcopy(self.tally_trigger, memo)
@@ -154,20 +158,22 @@ class Library(object):
         return self._by_nuclide
 
     @property
-    def domains(self):
-        if self.domain_type is None:
-            raise ValueError('Unable to get all domains without a domain type')
-
-        if self.domain_type == 'material':
-            return self.openmc_geometry.get_all_materials()
-        elif self.domain_type == 'cell' or self.domain_type == 'distribcell':
-            return self.openmc_geometry.get_all_material_cells()
-        elif self.domain_type == 'universe':
-            return self.openmc_geometry.get_all_universes()
-
-    @property
     def domain_type(self):
         return self._domain_type
+
+    @property
+    def domains(self):
+        if self._domains == 'all':
+            if self.domain_type == 'material':
+                return self.openmc_geometry.get_all_materials()
+            elif self.domain_type == 'cell' or self.domain_type == 'distribcell':
+                return self.openmc_geometry.get_all_material_cells()
+            elif self.domain_type == 'universe':
+                return self.openmc_geometry.get_all_universes()
+            else:
+                raise ValueError('Unable to get domains without a domain type')
+        else:
+            return self._domains
 
     @property
     def correction(self):
@@ -222,6 +228,28 @@ class Library(object):
     def domain_type(self, domain_type):
         cv.check_value('domain type', domain_type, tuple(openmc.mgxs.DOMAIN_TYPES))
         self._domain_type = domain_type
+
+    @domains.setter
+    def domains(self, domains):
+
+        # Use all materials, cells or universes in the geometry as domains
+        if domains == 'all':
+            self._domains = domains
+
+        # User specified a list of material, cell or universe domains
+        else:
+            if self.domain_type == 'material':
+                cv.check_iterable_type('domain', domains, openmc.Material)
+            elif self.domain_type == 'cell':
+                cv.check_iterable_type('domain', domains, openmc.Cell)
+            elif self.domain_type == 'universe':
+                cv.check_iterable_type('domain', domains, openmc.Universe)
+            else:
+                msg = 'Unable to set domains with ' \
+                      'domain type "{}"'.format(self.domain_type)
+                raise ValueError(msg)
+
+            self._domains = domains
 
     @correction.setter
     def correction(self, correction):


### PR DESCRIPTION
This PR modifies `openmc.mgxs.Library` to allow for fine-grained control over the domains (materials, (distrib)cells or universes) for which `MGXS` objects are created. This follows up on the discussion about this by @paulromano on PR #471. The user now has full fine-grained control over the MGXS types (*e.g.*, "transport", "nu-fission", etc.) and the spatial tally domains for an MGXS `Library`. The previous behavior of creating `MGXS` objects for each spatial domain for a given domain type ("material", "cell", "distribcell" or "universe") is retained as the default or if the user sets the `Library.domain` attribute to "all".