### PR TITLE
Remove NumPy Elementwise Comparison Warnings from openmc.mgxs

### DIFF
--- a/openmc/mgxs/mgxs.py
+++ b/openmc/mgxs/mgxs.py
@@ -673,14 +673,14 @@ class MGXS(object):
         filter_bins = []
 
         # Construct a collection of the domain filter bins
-        if subdomains != 'all':
+        if not isinstance(subdomains, basestring):
             cv.check_iterable_type('subdomains', subdomains, Integral)
             for subdomain in subdomains:
                 filters.append(self.domain_type)
                 filter_bins.append((subdomain,))
 
         # Construct list of energy group bounds tuples for all requested groups
-        if groups != 'all':
+        if not isinstance(groups, basestring):
             cv.check_iterable_type('groups', groups, Integral)
             for group in groups:
                 filters.append('energy')
@@ -838,7 +838,7 @@ class MGXS(object):
         """
 
         # Construct a collection of the subdomain filter bins to average across
-        if subdomains != 'all':
+        if not isinstance(subdomains, basestring):
             cv.check_iterable_type('subdomains', subdomains, Integral)
         elif self.domain_type == 'distribcell':
             subdomains = np.arange(self.num_subdomains)
@@ -881,7 +881,7 @@ class MGXS(object):
         """
 
         # Construct a collection of the subdomains to report
-        if subdomains != 'all':
+        if not isinstance(subdomains, basestring):
             cv.check_iterable_type('subdomains', subdomains, Integral)
         elif self.domain_type == 'distribcell':
             subdomains = np.arange(self.num_subdomains, dtype=np.int)
@@ -1010,7 +1010,7 @@ class MGXS(object):
             xs_results = h5py.File(filename, 'w')
 
         # Construct a collection of the subdomains to report
-        if subdomains != 'all':
+        if not isinstance(subdomains, basestring):
             cv.check_iterable_type('subdomains', subdomains, Integral)
         elif self.domain_type == 'distribcell':
             subdomains = np.arange(self.num_subdomains, dtype=np.int)
@@ -1192,7 +1192,7 @@ class MGXS(object):
 
         """
 
-        if groups != 'all':
+        if not isinstance(groups, basestring):
             cv.check_iterable_type('groups', groups, Integral)
         if nuclides != 'all' and nuclides != 'sum':
             cv.check_iterable_type('nuclides', nuclides, basestring)
@@ -1252,7 +1252,7 @@ class MGXS(object):
             columns = ['group in']
 
         # Select out those groups the user requested
-        if groups != 'all':
+        if not isinstance(groups, basestring):
             if 'group in' in df:
                 df = df[df['group in'].isin(groups)]
             if 'group out' in df:
@@ -1789,21 +1789,21 @@ class ScatterMatrixXS(MGXS):
         filter_bins = []
 
         # Construct a collection of the domain filter bins
-        if subdomains != 'all':
+        if not isinstance(subdomains, basestring):
             cv.check_iterable_type('subdomains', subdomains, Integral)
             for subdomain in subdomains:
                 filters.append(self.domain_type)
                 filter_bins.append((subdomain,))
 
         # Construct list of energy group bounds tuples for all requested groups
-        if in_groups != 'all':
+        if not isinstance(in_groups, basestring):
             cv.check_iterable_type('groups', in_groups, Integral)
             for group in in_groups:
                 filters.append('energy')
                 filter_bins.append((self.energy_groups.get_group_bounds(group),))
 
         # Construct list of energy group bounds tuples for all requested groups
-        if out_groups != 'all':
+        if not isinstance(out_groups, basestring):
             cv.check_iterable_type('groups', out_groups, Integral)
             for group in out_groups:
                 filters.append('energyout')
@@ -1887,7 +1887,7 @@ class ScatterMatrixXS(MGXS):
         """
 
         # Construct a collection of the subdomains to report
-        if subdomains != 'all':
+        if not isinstance(subdomains, basestring):
             cv.check_iterable_type('subdomains', subdomains, Integral)
         elif self.domain_type == 'distribcell':
             subdomains = np.arange(self.num_subdomains, dtype=np.int)
@@ -1925,12 +1925,6 @@ class ScatterMatrixXS(MGXS):
         for group in range(1, self.num_groups+1):
             bounds = self.energy_groups.get_group_bounds(group)
             string += template.format('', group, bounds[0], bounds[1])
-
-        if subdomains == 'all':
-            if self.domain_type == 'distribcell':
-                subdomains = np.arange(self.num_subdomains, dtype=np.int)
-            else:
-                subdomains = [self.domain.id]
 
         # Loop over all subdomains
         for subdomain in subdomains:
@@ -2135,14 +2129,14 @@ class Chi(MGXS):
         filter_bins = []
 
         # Construct a collection of the domain filter bins
-        if subdomains != 'all':
+        if not isinstance(subdomains, basestring):
             cv.check_iterable_type('subdomains', subdomains, Integral)
             for subdomain in subdomains:
                 filters.append(self.domain_type)
                 filter_bins.append((subdomain,))
 
         # Construct list of energy group bounds tuples for all requested groups
-        if groups != 'all':
+        if not isinstance(groups, basestring):
             cv.check_iterable_type('groups', groups, Integral)
             for group in groups:
                 filters.append('energyout')


### PR DESCRIPTION
Some of the class methods in `openmc.mgxs` produce the following NumPy warning

```python
/usr/local/lib/python2.7/dist-packages/openmc-0.7.1-py2.7.egg/openmc/mgxs/mgxs.py:841: FutureWarning: elementwise comparison failed; returning scalar instead, but in the future will perform elementwise comparison
```

This PR fixes this issue by replacing equality comparisons for the `subdomains` and `group` parameters to these class methods with `isinstance(...)` in the conditionals.