### PR TITLE
Fix bug in Complement.bounding_box

### DIFF
--- a/openmc/region.py
+++ b/openmc/region.py
@@ -355,6 +355,8 @@ class Complement(Region):
             temp_region = Intersection(*[~n for n in self.node.nodes])
         elif isinstance(self.node, Intersection):
             temp_region = Union(*[~n for n in self.node.nodes])
+        elif isinstance(self.node, Complement):
+            temp_region = self.node.node
         else:
-            temp_region = ~n
+            temp_region = ~self.node
         return temp_region.bounding_box

--- a/src/state_point.F90
+++ b/src/state_point.F90
@@ -870,7 +870,6 @@ contains
     integer(HSIZE_T) :: dims(1)
     type(c_ptr) :: f_ptr
 #ifdef PHDF5
-    integer :: data_xfer_mode
     integer(HID_T) :: plist    ! property list
 #else
     integer :: i
@@ -989,7 +988,6 @@ contains
     integer(HSIZE_T) :: offset(1) ! offset of data
     type(c_ptr) :: f_ptr
 #ifdef PHDF5
-    integer :: data_xfer_mode
     integer(HID_T) :: plist    ! property list
 #endif
 


### PR DESCRIPTION
This is a fairly trivial bugfix for finding the bounding box of a region with a complement. It now explicitly handles double complements (seems silly, but I encountered this in automatic conversion of MCNP models). The more obvious bug was for a Complement of a Halfspace. Because of the `Halfspace.__invert__()` implementation, it's not common to actually have an explicit Complement of a Halfspace like the following
``` Python
s = openmc.Sphere()
b1 = (~(+s)).bounding_box                # This worked fine
b2 = openmc.Complement(+s).bounding_box  # but this was broken
```

I also removed two unused variables in state_point.F90 that I ran across.
