### PR TITLE
Hotfix for OpenCG Support for Z-Y-X Lattice Universes Ordering

### DIFF
--- a/openmc/opencg_compatible.py
+++ b/openmc/opencg_compatible.py
@@ -881,15 +881,26 @@ def get_opencg_lattice(openmc_lattice):
     universes = openmc_lattice.universes
     outer = openmc_lattice.outer
 
+    # Convert 2D dimension to 3D for OpenCG
+    if len(dimension) == 2:
+        new_dimension = np.ones(3, dtype=np.int)
+        new_dimension[:2] = dimension
+        dimension = new_dimension
+
+    # Convert 2D pitch to 3D for OpenCG
     if len(pitch) == 2:
-        new_pitch = np.ones(3, dtype=np.float64) * np.inf
+        new_pitch = np.ones(3, dtype=np.float64) * np.finfo(np.float64).max
         new_pitch[:2] = pitch
         pitch = new_pitch
 
+    # Convert 2D lower left to 3D for OpenCG
     if len(lower_left) == 2:
-        new_lower_left = np.ones(3, dtype=np.float64)
+        new_lower_left = np.ones(3, dtype=np.float64) * np.finfo(np.float64).min
         new_lower_left[:2] = lower_left
         lower_left = new_lower_left
+
+    # Convert 2D universes array to 3D for OpenCG
+    universes = np.atleast_3d(universes)
 
     # Initialize an empty array for the OpenCG nested Universes in this Lattice
     universe_array = np.ndarray(tuple(np.array(dimension)[::-1]),
@@ -905,7 +916,7 @@ def get_opencg_lattice(openmc_lattice):
     for z in range(dimension[2]):
         for y in range(dimension[1]):
             for x in range(dimension[0]):
-                universe_id = universes[z][y][x].id
+                universe_id = universes[x][y][z].id
                 universe_array[z][y][x] = unique_universes[universe_id]
 
     opencg_lattice = opencg.Lattice(lattice_id, name)

--- a/openmc/opencg_compatible.py
+++ b/openmc/opencg_compatible.py
@@ -905,11 +905,8 @@ def get_opencg_lattice(openmc_lattice):
     for z in range(dimension[2]):
         for y in range(dimension[1]):
             for x in range(dimension[0]):
-                universe_id = universes[z][dimension[1]-y-1][x].id
+                universe_id = universes[z][y][x].id
                 universe_array[z][y][x] = unique_universes[universe_id]
-
-    # Reverse y-dimension in array to match ordering in OpenCG
-    universe_array = universe_array[:, ::-1, :]
 
     opencg_lattice = opencg.Lattice(lattice_id, name)
     opencg_lattice.dimension = dimension

--- a/openmc/opencg_compatible.py
+++ b/openmc/opencg_compatible.py
@@ -905,7 +905,7 @@ def get_opencg_lattice(openmc_lattice):
     for z in range(dimension[2]):
         for y in range(dimension[1]):
             for x in range(dimension[0]):
-                universe_id = universes[x][dimension[1]-y-1][z].id
+                universe_id = universes[z][dimension[1]-y-1][x].id
                 universe_array[z][y][x] = unique_universes[universe_id]
 
     opencg_lattice = opencg.Lattice(lattice_id, name)
@@ -963,7 +963,7 @@ def get_openmc_lattice(opencg_lattice):
     outer = opencg_lattice.outside
 
     # Initialize an empty array for the OpenMC nested Universes in this Lattice
-    universe_array = np.ndarray(tuple(np.array(dimension)),
+    universe_array = np.ndarray(tuple(np.array(dimension)[::-1]),
                                 dtype=openmc.Universe)
 
     # Create OpenMC Universes for each unique nested Universe in this Lattice
@@ -977,7 +977,7 @@ def get_openmc_lattice(opencg_lattice):
         for y in range(dimension[1]):
             for x in range(dimension[0]):
                 universe_id = universes[z][y][x].id
-                universe_array[x][y][z] = unique_universes[universe_id]
+                universe_array[z][y][x] = unique_universes[universe_id]
 
     # Reverse y-dimension in array to match ordering in OpenCG
     universe_array = universe_array[:, ::-1, :]

--- a/openmc/opencg_compatible.py
+++ b/openmc/opencg_compatible.py
@@ -900,7 +900,8 @@ def get_opencg_lattice(openmc_lattice):
         lower_left = new_lower_left
 
     # Convert 2D universes array to 3D for OpenCG
-    universes = np.atleast_3d(universes)
+    if len(universes.shape) == 2:
+        universes.shape = (1,) + universes.shape
 
     # Initialize an empty array for the OpenCG nested Universes in this Lattice
     universe_array = np.ndarray(tuple(np.array(dimension)[::-1]),
@@ -916,7 +917,7 @@ def get_opencg_lattice(openmc_lattice):
     for z in range(dimension[2]):
         for y in range(dimension[1]):
             for x in range(dimension[0]):
-                universe_id = universes[x][y][z].id
+                universe_id = universes[z][y][x].id
                 universe_array[z][y][x] = unique_universes[universe_id]
 
     opencg_lattice = opencg.Lattice(lattice_id, name)

--- a/openmc/opencg_compatible.py
+++ b/openmc/opencg_compatible.py
@@ -725,11 +725,11 @@ def get_openmc_cell(opencg_cell):
     else:
         openmc_cell.fill = get_openmc_material(fill)
 
-    if opencg_cell.rotation:
+    if opencg_cell.rotation is not None:
         rotation = np.asarray(opencg_cell.rotation, dtype=np.float64)
         openmc_cell.rotation = rotation
 
-    if opencg_cell.translation:
+    if opencg_cell.translation is not None:
         translation = np.asarray(opencg_cell.translation, dtype=np.float64)
         openmc_cell.translation = translation
 
@@ -907,6 +907,9 @@ def get_opencg_lattice(openmc_lattice):
             for x in range(dimension[0]):
                 universe_id = universes[z][dimension[1]-y-1][x].id
                 universe_array[z][y][x] = unique_universes[universe_id]
+
+    # Reverse y-dimension in array to match ordering in OpenCG
+    universe_array = universe_array[:, ::-1, :]
 
     opencg_lattice = opencg.Lattice(lattice_id, name)
     opencg_lattice.dimension = dimension

--- a/openmc/summary.py
+++ b/openmc/summary.py
@@ -352,6 +352,13 @@ class Summary(object):
                             universes[z, y, x] = \
                                  self.get_universe_by_id(universe_ids[z, y, x])
 
+                # Use 2D NumPy array to store lattice universes for 2D lattices
+                if len(dimension) == 2:
+                    print('squeezing!')
+                    universes = np.squeeze(universes)
+                    universes = np.atleast_2d(universes)
+                    print(universes.shape)
+
                 # Set the universes for the lattice
                 lattice.universes = universes
 

--- a/openmc/summary.py
+++ b/openmc/summary.py
@@ -329,11 +329,8 @@ class Summary(object):
                      self._f['geometry/lattices'][key]['lower_left'][...]
                 pitch = self._f['geometry/lattices'][key]['pitch'][...]
                 outer = self._f['geometry/lattices'][key]['outer'].value
-
                 universe_ids = \
-                     self._f['geometry/lattices'][key]['universes'][...]
-                universe_ids = np.swapaxes(universe_ids, 0, 1)
-                universe_ids = np.swapaxes(universe_ids, 1, 2)
+                    self._f['geometry/lattices'][key]['universes'][...]
 
                 # Create the Lattice
                 lattice = openmc.RectLattice(lattice_id=lattice_id, name=name)
@@ -349,22 +346,17 @@ class Summary(object):
                 universes = \
                     np.ndarray(tuple(universe_ids.shape), dtype=openmc.Universe)
 
-                for x in range(universe_ids.shape[0]):
+                for z in range(universe_ids.shape[0]):
                     for y in range(universe_ids.shape[1]):
-                        for z in range(universe_ids.shape[2]):
-                            universes[x, y, z] = \
-                                 self.get_universe_by_id(universe_ids[x, y, z])
+                        for x in range(universe_ids.shape[2]):
+                            universes[z, y, x] = \
+                                 self.get_universe_by_id(universe_ids[z, y, x])
 
-                # Transpose, reverse y-dimension for appropriate ordering
-                shape = universes.shape[::-1]
-                universes = np.transpose(universes, (2, 1, 0))
-                universes.shape = shape
-                universes = universes[:, ::-1, :]
+                # Set the universes for the lattice
                 lattice.universes = universes
 
                 if offsets is not None:
-                    offsets = np.swapaxes(offsets, 0, 1)
-                    offsets = np.swapaxes(offsets, 1, 2)
+                    offsets = np.swapaxes(offsets, 0, 2)
                     lattice.offsets = offsets
 
                 # Add the Lattice to the global dictionary of all Lattices

--- a/openmc/summary.py
+++ b/openmc/summary.py
@@ -354,10 +354,8 @@ class Summary(object):
 
                 # Use 2D NumPy array to store lattice universes for 2D lattices
                 if len(dimension) == 2:
-                    print('squeezing!')
                     universes = np.squeeze(universes)
                     universes = np.atleast_2d(universes)
-                    print(universes.shape)
 
                 # Set the universes for the lattice
                 lattice.universes = universes

--- a/openmc/summary.py
+++ b/openmc/summary.py
@@ -356,8 +356,8 @@ class Summary(object):
                                  self.get_universe_by_id(universe_ids[x, y, z])
 
                 # Transpose, reverse y-dimension for appropriate ordering
-                shape = universes.shape
-                universes = np.transpose(universes, (1, 0, 2))
+                shape = universes.shape[::-1]
+                universes = np.transpose(universes, (2, 1, 0))
                 universes.shape = shape
                 universes = universes[:, ::-1, :]
                 lattice.universes = universes

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -807,7 +807,7 @@ class Lattice(object):
     def universes(self, universes):
         cv.check_iterable_type('lattice universes', universes, Universe,
                                min_depth=2, max_depth=3)
-        self._universes = universes
+        self._universes = np.asarray(universes)
 
     def get_unique_universes(self):
         """Determine all unique universes in the lattice

--- a/src/summary.F90
+++ b/src/summary.F90
@@ -362,9 +362,10 @@ contains
         allocate(lattice_universes(lat%n_cells(1), lat%n_cells(2), &
              &lat%n_cells(3)))
         do j = 1, lat%n_cells(1)
-          do k = 1, lat%n_cells(2)
+          do k = 0, lat%n_cells(2) - 1
             do m = 1, lat%n_cells(3)
-              lattice_universes(j,k,m) = universes(lat%universes(j,k,m))%id
+              lattice_universes(j, k+1, m) = &
+                   universes(lat%universes(j, lat%n_cells(2) - k, m))%id
             end do
           end do
         end do

--- a/src/summary.F90
+++ b/src/summary.F90
@@ -355,8 +355,13 @@ contains
         call write_dataset(lattice_group, "type", "rectangular")
 
         ! Write lattice dimensions, lower left corner, and pitch
-        call write_dataset(lattice_group, "dimension", lat%n_cells)
-        call write_dataset(lattice_group, "lower_left", lat%lower_left)
+        if (lat % is_3d) then
+          call write_dataset(lattice_group, "dimension", lat % n_cells)
+          call write_dataset(lattice_group, "lower_left", lat % lower_left)
+        else
+          call write_dataset(lattice_group, "dimension", lat % n_cells(1:2))
+          call write_dataset(lattice_group, "lower_left", lat % lower_left)
+        end if
 
         ! Write lattice universes.
         allocate(lattice_universes(lat%n_cells(1), lat%n_cells(2), &


### PR DESCRIPTION
This fixes a few issues in the `openmc.opencg_compatible` and `openmc.Summary` modules of the Python API related to the z-y-z lattice universe ordering introduced in PR #537.