### PR TITLE
Prevent segfault when user specifies '18' on tally scores

### DIFF
--- a/src/input_xml.F90
+++ b/src/input_xml.F90
@@ -3247,7 +3247,7 @@ contains
               call fatal_error("Cannot tally absorption rate with an outgoing &
                    &energy filter.")
             end if
-          case ('fission')
+          case ('fission', '18')
             t % score_bins(j) = SCORE_FISSION
             if (t % find_filter(FILTER_ENERGYOUT) > 0) then
               call fatal_error("Cannot tally fission rate with an outgoing &


### PR DESCRIPTION
This pull request fixes a bug that results in a segfault if a user specifies 18 as a tally score. This closes #574.