### PR TITLE
Fix type of return argument for h5pget_driver_f

### DIFF
--- a/src/hdf5_interface.F90
+++ b/src/hdf5_interface.F90
@@ -1898,7 +1898,7 @@ contains
     logical :: mpio
 
     integer :: hdf5_err
-    integer :: driver
+    integer(HID_T) :: driver
     integer(HID_T) :: file_id
     integer(HID_T) :: fapl_id
 


### PR DESCRIPTION
This is a one-line fix related to an HDF5 routine. The [documentation for h5pget_driver_f](https://www.hdfgroup.org/HDF5/doc/RM/RM_H5P.html#Property-GetDriver) says that the argument should be `INTEGER, INTENT(OUT)` but inspection of the source code clearly shows it to be `INTEGER(HID_T), INTENT(OUT)`. I noticed this when testing the new version of HDF5, 1.10.0-alpha0, which takes advantage of F2003-style C bindings for its Fortran interface resulting in better type checks. Whereas with versions 1.8.16 and before passing a plain integer resulted in no problems, it now causes a compile-time error with 1.10.0.