### PR TITLE
Fix bug with void fills in the Python API

### DIFF
--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -402,22 +402,23 @@ class Cell(object):
         if len(self._name) > 0:
             element.set("name", str(self._name))
 
-        if isinstance(self._fill, openmc.Material):
-            element.set("material", str(self._fill._id))
+        if isinstance(self.fill, basestring):
+            assert self.fill.strip().lower() == 'void'
+            element.set("material", "void")
 
-        elif isinstance(self._fill, Iterable):
+        elif isinstance(self.fill, openmc.Material):
+            element.set("material", str(self.fill.id))
+
+        elif isinstance(self.fill, Iterable):
             element.set("material", ' '.join([m if m == 'void' else str(m.id)
                                               for m in self.fill]))
 
-        elif isinstance(self._fill, (Universe, Lattice)):
-            element.set("fill", str(self._fill._id))
+        elif isinstance(self.fill, (Universe, Lattice)):
+            element.set("fill", str(self.fill.id))
             self._fill.create_xml_subelement(xml_element)
 
-        elif self._fill.strip().lower() == "void":
-            element.set("material", "void")
-
         else:
-            element.set("fill", str(self._fill))
+            element.set("fill", str(self.fill))
             self._fill.create_xml_subelement(xml_element)
 
         if self.region is not None:

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -403,7 +403,6 @@ class Cell(object):
             element.set("name", str(self.name))
 
         if isinstance(self.fill, basestring):
-            assert self.fill.strip().lower() == 'void'
             element.set("material", "void")
 
         elif isinstance(self.fill, openmc.Material):

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -397,10 +397,10 @@ class Cell(object):
 
     def create_xml_subelement(self, xml_element):
         element = ET.Element("cell")
-        element.set("id", str(self._id))
+        element.set("id", str(self.id))
 
         if len(self._name) > 0:
-            element.set("name", str(self._name))
+            element.set("name", str(self.name))
 
         if isinstance(self.fill, basestring):
             assert self.fill.strip().lower() == 'void'
@@ -415,11 +415,11 @@ class Cell(object):
 
         elif isinstance(self.fill, (Universe, Lattice)):
             element.set("fill", str(self.fill.id))
-            self._fill.create_xml_subelement(xml_element)
+            self.fill.create_xml_subelement(xml_element)
 
         else:
             element.set("fill", str(self.fill))
-            self._fill.create_xml_subelement(xml_element)
+            self.fill.create_xml_subelement(xml_element)
 
         if self.region is not None:
             # Set the region attribute with the region specification
@@ -446,11 +446,11 @@ class Cell(object):
             # Call the recursive function from the top node
             create_surface_elements(self.region, xml_element)
 
-        if self._translation is not None:
-            element.set("translation", ' '.join(map(str, self._translation)))
+        if self.translation is not None:
+            element.set("translation", ' '.join(map(str, self.translation)))
 
-        if self._rotation is not None:
-            element.set("rotation", ' '.join(map(str, self._rotation)))
+        if self.rotation is not None:
+            element.set("rotation", ' '.join(map(str, self.rotation)))
 
         return element
 


### PR DESCRIPTION
I ran across an error when exporting PyAPI geometries that was caused by #548.  Strings (like `'void'`) are iterables so they get caught by the `if` statement that was intended for lists of materials.  The error is fixed in this PR by switching the order of the string and iterable `if` blocks.