### PR TITLE
Ability to determine bounding boxes for Regions

### DIFF
--- a/examples/python/boxes/build-xml.py
+++ b/examples/python/boxes/build-xml.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 import openmc
 
 ###############################################################################
@@ -115,7 +117,7 @@ settings_file = openmc.SettingsFile()
 settings_file.batches = batches
 settings_file.inactive = inactive
 settings_file.particles = particles
-settings_file.set_source_space('point', [0., 0., 0.])
+settings_file.set_source_space('box', np.concatenate(outer_cube.bounding_box))
 settings_file.export_to_xml()
 
 ###############################################################################

--- a/examples/python/reflective/build-xml.py
+++ b/examples/python/reflective/build-xml.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 import openmc
 
 ###############################################################################
@@ -82,5 +84,5 @@ settings_file = openmc.SettingsFile()
 settings_file.batches = batches
 settings_file.inactive = inactive
 settings_file.particles = particles
-settings_file.set_source_space('box', [-1, -1, -1, 1, 1, 1])
+settings_file.set_source_space('box', np.concatenate(cell.region.bounding_box))
 settings_file.export_to_xml()

--- a/examples/xml/boxes/settings.xml
+++ b/examples/xml/boxes/settings.xml
@@ -10,7 +10,7 @@
 
   <!-- Starting source -->
   <source>
-    <space type="point" parameters="0. 0. 0." />
+    <space type="box" parameters="-10. -10. -10. 10. 10. 10." />
   </source>
 
 </settings>

--- a/openmc/region.py
+++ b/openmc/region.py
@@ -237,13 +237,13 @@ class Intersection(Region):
 
     @property
     def bounding_box(self):
-        ll = np.array([-np.inf, -np.inf, -np.inf])
-        ur = np.array([np.inf, np.inf, np.inf])
+        lower_left = np.array([-np.inf, -np.inf, -np.inf])
+        upper_right = np.array([np.inf, np.inf, np.inf])
         for n in self.nodes:
-            ll_n, ur_n = n.bounding_box
-            ll[:] = np.maximum(ll, ll_n)
-            ur[:] = np.minimum(ur, ur_n)
-        return ll, ur
+            lower_left_n, upper_right_n = n.bounding_box
+            lower_left[:] = np.maximum(lower_left, lower_left_n)
+            upper_right[:] = np.minimum(upper_right, upper_right_n)
+        return lower_left, upper_right
 
     @nodes.setter
     def nodes(self, nodes):
@@ -288,13 +288,13 @@ class Union(Region):
 
     @property
     def bounding_box(self):
-        ll = np.array([np.inf, np.inf, np.inf])
-        ur = np.array([-np.inf, -np.inf, -np.inf])
+        lower_left = np.array([np.inf, np.inf, np.inf])
+        upper_right = np.array([-np.inf, -np.inf, -np.inf])
         for n in self.nodes:
-            ll_n, ur_n = n.bounding_box
-            ll[:] = np.minimum(ll, ll_n)
-            ur[:] = np.maximum(ur, ur_n)
-        return ll, ur
+            lower_left_n, upper_right_n = n.bounding_box
+            lower_left[:] = np.minimum(lower_left, lower_left_n)
+            upper_right[:] = np.maximum(upper_right, upper_right_n)
+        return lower_left, upper_right
 
     @nodes.setter
     def nodes(self, nodes):

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -327,9 +327,9 @@ class XPlane(Plane):
         """Determine an axis-aligned bounding box.
 
         An axis-aligned bounding box for surface half-spaces is represented by
-        its lower-left and upper-right coordinates. If the half-space is
-        unbounded in a particular direction, numpy.inf is used to represent
-        infinity.
+        its lower-left and upper-right coordinates. For the x-plane surface, the
+        half-spaces are unbounded in their y- and z- directions. To represent
+        infinity, numpy.inf is used.
 
         Parameters
         ----------
@@ -405,9 +405,9 @@ class YPlane(Plane):
         """Determine an axis-aligned bounding box.
 
         An axis-aligned bounding box for surface half-spaces is represented by
-        its lower-left and upper-right coordinates. If the half-space is
-        unbounded in a particular direction, numpy.inf is used to represent
-        infinity.
+        its lower-left and upper-right coordinates. For the y-plane surface, the
+        half-spaces are unbounded in their x- and z- directions. To represent
+        infinity, numpy.inf is used.
 
         Parameters
         ----------
@@ -483,9 +483,9 @@ class ZPlane(Plane):
         """Determine an axis-aligned bounding box.
 
         An axis-aligned bounding box for surface half-spaces is represented by
-        its lower-left and upper-right coordinates. If the half-space is
-        unbounded in a particular direction, numpy.inf is used to represent
-        infinity.
+        its lower-left and upper-right coordinates. For the z-plane surface, the
+        half-spaces are unbounded in their x- and y- directions. To represent
+        infinity, numpy.inf is used.
 
         Parameters
         ----------
@@ -629,9 +629,10 @@ class XCylinder(Cylinder):
         """Determine an axis-aligned bounding box.
 
         An axis-aligned bounding box for surface half-spaces is represented by
-        its lower-left and upper-right coordinates. If the half-space is
-        unbounded in a particular direction, numpy.inf is used to represent
-        infinity.
+        its lower-left and upper-right coordinates. For the x-cylinder surface,
+        the negative half-space is unbounded in the x- direction and the
+        positive half-space is unbounded in all directions. To represent
+        infinity, numpy.inf is used.
 
         Parameters
         ----------
@@ -651,7 +652,7 @@ class XCylinder(Cylinder):
 
         if side == '-':
             return (np.array([-np.inf, self.y0 - self.r, self.z0 - self.r]),
-                    np.array([np.inf, self.y0 + self.r, self.y0 + self.r]))
+                    np.array([np.inf, self.y0 + self.r, self.z0 + self.r]))
         elif side == '+':
             return (np.array([-np.inf, -np.inf, -np.inf]),
                     np.array([np.inf, np.inf, np.inf]))
@@ -727,9 +728,10 @@ class YCylinder(Cylinder):
         """Determine an axis-aligned bounding box.
 
         An axis-aligned bounding box for surface half-spaces is represented by
-        its lower-left and upper-right coordinates. If the half-space is
-        unbounded in a particular direction, numpy.inf is used to represent
-        infinity.
+        its lower-left and upper-right coordinates. For the y-cylinder surface,
+        the negative half-space is unbounded in the y- direction and the
+        positive half-space is unbounded in all directions. To represent
+        infinity, numpy.inf is used.
 
         Parameters
         ----------
@@ -749,7 +751,7 @@ class YCylinder(Cylinder):
 
         if side == '-':
             return (np.array([self.x0 - self.r, -np.inf, self.z0 - self.r]),
-                    np.array([self.x0 + self.r, np.inf, self.y0 + self.r]))
+                    np.array([self.x0 + self.r, np.inf, self.z0 + self.r]))
         elif side == '+':
             return (np.array([-np.inf, -np.inf, -np.inf]),
                     np.array([np.inf, np.inf, np.inf]))
@@ -825,9 +827,10 @@ class ZCylinder(Cylinder):
         """Determine an axis-aligned bounding box.
 
         An axis-aligned bounding box for surface half-spaces is represented by
-        its lower-left and upper-right coordinates. If the half-space is
-        unbounded in a particular direction, numpy.inf is used to represent
-        infinity.
+        its lower-left and upper-right coordinates. For the z-cylinder surface,
+        the negative half-space is unbounded in the z- direction and the
+        positive half-space is unbounded in all directions. To represent
+        infinity, numpy.inf is used.
 
         Parameters
         ----------
@@ -953,9 +956,9 @@ class Sphere(Surface):
         """Determine an axis-aligned bounding box.
 
         An axis-aligned bounding box for surface half-spaces is represented by
-        its lower-left and upper-right coordinates. If the half-space is
-        unbounded in a particular direction, numpy.inf is used to represent
-        infinity.
+        its lower-left and upper-right coordinates. The positive half-space of a
+        sphere is unbounded in all directions. To represent infinity, numpy.inf
+        is used.
 
         Parameters
         ----------

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -3,6 +3,8 @@ from numbers import Real, Integral
 from xml.etree import ElementTree as ET
 import sys
 
+import numpy as np
+
 from openmc.checkvalue import check_type, check_value, check_greater_than
 from openmc.region import Region
 
@@ -136,6 +138,33 @@ class Surface(object):
         check_value('boundary type', boundary_type, _BC_TYPES)
         self._boundary_type = boundary_type
 
+    def bounding_box(self, side):
+        """Determine an axis-aligned bounding box.
+
+        An axis-aligned bounding box for surface half-spaces is represented by
+        its lower-left and upper-right coordinates. If the half-space is
+        unbounded in a particular direction, numpy.inf is used to represent
+        infinity.
+
+        Parameters
+        ----------
+        side : {'+', '-'}
+            Indicates the negative or positive half-space
+
+        Returns
+        -------
+        numpy.array
+            Lower-left coordinates of the axis-aligned bounding box for the
+            desired half-space
+        numpy.array
+            Upper-right coordinates of the axis-aligned bounding box for the
+            desired half-space
+
+        """
+
+        return (np.array([-np.inf, -np.inf, -np.inf]),
+                np.array([np.inf, np.inf, np.inf]))
+
     def create_xml_subelement(self):
         element = ET.Element("surface")
         element.set("id", str(self._id))
@@ -194,6 +223,10 @@ class Plane(Surface):
 
         self._type = 'plane'
         self._coeff_keys = ['A', 'B', 'C', 'D']
+        self._coeffs['A'] = 1.
+        self._coeffs['B'] = 0.
+        self._coeffs['C'] = 0.
+        self._coeffs['D'] = 0.
 
         if A is not None:
             self.a = A
@@ -276,6 +309,7 @@ class XPlane(Plane):
 
         self._type = 'x-plane'
         self._coeff_keys = ['x0']
+        self._coeffs['x0'] = 0.
 
         if x0 is not None:
             self.x0 = x0
@@ -288,6 +322,37 @@ class XPlane(Plane):
     def x0(self, x0):
         check_type('x0 coefficient', x0, Real)
         self._coeffs['x0'] = x0
+
+    def bounding_box(self, side):
+        """Determine an axis-aligned bounding box.
+
+        An axis-aligned bounding box for surface half-spaces is represented by
+        its lower-left and upper-right coordinates. If the half-space is
+        unbounded in a particular direction, numpy.inf is used to represent
+        infinity.
+
+        Parameters
+        ----------
+        side : {'+', '-'}
+            Indicates the negative or positive half-space
+
+        Returns
+        -------
+        numpy.array
+            Lower-left coordinates of the axis-aligned bounding box for the
+            desired half-space
+        numpy.array
+            Upper-right coordinates of the axis-aligned bounding box for the
+            desired half-space
+
+        """
+
+        if side == '-':
+            return (np.array([-np.inf, -np.inf, -np.inf]),
+                    np.array([self.x0, np.inf, np.inf]))
+        elif side == '+':
+            return (np.array([self.x0, -np.inf, -np.inf]),
+                    np.array([np.inf, np.inf, np.inf]))
 
 
 class YPlane(Plane):
@@ -322,6 +387,7 @@ class YPlane(Plane):
 
         self._type = 'y-plane'
         self._coeff_keys = ['y0']
+        self._coeffs['y0'] = 0.
 
         if y0 is not None:
             self.y0 = y0
@@ -334,6 +400,37 @@ class YPlane(Plane):
     def y0(self, y0):
         check_type('y0 coefficient', y0, Real)
         self._coeffs['y0'] = y0
+
+    def bounding_box(self, side):
+        """Determine an axis-aligned bounding box.
+
+        An axis-aligned bounding box for surface half-spaces is represented by
+        its lower-left and upper-right coordinates. If the half-space is
+        unbounded in a particular direction, numpy.inf is used to represent
+        infinity.
+
+        Parameters
+        ----------
+        side : {'+', '-'}
+            Indicates the negative or positive half-space
+
+        Returns
+        -------
+        numpy.array
+            Lower-left coordinates of the axis-aligned bounding box for the
+            desired half-space
+        numpy.array
+            Upper-right coordinates of the axis-aligned bounding box for the
+            desired half-space
+
+        """
+
+        if side == '-':
+            return (np.array([-np.inf, -np.inf, -np.inf]),
+                    np.array([np.inf, self.y0, np.inf]))
+        elif side == '+':
+            return (np.array([-np.inf, -self.y0, -np.inf]),
+                    np.array([np.inf, np.inf, np.inf]))
 
 
 class ZPlane(Plane):
@@ -368,6 +465,7 @@ class ZPlane(Plane):
 
         self._type = 'z-plane'
         self._coeff_keys = ['z0']
+        self._coeffs['z0'] = 0.
 
         if z0 is not None:
             self.z0 = z0
@@ -380,6 +478,37 @@ class ZPlane(Plane):
     def z0(self, z0):
         check_type('z0 coefficient', z0, Real)
         self._coeffs['z0'] = z0
+
+    def bounding_box(self, side):
+        """Determine an axis-aligned bounding box.
+
+        An axis-aligned bounding box for surface half-spaces is represented by
+        its lower-left and upper-right coordinates. If the half-space is
+        unbounded in a particular direction, numpy.inf is used to represent
+        infinity.
+
+        Parameters
+        ----------
+        side : {'+', '-'}
+            Indicates the negative or positive half-space
+
+        Returns
+        -------
+        numpy.array
+            Lower-left coordinates of the axis-aligned bounding box for the
+            desired half-space
+        numpy.array
+            Upper-right coordinates of the axis-aligned bounding box for the
+            desired half-space
+
+        """
+
+        if side == '-':
+            return (np.array([-np.inf, -np.inf, -np.inf]),
+                    np.array([np.inf, np.inf, self.z0]))
+        elif side == '+':
+            return (np.array([-np.inf, -np.inf, -self.z0]),
+                    np.array([np.inf, np.inf, np.inf]))
 
 
 class Cylinder(Surface):
@@ -415,6 +544,7 @@ class Cylinder(Surface):
         super(Cylinder, self).__init__(surface_id, boundary_type, name=name)
 
         self._coeff_keys = ['R']
+        self._coeffs['R'] = 1.
 
         if R is not None:
             self.r = R
@@ -468,6 +598,8 @@ class XCylinder(Cylinder):
 
         self._type = 'x-cylinder'
         self._coeff_keys = ['y0', 'z0', 'R']
+        self._coeffs['y0'] = 0.
+        self._coeffs['z0'] = 0.
 
         if y0 is not None:
             self.y0 = y0
@@ -492,6 +624,37 @@ class XCylinder(Cylinder):
     def z0(self, z0):
         check_type('z0 coefficient', z0, Real)
         self._coeffs['z0'] = z0
+
+    def bounding_box(self, side):
+        """Determine an axis-aligned bounding box.
+
+        An axis-aligned bounding box for surface half-spaces is represented by
+        its lower-left and upper-right coordinates. If the half-space is
+        unbounded in a particular direction, numpy.inf is used to represent
+        infinity.
+
+        Parameters
+        ----------
+        side : {'+', '-'}
+            Indicates the negative or positive half-space
+
+        Returns
+        -------
+        numpy.array
+            Lower-left coordinates of the axis-aligned bounding box for the
+            desired half-space
+        numpy.array
+            Upper-right coordinates of the axis-aligned bounding box for the
+            desired half-space
+
+        """
+
+        if side == '-':
+            return (np.array([-np.inf, self.y0 - self.r, self.z0 - self.r]),
+                    np.array([np.inf, self.y0 + self.r, self.y0 + self.r]))
+        elif side == '+':
+            return (np.array([-np.inf, -np.inf, -np.inf]),
+                    np.array([np.inf, np.inf, np.inf]))
 
 
 class YCylinder(Cylinder):
@@ -533,6 +696,8 @@ class YCylinder(Cylinder):
 
         self._type = 'y-cylinder'
         self._coeff_keys = ['x0', 'z0', 'R']
+        self._coeffs['x0'] = 0.
+        self._coeffs['z0'] = 0.
 
         if x0 is not None:
             self.x0 = x0
@@ -557,6 +722,37 @@ class YCylinder(Cylinder):
     def z0(self, z0):
         check_type('z0 coefficient', z0, Real)
         self._coeffs['z0'] = z0
+
+    def bounding_box(self, side):
+        """Determine an axis-aligned bounding box.
+
+        An axis-aligned bounding box for surface half-spaces is represented by
+        its lower-left and upper-right coordinates. If the half-space is
+        unbounded in a particular direction, numpy.inf is used to represent
+        infinity.
+
+        Parameters
+        ----------
+        side : {'+', '-'}
+            Indicates the negative or positive half-space
+
+        Returns
+        -------
+        numpy.array
+            Lower-left coordinates of the axis-aligned bounding box for the
+            desired half-space
+        numpy.array
+            Upper-right coordinates of the axis-aligned bounding box for the
+            desired half-space
+
+        """
+
+        if side == '-':
+            return (np.array([self.x0 - self.r, -np.inf, self.z0 - self.r]),
+                    np.array([self.x0 + self.r, np.inf, self.y0 + self.r]))
+        elif side == '+':
+            return (np.array([-np.inf, -np.inf, -np.inf]),
+                    np.array([np.inf, np.inf, np.inf]))
 
 
 class ZCylinder(Cylinder):
@@ -598,6 +794,8 @@ class ZCylinder(Cylinder):
 
         self._type = 'z-cylinder'
         self._coeff_keys = ['x0', 'y0', 'R']
+        self._coeffs['x0'] = 0.
+        self._coeffs['y0'] = 0.
 
         if x0 is not None:
             self.x0 = x0
@@ -622,6 +820,37 @@ class ZCylinder(Cylinder):
     def y0(self, y0):
         check_type('y0 coefficient', y0, Real)
         self._coeffs['y0'] = y0
+
+    def bounding_box(self, side):
+        """Determine an axis-aligned bounding box.
+
+        An axis-aligned bounding box for surface half-spaces is represented by
+        its lower-left and upper-right coordinates. If the half-space is
+        unbounded in a particular direction, numpy.inf is used to represent
+        infinity.
+
+        Parameters
+        ----------
+        side : {'+', '-'}
+            Indicates the negative or positive half-space
+
+        Returns
+        -------
+        numpy.array
+            Lower-left coordinates of the axis-aligned bounding box for the
+            desired half-space
+        numpy.array
+            Upper-right coordinates of the axis-aligned bounding box for the
+            desired half-space
+
+        """
+
+        if side == '-':
+            return (np.array([self.x0 - self.r, self.y0 - self.r, -np.inf]),
+                    np.array([self.x0 + self.r, self.y0 + self.r, np.inf]))
+        elif side == '+':
+            return (np.array([-np.inf, -np.inf, -np.inf]),
+                    np.array([np.inf, np.inf, np.inf]))
 
 
 class Sphere(Surface):
@@ -667,6 +896,10 @@ class Sphere(Surface):
 
         self._type = 'sphere'
         self._coeff_keys = ['x0', 'y0', 'z0', 'R']
+        self._coeffs['x0'] = 0.
+        self._coeffs['y0'] = 0.
+        self._coeffs['z0'] = 0.
+        self._coeffs['R'] = 1.
 
         if x0 is not None:
             self.x0 = x0
@@ -716,6 +949,39 @@ class Sphere(Surface):
         check_type('R coefficient', R, Real)
         self._coeffs['R'] = R
 
+    def bounding_box(self, side):
+        """Determine an axis-aligned bounding box.
+
+        An axis-aligned bounding box for surface half-spaces is represented by
+        its lower-left and upper-right coordinates. If the half-space is
+        unbounded in a particular direction, numpy.inf is used to represent
+        infinity.
+
+        Parameters
+        ----------
+        side : {'+', '-'}
+            Indicates the negative or positive half-space
+
+        Returns
+        -------
+        numpy.array
+            Lower-left coordinates of the axis-aligned bounding box for the
+            desired half-space
+        numpy.array
+            Upper-right coordinates of the axis-aligned bounding box for the
+            desired half-space
+
+        """
+
+        if side == '-':
+            return (np.array([self.x0 - self.r, self.y0 - self.r,
+                              self.z0 - self.r]),
+                    np.array([self.x0 + self.r, self.y0 + self.r,
+                              self.z0 + self.r]))
+        elif side == '+':
+            return (np.array([-np.inf, -np.inf, -np.inf]),
+                    np.array([np.inf, np.inf, np.inf]))
+
 
 class Cone(Surface):
     """A conical surface parallel to the x-, y-, or z-axis.
@@ -761,6 +1027,10 @@ class Cone(Surface):
         super(Cone, self).__init__(surface_id, boundary_type, name=name)
 
         self._coeff_keys = ['x0', 'y0', 'z0', 'R2']
+        self._coeffs['x0'] = 0.
+        self._coeffs['y0'] = 0.
+        self._coeffs['z0'] = 0.
+        self._coeffs['R2'] = 1.
 
         if x0 is not None:
             self.x0 = x0
@@ -982,6 +1252,8 @@ class Quadric(Surface):
 
         self._type = 'quadric'
         self._coeff_keys = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k']
+        for key in self._coeff_keys:
+            self._coeffs[key] = 0.
 
         if a is not None:
             self.a = a
@@ -1127,6 +1399,8 @@ class Halfspace(Region):
         Surface which divides Euclidean space.
     side : {'+', '-'}
         Indicates whether the positive or negative half-space is used.
+    bounding_box : tuple of numpy.array
+        Lower-left and upper-right coordinates of an axis-aligned bounding box
 
     """
 
@@ -1154,6 +1428,10 @@ class Halfspace(Region):
     def side(self, side):
         check_value('side', side, ('+', '-'))
         self._side = side
+
+    @property
+    def bounding_box(self):
+        return self.surface.bounding_box(self.side)
 
     def __str__(self):
         return '-' + str(self.surface.id) if self.side == '-' \

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -429,7 +429,7 @@ class YPlane(Plane):
             return (np.array([-np.inf, -np.inf, -np.inf]),
                     np.array([np.inf, self.y0, np.inf]))
         elif side == '+':
-            return (np.array([-np.inf, -self.y0, -np.inf]),
+            return (np.array([-np.inf, self.y0, -np.inf]),
                     np.array([np.inf, np.inf, np.inf]))
 
 
@@ -507,7 +507,7 @@ class ZPlane(Plane):
             return (np.array([-np.inf, -np.inf, -np.inf]),
                     np.array([np.inf, np.inf, self.z0]))
         elif side == '+':
-            return (np.array([-np.inf, -np.inf, -self.z0]),
+            return (np.array([-np.inf, -np.inf, self.z0]),
                     np.array([np.inf, np.inf, np.inf]))
 
 


### PR DESCRIPTION
This pull request adds the ability to determine axis-aligned bounding boxes for CSG regions defined using OpenMC's Region abstraction. I was able to handle unions, intersections, and complements in the following manner:
- *Unions*: for the lower-left coordinate, use the "left-most" coordinate between the bounding boxes of each region within the union. Reverse the logic for upper-right
- *Intersections*: for the lower-left coordinate, use the "right-most" coordinate between the bounding boxes of each region within the intersection.
- *Complements*: Use De Morgan's laws to distribute the complement operator recursively until it can be applied to half-spaces directly, where the `__invert__` method flips the side.

Since it is not trivial to handle general plane, cone, and general quadratic surfaces, those surfaces have a default infinite bounding box (in the implementation, they don't override a default Surface.bounding_box property). All other surfaces work correctly.

There are some implementation differences between what I have here and how OpenCG handles bounding boxes. I return two numpy arrays (this enables use of numpy.minimum and numpy.maximum in recursion) rather than have separate min_x/y/z and max_x/y/z properties. I also don't store any private attributes (e.g. _max_x) and instead compute everything on the fly using the existing surface coefficient attributes.

I mostly wanted this capability to make it easy to automatically generate a box source over an arbitrary geometry. Assuming the root universe doesn't contain cells that use any of the nasty surface types, a bounding box for the geometry can be found by looking at the bounding box of the union of all root universe cells.