### PR TITLE
Fix CSS override for RTD documentation builds

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -154,7 +154,8 @@ html_title = "OpenMC Documentation"
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
-html_context = {'css_files': ['_static/theme_overrides.css']}
+def setup(app):
+    app.add_stylesheet('theme_overrides.css')
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.


### PR DESCRIPTION
@smharper So the RTD build problem had to do with some CSS hackery I put in so that wide tables rendered correctly in the tally scores documentation. This PR should fix it so that the style displays correctly.