### PR TITLE
Link fixes

### DIFF
--- a/docs/source/methods/physics.rst
+++ b/docs/source/methods/physics.rst
@@ -1626,7 +1626,7 @@ another.
 
 .. _ENDF-6 Format: http://www-nds.iaea.org/ndspub/documents/endf/endf102/endf102.pdf
 
-.. _Monte Carlo Sampler: https://laws.lanl.gov/vhosts/mcnp.lanl.gov/pdf_files/la-9721_3rdmcsampler.pdf
+.. _Monte Carlo Sampler: https://laws.lanl.gov/vhosts/mcnp.lanl.gov/pdf_files/la-9721.pdf
 
 .. _LA-UR-14-27694: http://permalink.lanl.gov/object/tr?what=info:lanl-repo/lareport/LA-UR-14-27694
 

--- a/docs/source/methods/physics.rst
+++ b/docs/source/methods/physics.rst
@@ -1636,4 +1636,4 @@ another.
 
 .. _lectures: https://laws.lanl.gov/vhosts/mcnp.lanl.gov/pdf_files/la-ur-05-4983.pdf
 
-.. _MCNP Manual: https://laws.lanl.gov/vhosts/mcnp.lanl.gov/pdf_files/la-ur-03-1987.pdf 
+.. _MCNP Manual: https://laws.lanl.gov/vhosts/mcnp.lanl.gov/pdf_files/la-ur-03-1987.pdf

--- a/docs/source/methods/random_numbers.rst
+++ b/docs/source/methods/random_numbers.rst
@@ -70,5 +70,5 @@ the idea is to determine the new multiplicative and additive constants in
    Different Sizes and Good Lattice Structures," *Math. Comput.*, **68**, 249
    (1999).
 
-.. _Brown: https://laws.lanl.gov/vhosts/mcnp.lanl.gov/pdf_files/anl_rn_arb-strides_1994.pdf
+.. _Brown: https://laws.lanl.gov/vhosts/mcnp.lanl.gov/pdf_files/anl-rn-arb-stride.pdf
 .. _linear congruential generator: http://en.wikipedia.org/wiki/Linear_congruential_generator

--- a/docs/source/methods/tallies.rst
+++ b/docs/source/methods/tallies.rst
@@ -507,6 +507,6 @@ improve the estimate of the percentile.
 
 .. _Cauchy distribution: http://en.wikipedia.org/wiki/Cauchy_distribution
 
-.. _unpublished rational approximation: http://home.online.no/~pjacklam/notes/invnorm/
+.. _unpublished rational approximation: https://web.archive.org/web/20150926021742/http://home.online.no/~pjacklam/notes/invnorm/
 
 .. _MC21: http://www.osti.gov/bridge/servlets/purl/903083-HT5p1o/903083.pdf


### PR DESCRIPTION
This PR fixes a few more links from the LANL laws page.

In addition to these, I'm having difficulty loading the "unpublished rational approximation" link at the bottom of the section on Tallies. The error is that the connection timed out, though, so there's a possibility that the issue is on my end.