### PR TITLE
Use same region spec. length for input and summary

### DIFF
--- a/src/constants.F90
+++ b/src/constants.F90
@@ -45,10 +45,11 @@ module constants
 
   ! Maximum number of words in a single line, length of line, and length of
   ! single word
-  integer, parameter :: MAX_WORDS    = 500
-  integer, parameter :: MAX_LINE_LEN = 250
-  integer, parameter :: MAX_WORD_LEN = 150
-  integer, parameter :: MAX_FILE_LEN = 255
+  integer, parameter :: MAX_WORDS       = 500
+  integer, parameter :: MAX_LINE_LEN    = 250
+  integer, parameter :: MAX_WORD_LEN    = 150
+  integer, parameter :: MAX_FILE_LEN    = 255
+  integer, parameter :: REGION_SPEC_LEN = 1000
 
   ! Maximum number of external source spatial resamples to encounter before an
   ! error is thrown.

--- a/src/input_xml.F90
+++ b/src/input_xml.F90
@@ -994,7 +994,7 @@ contains
     logical :: boundary_exists
     character(MAX_LINE_LEN) :: filename
     character(MAX_WORD_LEN) :: word
-    character(1000) :: region_spec
+    character(REGION_SPEC_LEN) :: region_spec
     type(Cell),     pointer :: c
     class(Surface), pointer :: s
     class(Lattice), pointer :: lat

--- a/src/summary.F90
+++ b/src/summary.F90
@@ -113,7 +113,7 @@ contains
     integer(HID_T) :: universes_group, univ_group
     integer(HID_T) :: lattices_group, lattice_group
     real(8), allocatable :: coeffs(:)
-    character(MAX_LINE_LEN) :: region_spec
+    character(REGION_SPEC_LEN) :: region_spec
     type(Cell),     pointer :: c
     class(Surface), pointer :: s
     type(Universe), pointer :: u


### PR DESCRIPTION
A small bugfix here.  summary.F90 used a shorter character length than input_xml.F90 which would cause errors when trying to use the summary file.