### PR TITLE
Python API fix for UFS Dimension

### DIFF
--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -970,7 +970,7 @@ class SettingsFile(object):
             element = ET.SubElement(self._settings_file, "uniform_fs")
 
             subelement = ET.SubElement(element, "dimension")
-            subelement.text = str(self._ufs_dimension)
+            subelement.text = ' '.join(map(str, self._ufs_dimension))
 
             subelement = ET.SubElement(element, "lower_left")
             subelement.text = ' '.join(map(str, self._ufs_lower_left))


### PR DESCRIPTION
This PR fixes a minor bug in the Python API where the uniform fission source mesh dimension was not being written correctly by the python api.

If the mesh dimensions given in the python API were ```[10,10,1]```, then the corresponding attribute incorrect behavior of the current develop branch would be to write ```<dimension>[10, 10, 1]</dimension>```.
Now, it correctly writes ```<dimension>10 10 1</dimension>```