### PR TITLE
Prevent floating point errors from low-E inelastic scatters

### DIFF
--- a/src/constants.F90
+++ b/src/constants.F90
@@ -31,10 +31,13 @@ module constants
   ! Used for surface current tallies
   real(8), parameter :: TINY_BIT = 1e-8_8
 
-  ! User for precision in geometry
+  ! Used for precision in geometry
   real(8), parameter :: FP_PRECISION = 1e-14_8
   real(8), parameter :: FP_REL_PRECISION = 1e-5_8
   real(8), parameter :: FP_COINCIDENT = 1e-12_8
+
+  ! Minimum allowed neutron energy
+  real(8), parameter :: VERY_LOW_ENERGY = 1.0e-100_8
 
   ! Maximum number of collisions/crossings
   integer, parameter :: MAX_EVENTS = 10000

--- a/src/physics.F90
+++ b/src/physics.F90
@@ -50,8 +50,8 @@ contains
            &// ". Energy = " // trim(to_str(p % E * 1e6_8)) // " eV.")
     end if
 
-    ! check for very low energy
-    if (p % E < 1.0e-100_8) then
+    ! Check for very low energy
+    if (p % alive .and. p % E < 1.0e-100_8) then
       p % alive = .false.
       if (master) call warning("Killing neutron with extremely low energy")
     end if
@@ -1332,6 +1332,17 @@ contains
 
     ! sample outgoing energy and scattering cosine
     call rxn%secondary%sample(E_in, E, mu)
+
+    ! If the sampled energy is very low, kill the particle and don't finish
+    ! anything else in this subroutine.  Those small E values can cause some
+    ! ugly floating point errors in rotate_angle, and secondaries created with
+    ! low energy will cause errors in calculate_xs.
+    if (E < 1.0e-100_8) then
+      p % E = ZERO
+      p % alive = .false.
+      if (master) call warning("Killing neutron with extremely low energy")
+      return
+    end if
 
     ! if scattering system is in center-of-mass, transfer cosine of scattering
     ! angle and outgoing energy from CM to LAB

--- a/src/physics.F90
+++ b/src/physics.F90
@@ -51,7 +51,7 @@ contains
     end if
 
     ! Check for very low energy
-    if (p % alive .and. p % E < 1.0e-100_8) then
+    if (p % alive .and. p % E < VERY_LOW_ENERGY) then
       p % alive = .false.
       if (master) call warning("Killing neutron with extremely low energy")
     end if
@@ -1337,7 +1337,7 @@ contains
     ! anything else in this subroutine.  Those small E values can cause some
     ! ugly floating point errors in rotate_angle, and secondaries created with
     ! low energy will cause errors in calculate_xs.
-    if (E < 1.0e-100_8) then
+    if (E < VERY_LOW_ENERGY) then
       p % E = ZERO
       p % alive = .false.
       if (master) call warning("Killing neutron with extremely low energy")


### PR DESCRIPTION
This PR prevents a nasty floating point error that I ran into.  In my problem, I was sampling an outgoing energy of 1e-323 from an inelastic scatter.  First, this caused a bug in `rotate_angle` because `mu` < 1e-300 which caused an error on the `mu * mu` computation.  Once I got past that, I found that this reaction also banked secondaries with really low energies which would cause a floating point exception in `calculate_xs`.

This PR fixes those issues by calling `return` early in `inelastic_scatter` when low E values are sampled.

I also have a question about this piece of code.  Why do the secondaries get the parent particle's energy?  Shouldn't we be sampling other energies from the reaction?