### PR TITLE
Fix for Material ID Property Setter

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -12,17 +12,13 @@ from openmc.checkvalue import check_type, check_value, check_greater_than
 from openmc.clean_xml import *
 
 
-# A list of all IDs for all Materials created
-MATERIAL_IDS = []
-
 # A static variable for auto-generated Material IDs
 AUTO_MATERIAL_ID = 10000
 
 
 def reset_auto_material_id():
-    global AUTO_MATERIAL_ID, MATERIAL_IDS
+    global AUTO_MATERIAL_ID
     AUTO_MATERIAL_ID = 10000
-    MATERIAL_IDS = []
 
 
 # Units for density supported by OpenMC
@@ -192,22 +188,15 @@ class Material(object):
 
     @id.setter
     def id(self, material_id):
-        global AUTO_MATERIAL_ID, MATERIAL_IDS
 
         if material_id is None:
+            global AUTO_MATERIAL_ID
             self._id = AUTO_MATERIAL_ID
-            MATERIAL_IDS.append(AUTO_MATERIAL_ID)
             AUTO_MATERIAL_ID += 1
         else:
             check_type('material ID', material_id, Integral)
-            if material_id in MATERIAL_IDS:
-                msg = 'Unable to set Material ID to "{0}" since a Material with ' \
-                      'this ID was already initialized'.format(material_id)
-                raise ValueError(msg)
             check_greater_than('material ID', material_id, 0, equality=True)
-
             self._id = material_id
-            MATERIAL_IDS.append(material_id)
 
     @name.setter
     def name(self, name):

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -194,10 +194,6 @@ class Material(object):
     def id(self, material_id):
         global AUTO_MATERIAL_ID, MATERIAL_IDS
 
-        # If the Material already has an ID, remove it from global list
-        if hasattr(self, '_id') and self._id is not None:
-            MATERIAL_IDS.remove(self._id)
-
         if material_id is None:
             self._id = AUTO_MATERIAL_ID
             MATERIAL_IDS.append(AUTO_MATERIAL_ID)

--- a/openmc/summary.py
+++ b/openmc/summary.py
@@ -567,7 +567,7 @@ class Summary(object):
         """
 
         for index, material in self.materials.items():
-            if material._id == material_id:
+            if material.id == material_id:
                 return material
 
         return None
@@ -588,7 +588,7 @@ class Summary(object):
         """
 
         for index, surface in self.surfaces.items():
-            if surface._id == surface_id:
+            if surface.id == surface_id:
                 return surface
 
         return None
@@ -609,7 +609,7 @@ class Summary(object):
         """
 
         for index, cell in self.cells.items():
-            if cell._id == cell_id:
+            if cell.id == cell_id:
                 return cell
 
         return None
@@ -630,7 +630,7 @@ class Summary(object):
         """
 
         for index, universe in self.universes.items():
-            if universe._id == universe_id:
+            if universe.id == universe_id:
                 return universe
 
         return None
@@ -651,7 +651,7 @@ class Summary(object):
         """
 
         for index, lattice in self.lattices.items():
-            if lattice._id == lattice_id:
+            if lattice.id == lattice_id:
                 return lattice
 
         return None


### PR DESCRIPTION
This tiny PR fixes a bug in the way the Python API's `Material` class sets IDs. In addition, the `Summary` API now properly uses the `id` property setters for `Material`, `Surface`, etc. classes rather than directly accessing the underlying private `_id` instance attributes.