### PR TITLE
Comparison methods for Python classes

### DIFF
--- a/openmc/cross.py
+++ b/openmc/cross.py
@@ -52,7 +52,7 @@ class CrossScore(object):
             self.binary_op = binary_op
 
     def __hash__(self):
-        return hash(str(self))
+        return hash(repr(self))
 
     def __eq__(self, other):
         return str(other) == str(self)
@@ -152,7 +152,7 @@ class CrossNuclide(object):
             self.binary_op = binary_op
 
     def __hash__(self):
-        return hash(str(self))
+        return hash(repr(self))
 
     def __eq__(self, other):
         return str(other) == str(self)

--- a/openmc/element.py
+++ b/openmc/element.py
@@ -58,7 +58,7 @@ class Element(object):
         return not self == other
 
     def __hash__(self):
-        return hash(str(self))
+        return hash(repr(self))
 
     def __repr__(self):
         string = 'Element    -    {0}\n'.format(self._name)

--- a/openmc/element.py
+++ b/openmc/element.py
@@ -58,7 +58,7 @@ class Element(object):
         return not self == other
 
     def __hash__(self):
-        return hash((self._name, self._xs))
+        return hash(str(self))
 
     def __repr__(self):
         string = 'Element    -    {0}\n'.format(self._name)

--- a/openmc/filter.py
+++ b/openmc/filter.py
@@ -81,7 +81,7 @@ class Filter(object):
         return not self == other
 
     def __hash__(self):
-        return hash((self.type, tuple(self.bins)))
+        return hash(str(self))
 
     def __deepcopy__(self, memo):
         existing = memo.get(id(self))

--- a/openmc/filter.py
+++ b/openmc/filter.py
@@ -81,7 +81,7 @@ class Filter(object):
         return not self == other
 
     def __hash__(self):
-        return hash(str(self))
+        return hash(repr(self))
 
     def __deepcopy__(self, memo):
         existing = memo.get(id(self))

--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -147,7 +147,7 @@ class Geometry(object):
             if cell._type == 'normal':
                 material_cells.add(cell)
 
-        material_cells = list(material_cells)
+        material_cells = list(set(material_cells))
         material_cells.sort(key=lambda x: x.id)
         return material_cells
 

--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -147,7 +147,7 @@ class Geometry(object):
             if cell._type == 'normal':
                 material_cells.add(cell)
 
-        material_cells = list(set(material_cells))
+        material_cells = list(material_cells)
         material_cells.sort(key=lambda x: x.id)
         return material_cells
 

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -90,16 +90,15 @@ class Material(object):
             return False
         elif self.name != other.name:
             return False
-        # FIXME: This won't work since OpenMC only outputs densities in units
-        # of atom/b-cm in summary.h5 irregardless of input units, and it we
+        # FIXME: We cannot compare densities since OpenMC outputs densities
+        # in atom/b-cm in summary.h5 irregardless of input units, and we
         # cannot compute the sum percent in Python since we lack AWR
-        # elif self.density != other.density:
+        #elif self.density != other.density:
         #    return False
-        # FIXME: The nuclide densities are different in summary.h5???
-        # elif self._nuclides != other._nuclides:
+        #elif self._nuclides != other._nuclides:
         #    return False
-        # elif self._elements != other._elements:
-        #    return False
+        #elif self._elements != other._elements:
+        #   return False
         elif self._sab != other._sab:
             return False
         else:

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -108,7 +108,7 @@ class Material(object):
         return not self == other
 
     def __hash__(self):
-        return hash(str(self))
+        return hash(repr(self))
 
     def __repr__(self):
         string = 'Material\n'

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -108,6 +108,9 @@ class Material(object):
     def __ne__(self, other):
         return not self == other
 
+    def __hash__(self):
+        return hash(str(self))
+
     def __repr__(self):
         string = 'Material\n'
         string += '{0: <16}{1}{2}\n'.format('\tID', '=\t', self._id)

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -83,6 +83,29 @@ class Material(object):
         # If specified, this file will be used instead of composition values
         self._distrib_otf_file = None
 
+    def __eq__(self, other):
+        if not isinstance(other, Material):
+            return False
+        elif self.id != other.id:
+            return False
+        elif self.name != other.name:
+            return False
+        elif self.density != other.density:
+            return False
+        elif self.density_units != other.density_units:
+            return False
+        elif self._nuclides != other.nuclides:
+            return False
+        elif self._elements != other._elements:
+            return False
+        elif self._sab != other._sab:
+            return False
+        else:
+            return True
+
+    def __ne__(self, other):
+        return not self == other
+
     def __repr__(self):
         string = 'Material\n'
         string += '{0: <16}{1}{2}\n'.format('\tID', '=\t', self._id)

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -90,14 +90,16 @@ class Material(object):
             return False
         elif self.name != other.name:
             return False
-        elif self.density != other.density:
-            return False
-        elif self.density_units != other.density_units:
-            return False
-        elif self._nuclides != other.nuclides:
-            return False
-        elif self._elements != other._elements:
-            return False
+        # FIXME: This won't work since OpenMC only outputs densities in units
+        # of atom/b-cm in summary.h5 irregardless of input units, and it we
+        # cannot compute the sum percent in Python since we lack AWR
+        # elif self.density != other.density:
+        #    return False
+        # FIXME: The nuclide densities are different in summary.h5???
+        # elif self._nuclides != other._nuclides:
+        #    return False
+        # elif self._elements != other._elements:
+        #    return False
         elif self._sab != other._sab:
             return False
         else:

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -190,7 +190,7 @@ class Mesh(object):
         self._width = width
 
     def __hash__(self):
-        return hash(str(self))
+        return hash(repr(self))
 
     def __repr__(self):
         string = 'Mesh\n'

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -189,6 +189,9 @@ class Mesh(object):
         cv.check_length('mesh width', width, 2, 3)
         self._width = width
 
+    def __hash__(self):
+        return hash(str(self))
+
     def __repr__(self):
         string = 'Mesh\n'
         string += '{0: <16}{1}{2}\n'.format('\tID', '=\t', self._id)

--- a/openmc/mgxs/library.py
+++ b/openmc/mgxs/library.py
@@ -203,6 +203,7 @@ class Library(object):
     def openmc_geometry(self, openmc_geometry):
         cv.check_type('openmc_geometry', openmc_geometry, openmc.Geometry)
         self._openmc_geometry = openmc_geometry
+        self._opencg_geometry = None
 
     @name.setter
     def name(self, name):
@@ -362,7 +363,6 @@ class Library(object):
 
         self._sp_filename = statepoint._f.filename
         self._openmc_geometry = statepoint.summary.openmc_geometry
-        self._opencg_geometry = None
 
         # Load tallies for each MGXS for each domain and mgxs type
         for domain in self.domains:

--- a/openmc/nuclide.py
+++ b/openmc/nuclide.py
@@ -61,7 +61,7 @@ class Nuclide(object):
         return not self == other
 
     def __hash__(self):
-        return hash((self._name, self._xs))
+        return hash(str(self))
 
     def __repr__(self):
         string = 'Nuclide    -    {0}\n'.format(self._name)

--- a/openmc/nuclide.py
+++ b/openmc/nuclide.py
@@ -61,7 +61,7 @@ class Nuclide(object):
         return not self == other
 
     def __hash__(self):
-        return hash(str(self))
+        return hash(repr(self))
 
     def __repr__(self):
         string = 'Nuclide    -    {0}\n'.format(self._name)

--- a/openmc/region.py
+++ b/openmc/region.py
@@ -29,6 +29,17 @@ class Region(object):
     def __str__(self):
         return ''
 
+    def __eq__(self, other):
+        if not isinstance(other, type(self)):
+            return False
+        elif str(self) != str(other):
+            return False
+        else:
+            return True
+
+    def __ne__(self, other):
+        return not self == other
+
     @staticmethod
     def from_expression(expression, surfaces):
         """Generate a region given an infix expression.

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -190,7 +190,7 @@ class Tally(object):
         return not self == other
 
     def __hash__(self):
-        return hash(str(self))
+        return hash(repr(self))
 
     def __repr__(self):
         string = 'Tally\n'

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -190,21 +190,7 @@ class Tally(object):
         return not self == other
 
     def __hash__(self):
-        hashable = []
-
-        for filter in self.filters:
-            hashable.append((filter.type, tuple(filter.bins)))
-
-        for nuclide in self.nuclides:
-            hashable.append(nuclide.name)
-
-        for score in self.scores:
-            hashable.append(score)
-
-        hashable.append(self.estimator)
-        hashable.append(self.name)
-
-        return hash(tuple(hashable))
+        return hash(str(self))
 
     def __repr__(self):
         string = 'Tally\n'

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -94,6 +94,9 @@ class Cell(object):
     def __ne__(self, other):
         return not self == other
 
+    def __hash__(self):
+        return hash(str(self))
+
     def __repr__(self):
         string = 'Cell\n'
         string += '{0: <16}{1}{2}\n'.format('\tID', '=\t', self._id)
@@ -478,6 +481,9 @@ class Universe(object):
 
     def __ne__(self, other):
         return not self == other
+
+    def __hash__(self):
+        return hash(str(self))
 
     def __repr__(self):
         string = 'Universe\n'
@@ -964,6 +970,9 @@ class RectLattice(Lattice):
     def __ne__(self, other):
         return not self == other
 
+    def __hash__(self):
+        return hash(str(self))
+
     def __repr__(self):
         string = 'RectLattice\n'
         string += '{0: <16}{1}{2}\n'.format('\tID', '=\t', self._id)
@@ -1197,6 +1206,9 @@ class HexLattice(Lattice):
 
     def __ne__(self, other):
         return not self == other
+
+    def __hash__(self):
+        return hash(str(self))
 
     def __repr__(self):
         string = 'HexLattice\n'

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -80,10 +80,8 @@ class Cell(object):
             return False
         elif self.name != other.name:
             return False
-        # FIXME: This won't work for materials fills since OpenMC only outputs
-        # nuclide densities in units of atom/b-cm irregardless of input units
-        # elif self.fill != other.fill:
-        #     return False
+        elif self.fill != other.fill:
+             return False
         elif self.region != other.region:
             return False
         elif self.rotation != other.rotation:

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -95,7 +95,7 @@ class Cell(object):
         return not self == other
 
     def __hash__(self):
-        return hash(str(self))
+        return hash(repr(self))
 
     def __repr__(self):
         string = 'Cell\n'
@@ -483,7 +483,7 @@ class Universe(object):
         return not self == other
 
     def __hash__(self):
-        return hash(str(self))
+        return hash(repr(self))
 
     def __repr__(self):
         string = 'Universe\n'
@@ -971,7 +971,7 @@ class RectLattice(Lattice):
         return not self == other
 
     def __hash__(self):
-        return hash(str(self))
+        return hash(repr(self))
 
     def __repr__(self):
         string = 'RectLattice\n'
@@ -1208,7 +1208,7 @@ class HexLattice(Lattice):
         return not self == other
 
     def __hash__(self):
-        return hash(str(self))
+        return hash(repr(self))
 
     def __repr__(self):
         string = 'HexLattice\n'

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -73,6 +73,29 @@ class Cell(object):
         self._translation = None
         self._offsets = None
 
+    def __eq__(self, other):
+        if not isinstance(other, Cell):
+            return False
+        elif self.id != other.id:
+            return False
+        elif self.name != other.name:
+            return False
+        # FIXME: This won't work for materials fills since OpenMC only outputs
+        # nuclide densities in units of atom/b-cm irregardless of input units
+        # elif self.fill != other.fill:
+        #     return False
+        elif self.region != other.region:
+            return False
+        elif self.rotation != other.rotation:
+            return False
+        elif self.translation != other.translation:
+            return False
+        else:
+            return True
+
+    def __ne__(self, other):
+        return not self == other
+
     def __repr__(self):
         string = 'Cell\n'
         string += '{0: <16}{1}{2}\n'.format('\tID', '=\t', self._id)
@@ -443,6 +466,31 @@ class Universe(object):
         self._cell_offsets = OrderedDict()
         self._num_regions = 0
 
+    def __eq__(self, other):
+        if not isinstance(other, Universe):
+            return False
+        elif self.id != other.id:
+            return False
+        elif self.name != other.name:
+            return False
+        elif self.cells != other.cells:
+            return False
+        else:
+            return True
+
+    def __ne__(self, other):
+        return not self == other
+
+    def __repr__(self):
+        string = 'Universe\n'
+        string += '{0: <16}{1}{2}\n'.format('\tID', '=\t', self._id)
+        string += '{0: <16}{1}{2}\n'.format('\tName', '=\t', self._name)
+        string += '{0: <16}{1}{2}\n'.format('\tCells', '=\t',
+                                            list(self._cells.keys()))
+        string += '{0: <16}{1}{2}\n'.format('\t# Regions', '=\t',
+                                            self._num_regions)
+        return string
+
     @property
     def id(self):
         return self._id
@@ -630,16 +678,6 @@ class Universe(object):
 
         return universes
 
-    def __repr__(self):
-        string = 'Universe\n'
-        string += '{0: <16}{1}{2}\n'.format('\tID', '=\t', self._id)
-        string += '{0: <16}{1}{2}\n'.format('\tName', '=\t', self._name)
-        string += '{0: <16}{1}{2}\n'.format('\tCells', '=\t',
-                                            list(self._cells.keys()))
-        string += '{0: <16}{1}{2}\n'.format('\t# Regions', '=\t',
-                                            self._num_regions)
-        return string
-
     def create_xml_subelement(self, xml_element):
 
         # Iterate over all Cells
@@ -694,6 +732,25 @@ class Lattice(object):
         self._pitch = None
         self._outer = None
         self._universes = None
+
+    def __eq__(self, other):
+        if not isinstance(other, Lattice):
+            return False
+        elif self.id != other.id:
+            return False
+        elif self.name != other.name:
+            return False
+        elif self.pitch != other.pitch:
+            return False
+        elif self.outer != other.outer:
+            return False
+        elif self.universes != other.universes:
+            return False
+        else:
+            return True
+
+    def __ne__(self, other):
+        return not self == other
 
     @property
     def id(self):
@@ -893,6 +950,21 @@ class RectLattice(Lattice):
         self._dimension = None
         self._lower_left = None
         self._offsets = None
+
+    def __eq__(self, other):
+        if not isinstance(other, RectLattice):
+            return False
+        elif not super(RectLattice, self).__eq__(other):
+            return False
+        elif self.dimension != other.dimension:
+            return False
+        elif self.lower_left != other.lower_left:
+            return False
+        else:
+            return True
+
+    def __ne__(self, other):
+        return not self == other
 
     def __repr__(self):
         string = 'RectLattice\n'
@@ -1110,6 +1182,23 @@ class HexLattice(Lattice):
         self._num_rings = None
         self._num_axial = None
         self._center = None
+
+    def __eq__(self, other):
+        if not isinstance(other, HexLattice):
+            return False
+        elif not super(HexLattice, self).__eq__(other):
+            return False
+        elif self.num_rings != other.num_rings:
+            return False
+        elif self.num_axial != other.num_axial:
+            return False
+        elif self.center != other.center:
+            return False
+        else:
+            return True
+
+    def __ne__(self, other):
+        return not self == other
 
     def __repr__(self):
         string = 'HexLattice\n'


### PR DESCRIPTION
This PR adds `__eq__` and `__ne__` methods for the `Cell`, `Universe`, `Lattice` and `Material` classes. I was recently working on some code that required these methods and was surprised to realize that I never implemented these in the first place. The only lingering issue that I know of regards the `Material.__eq__(self, other)` routine - it's not clear how to compare two different `Materials` densities, especially when `Materials` created from `Summary` objects use units of atom/b-cm. I made a comment on that portion of the code indicating my quandary about doing this - if you have any advice @paulromano, I'll be happy to implement it!