### PR TITLE
Preferential Alpha Compositing in Plots

### DIFF
--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -298,7 +298,7 @@ class Plot(object):
             self.col_spec[domain] = (r, g, b)
 
     def highlight_domains(self, geometry, domains, seed=1,
-                          alpha=0.5, background='grey'):
+                          alpha=0.5, background='gray'):
         """Use alpha compositing to highlight one or more domains in the plot.
 
         This routine generates a color scheme and applies alpha compositing
@@ -314,7 +314,7 @@ class Plot(object):
             The random number seed used to generate the color scheme
         alpha : Real in [0,1]
             The value to apply in alpha compisiting
-        background : 3-tuple of Integral or 'white' or 'black' or 'grey'
+        background : 3-tuple of Integral or 'white' or 'black' or 'gray'
             The background color to apply in alpha compisiting
 
         """
@@ -330,7 +330,7 @@ class Plot(object):
                 background = (255, 255, 255)
             elif background == 'black':
                 background = (0, 0, 0)
-            elif background == 'grey':
+            elif background == 'gray':
                 background = (160, 160, 160)
             else:
                 msg = 'The background "{}" is not defined'.format(background)
@@ -460,7 +460,7 @@ class PlotsFile(object):
 
 
     def highlight_domains(self, geometry, domains, seed=1,
-                          alpha=0.5, background='grey'):
+                          alpha=0.5, background='gray'):
         """Use alpha compositing to highlight one or more domains in the plot.
 
         This routine generates a color scheme and applies alpha compositing
@@ -476,7 +476,7 @@ class PlotsFile(object):
             The random number seed used to generate the color scheme
         alpha : Real in [0,1]
             The value to apply in alpha compisiting
-        background : 3-tuple of Integral or 'white' or 'black' or 'grey'
+        background : 3-tuple of Integral or 'white' or 'black' or 'gray'
             The background color to apply in alpha compisiting
 
         """

--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -270,7 +270,7 @@ class Plot(object):
         Params
         ------
         geometry : openmc.Geometry
-            The geometry for which the plot is created
+            The geometry for which the plot is defined
         seed : Integral
             The random number seed used to generate the color scheme
 
@@ -284,7 +284,7 @@ class Plot(object):
         if self.color is 'mat':
             domains = geometry.get_all_materials()
         else:
-            domains = geometry.get_all_materials()
+            domains = geometry.get_all_cells()
 
         # Set the seed for the random number generator
         np.random.seed(seed)
@@ -295,8 +295,62 @@ class Plot(object):
             r = np.random.randint(0, 255)
             g = np.random.randint(0, 255)
             b = np.random.randint(0, 255)
-            self.col_spec[domain.id] = (r, g, b)
+            self.col_spec[domain] = (r, g, b)
 
+
+    def highlight_domains(self, geometry, domains, seed=1,
+                          alpha=0.5, background='grey'):
+        """Use alpha compositing to highlight one or more domains in the plot.
+
+        This routine generates a color scheme and applies alpha compositing
+        to make all domains except the highlighted ones partially transparent.
+
+        Params
+        ------
+        geometry : openmc.Geometry
+            The geometry for which the plot is defined
+        domains : Iterable of Integral
+            A collection of the domain IDs to highlight in the plot
+        seed : Integral
+            The random number seed used to generate the color scheme
+        alpha : Real in [0,1]
+            The value to apply in alpha compisiting
+        background : 3-tuple of Integral or 'white' or 'black' or 'grey'
+            The background color to apply in alpha compisiting
+
+        """
+
+        cv.check_iterable_type('domains', domains, Integral)
+        cv.check_type('alpha', alpha, Real)
+        cv.check_greater_than('alpha', alpha, 0., equality=True)
+        cv.check_less_than('alpha', alpha, 1., equality=True)
+
+        # Get a background (R,G,B) tuple to apply in alpha compositing
+        if isinstance(background, basestring):
+            if background == 'white':
+                background = (255, 255, 255)
+            elif background == 'black':
+                background = (0, 0, 0)
+            elif background == 'grey':
+                background = (160, 160, 160)
+            else:
+                msg = 'The background "{}" is not defined'.format(background)
+                raise ValueError(msg)
+
+        cv.check_iterable_type('background', background, Integral)
+
+        # Generate a color scheme
+        self.colorize(geometry, seed)
+
+        # Apply alpha compositing to the colors for all domains
+        # other than those the user wishes to highlight
+        for domain_id in self.col_spec:
+            if domain_id not in domains:
+                r, g, b = self.col_spec[domain_id]
+                r = int(((1-alpha) * background[0]) + (alpha * r))
+                g = int(((1-alpha) * background[1]) + (alpha * g))
+                b = int(((1-alpha) * background[2]) + (alpha * b))
+                self._col_spec[domain_id] = (r, g, b)
 
     def get_plot_xml(self):
         """Return XML representation of the plot

--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -302,10 +302,11 @@ class Plot(object):
         """Use alpha compositing to highlight one or more domains in the plot.
 
         This routine generates a color scheme and applies alpha compositing
-        to make all domains except the highlighted ones partially transparent.
+        to make all domains except the highlighted ones appear partially
+        transparent.
 
-        Params
-        ------
+        Parameters
+        ----------
         geometry : openmc.Geometry
             The geometry for which the plot is defined
         domains : Iterable of Integral
@@ -466,8 +467,8 @@ class PlotsFile(object):
         This routine generates a color scheme and applies alpha compositing
         to make all domains except the highlighted ones partially transparent.
 
-        Params
-        ------
+        Parameters
+        ----------
         geometry : openmc.Geometry
             The geometry for which the plot is defined
         domains : Iterable of Integral

--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -459,6 +459,32 @@ class PlotsFile(object):
         for plot in self._plots:
             plot.colorize(geometry, seed)
 
+
+    def highlight_domains(self, geometry, domains, seed=1,
+                          alpha=0.5, background='grey'):
+        """Use alpha compositing to highlight one or more domains in the plot.
+
+        This routine generates a color scheme and applies alpha compositing
+        to make all domains except the highlighted ones partially transparent.
+
+        Params
+        ------
+        geometry : openmc.Geometry
+            The geometry for which the plot is defined
+        domains : Iterable of Integral
+            A collection of the domain IDs to highlight in the plot
+        seed : Integral
+            The random number seed used to generate the color scheme
+        alpha : Real in [0,1]
+            The value to apply in alpha compisiting
+        background : 3-tuple of Integral or 'white' or 'black' or 'grey'
+            The background color to apply in alpha compisiting
+
+        """
+
+        for plot in self._plots:
+            plot.highlight_domains(geometry, domains, seed, alpha, background)
+
     def _create_plot_subelements(self):
         for plot in self._plots:
             xml_element = plot.get_plot_xml()


### PR DESCRIPTION
This PR adds a new `Plot.highlight_domains(...)` routine to the Python API which builds upon the automated color schemes introduced in PR #503. The routine can be used to apply [alpha compositing](https://en.wikipedia.org/wiki/Alpha_compositing) to partially shade all domains (cells or materials) other than those specified by the user. The resulting effect is to "highlight" those domains which are left out of the shading process.

An example of how this routine may be used is shown below for a fuel assembly in the BEAVRS benchmark with OpenCG local neighbor symmetry (LNS) identification algorithm applied. In this case, I used the built-in "grey" background with an alpha of 0.1

*BEAVRS 1.6% enr. fuel assembly w/o BAs*
<img src="https://cloud.githubusercontent.com/assets/209492/11230967/1d05b1a4-8d72-11e5-9e08-b5f83918807c.png" width="200">

*With OpenCG LNS Identifers Applied*
<img src="https://cloud.githubusercontent.com/assets/209492/11231011/7db94baa-8d72-11e5-9129-ac3601adbc15.png" width="200">

*Highlight LNS ID=119*
<img src="https://cloud.githubusercontent.com/assets/209492/11231023/9c5f12e2-8d72-11e5-9b81-9082ecf95575.png" width="200">

*Highlight LNS ID=185*
<img src="https://cloud.githubusercontent.com/assets/209492/11231027/aa2cb302-8d72-11e5-99af-a4c27ba33718.png" width="200">

*Highlight LNS ID=251*
<img src="https://cloud.githubusercontent.com/assets/209492/11231043/c0be501c-8d72-11e5-8351-af0ff37edbdf.png" width="200">

*Highlight LNS ID=317*
<img src="https://cloud.githubusercontent.com/assets/209492/11231050/d171d8a2-8d72-11e5-995b-7ae831d5beba.png" width="200">

*Highlight LNS ID=440*
<img src="https://cloud.githubusercontent.com/assets/209492/11231054/df74c644-8d72-11e5-9d62-c9db66c0d57c.png" width="200">




