### PR TITLE
Fix bug when sampling multiple energy distributions

### DIFF
--- a/src/secondary_header.F90
+++ b/src/secondary_header.F90
@@ -1,5 +1,6 @@
 module secondary_header
 
+  use constants, only: ZERO
   use endf_header, only: Tab1
   use interpolation, only: interpolate_tab1
   use random_lcg, only: prn
@@ -54,16 +55,19 @@ contains
     real(8), intent(out) :: mu    ! sampled scattering cosine
 
     integer :: n       ! number of angle-energy distributions
-    real(8) :: p_valid ! probability that given distribution is valid
+    real(8) :: prob    ! cumulative probability
+    real(8) :: c       ! sampled cumulative probability
 
     n = size(this%applicability)
     if (n > 1) then
+      prob = ZERO
+      c = prn()
       do i = 1, n
         ! Determine probability that i-th energy distribution is sampled
-        p_valid = interpolate_tab1(this%applicability(i), E_in)
+        prob = prob + interpolate_tab1(this%applicability(i), E_in)
 
         ! If i-th distribution is sampled, sample energy from the distribution
-        if (prn() <= p_valid) then
+        if (c <= prob) then
           call this%distribution(i)%obj%sample(E_in, E_out, mu)
           exit
         end if


### PR DESCRIPTION
The segfault that @smharper was seeing related to #584 is actually due to a bug in how we sample among multiple energy distributions. This can occur for reactions like (n,2n) and (n,3n) where the evaluator might list different evaporation spectra for each of the outgoing neutrons. The ENDF file specifies the relative probability of each of the distributions in a TAB1 record that gets transcribed to the ACE file by NJOY. Now, I had assumed that NJOY actually changes the TAB1 based on the following comment in the ACE format manual (MCNP vol III):

*If more than one law is given, then LAW1 is used only if xi < P(E) where xi is a random number between 0 and 1*

The comment only mentions the first law, but I had interpreted it to apply to all laws, i.e., if you don't sample the first law, you move on to the second law, sample a random number, and check whether it is less than P(E) for the second law, and so on... Turns out that interpretation was incorrect -- NJOY just passes the TAB1 unchanged, meaning you should only sample a random number once, and then add the probabilities until xi < sum(P_i(E)).

The following reactions could have resulted in no energy distribution being sampled (hence seeing weird segfaults resulting from uninitialized values):
- O-17 (n,2n)
- Ba-140 (n,2n), (n,3n)
- Ta-182 (n,2n), (n,3n)
- Ra-223,224,225,226 (n,2n), (n,3n), (n,4n)
- Am-244,244m (n,2n), (n,3n), (n,4n)

Other reactions may have unnecessarily sampled more than one random number, but would still otherwise be correct.