### PR TITLE
Write summary.h5 by default

### DIFF
--- a/src/global.F90
+++ b/src/global.F90
@@ -390,7 +390,7 @@ module global
   type(SetInt) :: sourcepoint_batch
 
   ! Various output options
-  logical :: output_summary = .false.
+  logical :: output_summary = .true.
   logical :: output_xs      = .false.
   logical :: output_tallies = .true.
 

--- a/src/input_xml.F90
+++ b/src/input_xml.F90
@@ -905,8 +905,8 @@ contains
       if (check_for_node(node_output, "summary")) then
         call get_node_value(node_output, "summary", temp_str)
         temp_str = to_lower(temp_str)
-        if (trim(temp_str) == 'true' .or. &
-             trim(temp_str) == '1') output_summary = .true.
+        if (trim(temp_str) == 'false' .or. &
+             trim(temp_str) == '0') output_summary = .false.
       end if
 
       ! Check for cross sections option


### PR DESCRIPTION
This pull request changes OpenMC to write the summary.h5 output file by default as suggested by @wbinventor in the discussion on #458.