### PR TITLE
Single print for Deprecated Cell.add_surface(...) method

### DIFF
--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -15,6 +15,10 @@ from openmc.region import Region, Intersection, Complement
 if sys.version_info[0] >= 3:
     basestring = str
 
+
+# DeprecationWarning filter for the Cell.add_surface(...) method
+warnings.simplefilter('always', DeprecationWarning)
+
 # A static variable for auto-generated Cell IDs
 AUTO_CELL_ID = 10000
 
@@ -240,7 +244,6 @@ class Cell(object):
 
         """
 
-        warnings.simplefilter('once', DeprecationWarning)
         warnings.warn("Cell.add_surface(...) has been deprecated and may be "
                       "removed in a future version. The region for a Cell "
                       "should be defined using the region property directly.",

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -240,7 +240,7 @@ class Cell(object):
 
         """
 
-        warnings.simplefilter('always', DeprecationWarning)
+        warnings.simplefilter('once', DeprecationWarning)
         warnings.warn("Cell.add_surface(...) has been deprecated and may be "
                       "removed in a future version. The region for a Cell "
                       "should be defined using the region property directly.",


### PR DESCRIPTION
The OpenCG-based BEAVRS builder in mit-crpg/PWR_benchmarks throws a large number of the following `DeprecationWarnings`:

```bash
/usr/local/lib/python2.7/dist-packages/openmc-0.7.0-py2.7.egg/openmc/universe.py:247: DeprecationWarning: Cell.add_surface(...) has been deprecated and may be removed in a future version. The region for a Cell should be defined using the region property directly.
```

These warnings were introduced in PR #463 with complex regions. OpenCG does not (yet) support complex regions, and hence the OpenMC-OpenCG compatibility module still uses the `Cell.add_surface(...)` method. These `DeprecationWarnings` really cloud the output when one runs the BEAVRS builder which can annoying and distracting, esp. to those users who have no reason to know the reason for this. 

This PR makes it such that this warning is only printed to the console once. Perhaps this is not good practice since it is less transparent than before - if so, we can at least discuss the best course of action here. Of course the "real fix" is to implement complex regions in OpenCG (which could likely be based largely upon the current implementation in the OpenMC Python API). But this doesn't seem to be a priority for anyone at the moment, hence the need for this PR to bridge the gap.