### PR TITLE
Fix link to MCNP manual

### DIFF
--- a/docs/source/methods/physics.rst
+++ b/docs/source/methods/physics.rst
@@ -1636,4 +1636,4 @@ another.
 
 .. _lectures: https://laws.lanl.gov/vhosts/mcnp.lanl.gov/pdf_files/la-ur-05-4983.pdf
 
-.. _MCNP Manual: https://laws.lanl.gov/vhosts/mcnp.lanl.gov/pdf_files/MCNP5_Manual_Volume_I_LA-UR-03-1987.pdf
+.. _MCNP Manual: https://laws.lanl.gov/vhosts/mcnp.lanl.gov/pdf_files/la-ur-03-1987.pdf 


### PR DESCRIPTION
This PR fixes a broken link to the MCNP manual in section 5.7.1.3 (Tabular Angular Distribution) of the docs.