### PR TITLE
Changed Python API RectLattice universes ordering from [x][y] to [y][x] and [x][y][z] to [z][y][x]

### DIFF
--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -1119,7 +1119,7 @@ class RectLattice(Lattice):
             for z in range(self._dimension[2]):
                 for y in range(self._dimension[1]):
                     for x in range(self._dimension[0]):
-                        universe = self._universes[x][y][z]
+                        universe = self._universes[z][y][x]
 
                         # Append Universe ID to the Lattice XML subelement
                         universe_ids += '{0} '.format(universe._id)
@@ -1137,7 +1137,7 @@ class RectLattice(Lattice):
         else:
             for y in range(self._dimension[1]):
                 for x in range(self._dimension[0]):
-                    universe = self._universes[x][y]
+                    universe = self._universes[y][x]
 
                     # Append Universe ID to Lattice XML subelement
                     universe_ids += '{0} '.format(universe._id)


### PR DESCRIPTION
In the Python API `RectLattice.create_xml_subelement(...)` method, the `_universes` attribute is accessed by [x][y] for 2D and [x][y][z] for 3D:

    if len(self._dimension) == 3:
        for z in range(self._dimension[2]):
            for y in range(self._dimension[1]):
                for x in range(self._dimension[0]):
                    universe = self._universes[x][y][z]

                    ...

    else:
        for y in range(self._dimension[1]):
            for x in range(self._dimension[0]):
                universe = self._universes[x][y]

                ...

Currently, when the following lattice is created in the Python API:

    lattice = openmc.RectLattice(lattice_id=5)
    lattice.dimension = [2, 2]
    lattice.lower_left = [-1., -1.]
    lattice.pitch = [1., 1.]
    lattice.universes = [[univ1, univ1],
                         [univ2, univ1],

the `geometry.xml` input file will have the following lattice:

    <lattice id="5">
        <pitch>1.0 1.0</pitch>
        <dimension>2 2</dimension>
        <lower_left>-1.0 -1.0</lower_left>
        <universes>                                                                                                                                                 
            1 2
            1 1
        </universes>
    </lattice>

Thus the x and y indices are switched. This PR switches the indexing of the `_universes` attribute of the `RectLattice` class in the Python API to have the universes align in the Python and xml input files. Furthermore, OpenCG and OpenMOC use the ordering [y][x] and [z][y][x] in their python input files, which seems much more intuitive from a user input standpoint.