### PR TITLE
Fixed Issue with 3D Lattice Distribcell Offsets

### DIFF
--- a/openmc/arithmetic.py
+++ b/openmc/arithmetic.py
@@ -823,7 +823,8 @@ class AggregateFilter(object):
 
         """
 
-        if filter_bin not in self.bins:
+        if filter_bin not in self.bins and \
+           filter_bin != self._aggregate_filter.bins:
             msg = 'Unable to get the bin index for AggregateFilter since ' \
                   '"{0}" is not one of the bins'.format(filter_bin)
             raise ValueError(msg)

--- a/openmc/mgxs/library.py
+++ b/openmc/mgxs/library.py
@@ -568,8 +568,9 @@ class Library(object):
         for domain in self.domains:
             for mgxs_type in self.mgxs_types:
                 mgxs = subdomain_avg_library.get_mgxs(domain, mgxs_type)
-                avg_mgxs = mgxs.get_subdomain_avg_xs()
-                subdomain_avg_library.all_mgxs[domain.id][mgxs_type] = avg_mgxs
+                if mgxs.domain_type == 'distribcell':
+                    avg_mgxs = mgxs.get_subdomain_avg_xs()
+                    subdomain_avg_library.all_mgxs[domain.id][mgxs_type] = avg_mgxs
 
         return subdomain_avg_library
 

--- a/openmc/summary.py
+++ b/openmc/summary.py
@@ -368,7 +368,6 @@ class Summary(object):
                 lattice.universes = universes
 
                 if offsets is not None:
-                    offsets = np.swapaxes(offsets, 0, 2)
                     lattice.offsets = offsets
 
                 # Add the Lattice to the global dictionary of all Lattices

--- a/openmc/summary.py
+++ b/openmc/summary.py
@@ -367,6 +367,7 @@ class Summary(object):
                 # Set the universes for the lattice
                 lattice.universes = universes
 
+                # Set the distribcell offsets for the lattice
                 if offsets is not None:
                     lattice.offsets = offsets
 

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -1101,8 +1101,8 @@ class RectLattice(Lattice):
 
         # For 3D Lattices
         else:
-            offset = self._offsets[i[1]-1, i[2]-1, i[3]-1, distribcell_index-1]
-            offset += self._universes[i[1]-1][i[2]-1][i[3]-1].get_cell_instance(
+            offset = self._offsets[i[3]-1, i[2]-1, i[1]-1, distribcell_index-1]
+            offset += self._universes[i[3]-1][i[2]-1][i[1]-1].get_cell_instance(
                                                         path, distribcell_index)
 
         return offset

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -1095,7 +1095,7 @@ class RectLattice(Lattice):
 
         # For 2D Lattices
         if len(self._dimension) == 2:
-            offset = self._offsets[i[1]-1, i[2]-1, 0, distribcell_index-1]
+            offset = self._offsets[i[3]-1, i[2]-1, i[1]-1, distribcell_index-1]
             offset += self._universes[i[1]-1][i[2]-1].get_cell_instance(path,
                                                               distribcell_index)
 


### PR DESCRIPTION
This PR fixes a bug in the Python API for looking up distribcell offsets on 3D lattices (such as the fuel assemblies in the BEAVRS model in mit-crpg/PWR_benchmarks). Since PRs #537 and #539, lattice universes are indexed by z-y-x. This PR applies this same order to the lattice distribcell offsets array.

@smharper do you want to review this given your recent re-workings of the distribcell algorithm?