### PR TITLE
Make max lost particles relative to total number of particles

### DIFF
--- a/src/constants.F90
+++ b/src/constants.F90
@@ -139,6 +139,9 @@ module constants
   ! Maximum number of lost particles
   integer, parameter :: MAX_LOST_PARTICLES = 10
 
+  ! Maximum number of lost particles, relative to the total number of particles
+  real(8), parameter :: REL_MAX_LOST_PARTICLES = 1e-5_8
+
   ! ============================================================================
   ! CROSS SECTION RELATED CONSTANTS
 

--- a/src/constants.F90
+++ b/src/constants.F90
@@ -140,7 +140,7 @@ module constants
   integer, parameter :: MAX_LOST_PARTICLES = 10
 
   ! Maximum number of lost particles, relative to the total number of particles
-  real(8), parameter :: REL_MAX_LOST_PARTICLES = 1e-5_8
+  real(8), parameter :: REL_MAX_LOST_PARTICLES = 1e-6_8
 
   ! ============================================================================
   ! CROSS SECTION RELATED CONSTANTS

--- a/src/geometry.F90
+++ b/src/geometry.F90
@@ -947,6 +947,8 @@ contains
     type(Particle), intent(inout) :: p
     character(*)                  :: message
 
+    integer(8) :: tot_n_particles
+
     ! Print warning and write lost particle file
     call warning(message)
     call write_particle_restart(p)
@@ -956,9 +958,13 @@ contains
 !$omp atomic
     n_lost_particles = n_lost_particles + 1
 
+    ! Count the total number of simulated particles
+    tot_n_particles = n_batches * gen_per_batch * n_particles
+
     ! Abort the simulation if the maximum number of lost particles has been
     ! reached
-    if (n_lost_particles == MAX_LOST_PARTICLES) then
+    if (n_lost_particles >= MAX_LOST_PARTICLES .and. &
+         n_lost_particles >= REL_MAX_LOST_PARTICLES * tot_n_particles) then
       call fatal_error("Maximum number of lost particles has been reached.")
     end if
 

--- a/src/geometry.F90
+++ b/src/geometry.F90
@@ -958,8 +958,8 @@ contains
 !$omp atomic
     n_lost_particles = n_lost_particles + 1
 
-    ! Count the total number of simulated particles
-    tot_n_particles = n_batches * gen_per_batch * n_particles
+    ! Count the total number of simulated particles (on this processor)
+    tot_n_particles = n_batches * gen_per_batch * work
 
     ! Abort the simulation if the maximum number of lost particles has been
     ! reached


### PR DESCRIPTION
This PR makes the maximum number of lost particles dependent on the size of the simulation.  So now we no longer have to worry about that painful fatal error after 50 million simulated neutrons.

The nuclear world gets by well enough with a core damage frequency of 10^-5 so I picked that as our lost particle tolerance.  I also kept the old absolute limit in place so you're still allowed 10 lost particles when you're simulating less than a million total.