### PR TITLE
Implement azimuthal and polar filters in Pandas output

### DIFF
--- a/openmc/filter.py
+++ b/openmc/filter.py
@@ -735,6 +735,19 @@ class Filter(object):
             filter_bins = filter_bins
             df = pd.concat([df, pd.DataFrame({self.type + ' [MeV]' : filter_bins})])
 
+        elif self.type in ('azimuthal', 'polar'):
+            # Extract the lower and upper angle bounds, then repeat and tile
+            # them as necessary to account for other filters.
+            lo_bins = np.repeat(self.bins[:-1], self.stride)
+            hi_bins = np.repeat(self.bins[1:], self.stride)
+            tile_factor = data_size / len(lo_bins)
+            lo_bins = np.tile(lo_bins, tile_factor)
+            hi_bins = np.tile(hi_bins, tile_factor)
+
+            # Add the new angle columns to the DataFrame.
+            df.loc[:, self.type + ' low'] = lo_bins
+            df.loc[:, self.type + ' high'] = hi_bins
+
         # universe, material, surface, cell, and cellborn filters
         else:
             filter_bins = np.repeat(self.bins, self.stride)


### PR DESCRIPTION
We never stuck an implementation for azimuthal and polar filters in Pandas.  This PR adds such an implementation.  It will add two columns for each of those filters (a low and a high value column, similar to #582).  Here's an example output:

```
    azimuthal low  azimuthal high  polar low  polar high      mean  std. dev.
0       -3.141593       -1.047198   0.000000    1.047198  0.768852   0.011225
1       -3.141593       -1.047198   1.047198    2.094395  1.532390   0.015910
2       -3.141593       -1.047198   2.094395    3.141593  0.759414   0.006187
3       -1.047198        1.047198   0.000000    1.047198  0.779638   0.012688
4       -1.047198        1.047198   1.047198    2.094395  1.515546   0.016713
```