### PR TITLE
Add command flag to make a PyAPI TestHarness build inputs and halt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,9 @@ openmc.egg-info/
 # Inputs generated from Python API
 examples/python/**/*.xml
 
-# emacs backups
+# emacs and vim backups
 *~
+*.swp
 
 # OpenMC statepoints
 *.binary

--- a/tests/test_filter_distribcell/test_filter_distribcell.py
+++ b/tests/test_filter_distribcell/test_filter_distribcell.py
@@ -10,10 +10,7 @@ from testing_harness import *
 
 class DistribcellTestHarness(TestHarness):
     def __init__(self):
-        self._sp_name = None
-        self._tallies = True
-        self._opts = None
-        self._args = None
+        super(DistribcellTestHarness, self).__init__(None, True)
 
     def execute_test(self):
         """Run OpenMC with the appropriate arguments and check the outputs."""

--- a/tests/test_statepoint_batch/test_statepoint_batch.py
+++ b/tests/test_statepoint_batch/test_statepoint_batch.py
@@ -8,10 +8,7 @@ from testing_harness import TestHarness
 
 class StatepointTestHarness(TestHarness):
     def __init__(self):
-        self._sp_name = None
-        self._tallies = False
-        self._opts = None
-        self._args = None
+        super(StatepointTestHarness, self).__init__(None, False)
 
     def _test_output_created(self):
         """Make sure statepoint files have been created."""

--- a/tests/test_statepoint_interval/test_statepoint_interval.py
+++ b/tests/test_statepoint_interval/test_statepoint_interval.py
@@ -8,10 +8,7 @@ from testing_harness import TestHarness
 
 class StatepointTestHarness(TestHarness):
     def __init__(self):
-        self._sp_name = None
-        self._tallies = False
-        self._opts = None
-        self._args = None
+        super(StatepointTestHarness, self).__init__(None, False)
 
     def _test_output_created(self):
         """Make sure statepoint files have been created."""

--- a/tests/testing_harness.py
+++ b/tests/testing_harness.py
@@ -23,12 +23,18 @@ class TestHarness(object):
     def __init__(self, statepoint_name, tallies_present=False):
         self._sp_name = statepoint_name
         self._tallies = tallies_present
+        self.parser = OptionParser()
+        self.parser.add_option('--exe', dest='exe', default='openmc')
+        self.parser.add_option('--mpi_exec', dest='mpi_exec', default=None)
+        self.parser.add_option('--mpi_np', dest='mpi_np', type=int, default=3)
+        self.parser.add_option('--update', dest='update', action='store_true',
+                               default=False)
         self._opts = None
         self._args = None
 
     def main(self):
         """Accept commandline arguments and either run or update tests."""
-        self._parse_args()
+        (self._opts, self._args) = self.parser.parse_args()
         if self._opts.update:
             self.update_results()
         else:
@@ -55,15 +61,6 @@ class TestHarness(object):
             self._overwrite_results()
         finally:
             self._cleanup()
-
-    def _parse_args(self):
-        parser = OptionParser()
-        parser.add_option('--exe', dest='exe', default='openmc')
-        parser.add_option('--mpi_exec', dest='mpi_exec', default=None)
-        parser.add_option('--mpi_np', dest='mpi_np', type=int, default=3)
-        parser.add_option('--update', dest='update', action='store_true',
-                          default=False)
-        (self._opts, self._args) = parser.parse_args()
 
     def _run_openmc(self):
         executor = Executor()
@@ -158,9 +155,8 @@ class HashedTestHarness(TestHarness):
 class PlotTestHarness(TestHarness):
     """Specialized TestHarness for running OpenMC plotting tests."""
     def __init__(self, plot_names):
+        super(PlotTestHarness, self).__init__(None, False)
         self._plot_names = plot_names
-        self._opts = None
-        self._args = None
 
     def _run_openmc(self):
         executor = Executor()
@@ -275,7 +271,19 @@ class ParticleRestartTestHarness(TestHarness):
 class PyAPITestHarness(TestHarness):
     def __init__(self, statepoint_name, tallies_present=False):
         super(PyAPITestHarness, self).__init__(statepoint_name, tallies_present)
+        self.parser.add_option('--build-inputs', dest='build_only',
+                               action='store_true', default=False)
         self._input_set = InputSet()
+
+    def main(self):
+        """Accept commandline arguments and either run or update tests."""
+        (self._opts, self._args) = self.parser.parse_args()
+        if self._opts.build_only:
+            self._build_inputs()
+        elif self._opts.update:
+            self.update_results()
+        else:
+            self.execute_test()
 
     def execute_test(self):
         """Build input XMLs, run OpenMC, and verify correct results."""

--- a/tests/testing_harness.py
+++ b/tests/testing_harness.py
@@ -152,7 +152,7 @@ class HashedTestHarness(TestHarness):
     """Specialized TestHarness that hashes the results."""
     def _get_results(self):
         """Digest info in the statepoint and return as a string."""
-        return TestHarness._get_results(self, True)
+        return super(HashedTestHarness, self)._get_results(True)
 
 
 class PlotTestHarness(TestHarness):
@@ -174,7 +174,7 @@ class PlotTestHarness(TestHarness):
                  'Plot output file does not exist.'
 
     def _cleanup(self):
-        TestHarness._cleanup(self)
+        super(PlotTestHarness, self)._cleanup()
         output = glob.glob(os.path.join(os.getcwd(), '*.ppm'))
         for f in output:
             if os.path.exists(f):
@@ -208,7 +208,7 @@ class CMFDTestHarness(TestHarness):
         sp = StatePoint(statepoint)
 
         # Write out the eigenvalue and tallies.
-        outstr = TestHarness._get_results(self)
+        outstr = super(CMFDTestHarness, self)._get_results()
 
         # Write out CMFD data.
         outstr += 'cmfd indices\n'
@@ -274,7 +274,7 @@ class ParticleRestartTestHarness(TestHarness):
 
 class PyAPITestHarness(TestHarness):
     def __init__(self, statepoint_name, tallies_present=False):
-        TestHarness.__init__(self, statepoint_name, tallies_present)
+        super(PyAPITestHarness, self).__init__(statepoint_name, tallies_present)
         self._input_set = InputSet()
 
     def execute_test(self):
@@ -315,7 +315,8 @@ class PyAPITestHarness(TestHarness):
 
     def _get_inputs(self):
         """Return a hash digest of the input XML files."""
-        xmls = ('geometry.xml', 'tallies.xml', 'materials.xml', 'settings.xml')
+        xmls = ('geometry.xml', 'tallies.xml', 'materials.xml', 'settings.xml',
+                'plots.xml')
         xmls = [os.path.join(os.getcwd(), fname) for fname in xmls]
         outstr = '\n'.join([open(fname).read() for fname in xmls
                             if os.path.exists(fname)])
@@ -347,7 +348,7 @@ class PyAPITestHarness(TestHarness):
 
     def _cleanup(self):
         """Delete XMLs, statepoints, tally, and test files."""
-        TestHarness._cleanup(self)
+        super(PyAPITestHarness, self)._cleanup()
         output = [os.path.join(os.getcwd(), 'materials.xml')]
         output.append(os.path.join(os.getcwd(), 'geometry.xml'))
         output.append(os.path.join(os.getcwd(), 'settings.xml'))


### PR DESCRIPTION
This PR makes it easy to see the XML files created by a `PyAPITestHarness`.  It adds the `--build-inputs` flag which will cause the test harness to build the XML files and then halt without running the test or cleaning up.

It also adds vim `*.swp` files to the `.gitignore`