### PR TITLE
Python API Support for Fixed Source Calculations

### DIFF
--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -409,7 +409,7 @@ class SettingsFile(object):
 
     @run_mode.setter
     def run_mode(self, run_mode):
-        if not 'run_mode' in ['eigenvalue', 'fixed source']:
+        if 'run_mode' not in ['eigenvalue', 'fixed source']:
             msg = 'Unable to set run mode to "{0}". Only "eigenvalue" ' \
                   'and "fixed source" are supported."'.format(run_mode)
             raise ValueError(msg)

--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -882,17 +882,17 @@ class SettingsFile(object):
         if self.run_mode == 'eigenvalue':
             self._run_mode_subelement = \
                 ET.SubElement(self._settings_file, "eigenvalue")
-            self._create_batches_subelement()
-            self._create_generations_per_batch_subelement()
-            self._create_inactive_subelement()
             self._create_particles_subelement()
+            self._create_batches_subelement()
+            self._create_inactive_subelement()
+            self._create_generations_per_batch_subelement()
             self._create_keff_trigger_subelement()
         else:
             if self._run_mode_subelement is None:
                 self._run_mode_subelement = \
                     ET.SubElement(self._settings_file, "fixed_source")
-            self._create_batches_subelement()
             self._create_particles_subelement()
+            self._create_batches_subelement()
 
     def _create_batches_subelement(self):
         if self._batches is not None:


### PR DESCRIPTION
This PR extends the Python API to support fixed source calculations. As pointed out by @paulromano in #506, the `Settings` class did not include support for the `<fixed_source>` XML attribute. This PR adds a new `Settings._run_mode` class attribute which may be set to either "eigenvalue" (default) or "fixed source". This attribute is used to determine whether or not to create an `<eigenvalue>` or `<fixed_source>` block in the XML input when `Settings.export_to_xml()` is called.