### PR TITLE
RPATH MPI and HDF5 for installed exe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,6 +236,14 @@ endif()
 add_subdirectory(src/xml/fox)
 
 #===============================================================================
+# RPATH information
+#===============================================================================
+
+# add the automatically determined parts of the RPATH
+# which point to directories outside the build tree to the install RPATH
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+#===============================================================================
 # Build OpenMC executable
 #===============================================================================
 


### PR DESCRIPTION
When comparing openmc in build area to openmc in install area, there was an issue linking to shared libs. You will notice the discrepancies for HDF5 and MPI.

BUILD AREA
bherman@localhost:~/Documents/repos/openmc/build (develop)$ ldd bin/openmc 
	linux-vdso.so.1 (0x00007ffde5db5000)
	libhdf5hl_fortran.so.10 => /opt/phdf5/1.8.16/lib/libhdf5hl_fortran.so.10 (0x00007f347249f000)
	libhdf5_hl.so.10 => /opt/phdf5/1.8.16/lib/libhdf5_hl.so.10 (0x00007f347227d000)
	libhdf5_fortran.so.10 => /opt/phdf5/1.8.16/lib/libhdf5_fortran.so.10 (0x00007f3472032000)
	libhdf5.so.10 => /opt/phdf5/1.8.16/lib/libhdf5.so.10 (0x00007f3471b1c000)
	libz.so.1 => /lib64/libz.so.1 (0x00007f34718ee000)
	libdl.so.2 => /lib64/libdl.so.2 (0x00007f34716ea000)
	libgfortran.so.3 => /lib64/libgfortran.so.3 (0x00007f34713bf000)
	libm.so.6 => /lib64/libm.so.6 (0x00007f34710bc000)
	libmpifort.so.12 => /opt/mpich/3.2/lib/libmpifort.so.12 (0x00007f3470e85000)
	libmpi.so.12 => /opt/mpich/3.2/lib/libmpi.so.12 (0x00007f34709f6000)
	libgomp.so.1 => /lib64/libgomp.so.1 (0x00007f34707d3000)
	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007f34705bc000)
	libquadmath.so.0 => /lib64/libquadmath.so.0 (0x00007f347037d000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007f347015f000)
	libc.so.6 => /lib64/libc.so.6 (0x00007f346fd9e000)
	/lib64/ld-linux-x86-64.so.2 (0x000055616248d000)
	librt.so.1 => /lib64/librt.so.1 (0x00007f346fb95000)

INSTALL AREA before commit
bherman@localhost:~/Documents/repos/openmc/build (develop)$ ldd /opt/openmc/dev/bin/openmc
	linux-vdso.so.1 (0x00007fff16be0000)
	libhdf5hl_fortran.so.10 => /lib64/libhdf5hl_fortran.so.10 (0x00007f644e1e6000)
	libhdf5_hl.so.10 => /lib64/libhdf5_hl.so.10 (0x00007f644dfc4000)
	libhdf5_fortran.so.10 => /lib64/libhdf5_fortran.so.10 (0x00007f644dd85000)
	libhdf5.so.10 => /lib64/libhdf5.so.10 (0x00007f644d8c9000)
	libz.so.1 => /lib64/libz.so.1 (0x00007f644d6b3000)
	libdl.so.2 => /lib64/libdl.so.2 (0x00007f644d4ae000)
	libgfortran.so.3 => /lib64/libgfortran.so.3 (0x00007f644d183000)
	libm.so.6 => /lib64/libm.so.6 (0x00007f644ce81000)
	libmpifort.so.12 => not found
	libmpi.so.12 => not found
	libgomp.so.1 => /lib64/libgomp.so.1 (0x00007f644cc5e000)
	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007f644ca46000)
	libquadmath.so.0 => /lib64/libquadmath.so.0 (0x00007f644c807000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007f644c5ea000)
	libc.so.6 => /lib64/libc.so.6 (0x00007f644c228000)
	/lib64/ld-linux-x86-64.so.2 (0x0000561a6d11c000)

INSTALL AREA after commit
bherman@localhost:~/Documents/repos/openmc/build (develop)$ ldd bin/openmc 
	linux-vdso.so.1 (0x00007ffde5db5000)
	libhdf5hl_fortran.so.10 => /opt/phdf5/1.8.16/lib/libhdf5hl_fortran.so.10 (0x00007f347249f000)
	libhdf5_hl.so.10 => /opt/phdf5/1.8.16/lib/libhdf5_hl.so.10 (0x00007f347227d000)
	libhdf5_fortran.so.10 => /opt/phdf5/1.8.16/lib/libhdf5_fortran.so.10 (0x00007f3472032000)
	libhdf5.so.10 => /opt/phdf5/1.8.16/lib/libhdf5.so.10 (0x00007f3471b1c000)
	libz.so.1 => /lib64/libz.so.1 (0x00007f34718ee000)
	libdl.so.2 => /lib64/libdl.so.2 (0x00007f34716ea000)
	libgfortran.so.3 => /lib64/libgfortran.so.3 (0x00007f34713bf000)
	libm.so.6 => /lib64/libm.so.6 (0x00007f34710bc000)
	libmpifort.so.12 => /opt/mpich/3.2/lib/libmpifort.so.12 (0x00007f3470e85000)
	libmpi.so.12 => /opt/mpich/3.2/lib/libmpi.so.12 (0x00007f34709f6000)
	libgomp.so.1 => /lib64/libgomp.so.1 (0x00007f34707d3000)
	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007f34705bc000)
	libquadmath.so.0 => /lib64/libquadmath.so.0 (0x00007f347037d000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007f347015f000)
	libc.so.6 => /lib64/libc.so.6 (0x00007f346fd9e000)
	/lib64/ld-linux-x86-64.so.2 (0x000055616248d000)
	librt.so.1 => /lib64/librt.so.1 (0x00007f346fb95000)