### PR TITLE
Few minor fixes ahead of release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,14 +278,21 @@ target_link_libraries(${program} ${ldflags} ${HDF5_LIBRARIES} fox_dom)
 install(TARGETS ${program} RUNTIME DESTINATION bin)
 install(DIRECTORY src/relaxng DESTINATION share/openmc)
 install(FILES man/man1/openmc.1 DESTINATION share/man/man1)
-install(FILES LICENSE DESTINATION "share/doc/${program}/copyright")
+install(FILES LICENSE DESTINATION "share/doc/${program}" RENAME copyright)
 
 find_package(PythonInterp)
 if(PYTHONINTERP_FOUND)
-  install(CODE "execute_process(
-                  COMMAND ${PYTHON_EXECUTABLE} setup.py install
-                  --prefix=${CMAKE_INSTALL_PREFIX}
-                  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})")
+  if(debian)
+    install(CODE "execute_process(
+                    COMMAND ${PYTHON_EXECUTABLE} setup.py install
+                    --root=debian/openmc --install-layout=deb
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})")
+  else()
+    install(CODE "execute_process(
+                    COMMAND ${PYTHON_EXECUTABLE} setup.py install
+                    --prefix=${CMAKE_INSTALL_PREFIX}
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})")
+  endif()
 endif()
 
 #===============================================================================

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -200,7 +200,7 @@ latex_elements = {
 \usepackage{enumitem}
 \usepackage{amsfonts}
 \usepackage{amsmath}
-\setlistdepth{9}
+\setlistdepth{99}
 \usepackage{tikz}
 \usetikzlibrary{shapes,snakes,shadows,arrows,calc,decorations.markings,patterns,fit,matrix,spy}
 \usepackage{fixltx2e}

--- a/openmc/mgxs/library.py
+++ b/openmc/mgxs/library.py
@@ -382,9 +382,7 @@ class Library(object):
         ----------
         domain : Material or Cell or Universe or Integral
             The material, cell, or universe object of interest (or its ID)
-        mgxs_type : {'total', 'transport', 'absorption', 'capture', 'fission',
-                     'nu-fission', 'scatter', 'nu-scatter', 'scatter matrix',
-                     'nu-scatter matrix', 'chi'}
+        mgxs_type : {'total', 'transport', 'absorption', 'capture', 'fission', 'nu-fission', 'scatter', 'nu-scatter', 'scatter matrix', 'nu-scatter matrix', 'chi'}
             The type of multi-group cross section object to return
 
         Returns

--- a/src/hdf5_interface.F90
+++ b/src/hdf5_interface.F90
@@ -1483,7 +1483,7 @@ contains
     integer(HID_T) :: dspace  ! data or file space handle
     integer(HID_T) :: filetype
     integer(HID_T) :: memtype
-    integer(HSIZE_T) :: n
+    integer(SIZE_T) :: n
     type(c_ptr) :: f_ptr
 
     ! Set up collective vs. independent I/O
@@ -1544,8 +1544,8 @@ contains
     integer(HID_T) :: dspace  ! data or file space handle
     integer(HID_T) :: filetype
     integer(HID_T) :: memtype
-    integer(HSIZE_T) :: size
-    integer(HSIZE_T) :: n
+    integer(SIZE_T) :: size
+    integer(SIZE_T) :: n
     type(c_ptr) :: f_ptr
 
     ! Set up collective vs. independent I/O
@@ -1628,7 +1628,7 @@ contains
     integer(HID_T) :: dspace  ! data or file space handle
     integer(HID_T) :: filetype
     integer(HID_T) :: memtype
-    integer(HSIZE_T) :: n
+    integer(SIZE_T) :: n
     type(c_ptr) :: f_ptr
 
     ! Set up collective vs. independent I/O
@@ -1644,7 +1644,7 @@ contains
 
     ! Create datatype in memory based on Fortran character
     call h5tcopy_f(H5T_FORTRAN_S1, memtype, hdf5_err)
-    call h5tset_size_f(memtype, int(len(buffer(1)), HSIZE_T), hdf5_err)
+    call h5tset_size_f(memtype, int(len(buffer(1)), SIZE_T), hdf5_err)
 
     ! Create dataspace/dataset
     call h5screate_simple_f(1, dims, dspace, hdf5_err)
@@ -1706,8 +1706,8 @@ contains
     integer(HID_T) :: dspace  ! data or file space handle
     integer(HID_T) :: filetype
     integer(HID_T) :: memtype
-    integer(HSIZE_T) :: size
-    integer(HSIZE_T) :: n
+    integer(SIZE_T) :: size
+    integer(SIZE_T) :: n
     type(c_ptr) :: f_ptr
 
     ! Set up collective vs. independent I/O


### PR DESCRIPTION
This pull request fixes a few random things ahead of the 0.7.1 release:
- The `h5tget_size_f` and `h5tset_size_f` procedures from the HDF5 API take a few arguments that should be `integer(SIZE_T)` that instead we had as `integer(HSIZE_T)`. This caused builds on some 32-bit platforms to fail, namely when I tried to build a .deb for my Ubuntu PPA.
- When the Python API is installed from a .deb, there are a few specific command-line arguments to setup.py that need to be passed as explained [here](https://wiki.debian.org/Python/Packaging).
- Needed to increase the list depth for PDF documentation builds, which were failing.
- Make sure the docstring from `openmc.mgxs.Library.get_mgxs` is rendered correctly in the documentation.