### PR TITLE
Use common naming scheme for all abstract interfaces

### DIFF
--- a/src/distribution_multivariate.F90
+++ b/src/distribution_multivariate.F90
@@ -16,15 +16,15 @@ module distribution_multivariate
   type, abstract :: UnitSphereDistribution
     real(8) :: reference_uvw(3)
   contains
-    procedure(iSample), deferred :: sample
+    procedure(unitsphere_distribution_sample_), deferred :: sample
   end type UnitSphereDistribution
 
   abstract interface
-    function iSample(this) result(uvw)
+    function unitsphere_distribution_sample_(this) result(uvw)
       import UnitSphereDistribution
       class(UnitSphereDistribution), intent(in) :: this
       real(8) :: uvw(3)
-    end function iSample
+    end function unitsphere_distribution_sample_
   end interface
 
 !===============================================================================
@@ -58,15 +58,15 @@ module distribution_multivariate
 
   type, abstract :: SpatialDistribution
   contains
-    procedure(iSampleSpatial), deferred :: sample
+    procedure(spatial_distribution_sample_), deferred :: sample
   end type SpatialDistribution
 
   abstract interface
-    function iSampleSpatial(this) result(xyz)
+    function spatial_distribution_sample_(this) result(xyz)
       import SpatialDistribution
       class(SpatialDistribution), intent(in) :: this
       real(8) :: xyz(3)
-    end function iSampleSpatial
+    end function spatial_distribution_sample_
   end interface
 
   type, extends(SpatialDistribution) :: CartesianIndependent

--- a/src/distribution_univariate.F90
+++ b/src/distribution_univariate.F90
@@ -16,7 +16,7 @@ module distribution_univariate
 
   type, abstract :: Distribution
   contains
-    procedure(iSample), deferred :: sample
+    procedure(distribution_sample_), deferred :: sample
   end type Distribution
 
   type DistributionContainer
@@ -24,11 +24,11 @@ module distribution_univariate
   end type DistributionContainer
 
   abstract interface
-    function iSample(this) result(x)
+    function distribution_sample_(this) result(x)
       import Distribution
       class(Distribution), intent(in) :: this
       real(8) :: x
-    end function iSample
+    end function distribution_sample_
   end interface
 
 !===============================================================================

--- a/src/energy_distribution.F90
+++ b/src/energy_distribution.F90
@@ -16,16 +16,16 @@ module energy_distribution
 
   type, abstract :: EnergyDistribution
   contains
-    procedure(iSampleEnergy), deferred :: sample
+    procedure(energy_distribution_sample_), deferred :: sample
   end type EnergyDistribution
 
   abstract interface
-    function iSampleEnergy(this, E_in) result(E_out)
+    function energy_distribution_sample_(this, E_in) result(E_out)
       import EnergyDistribution
       class(EnergyDistribution), intent(in) :: this
       real(8), intent(in) :: E_in
       real(8) :: E_out
-    end function iSampleEnergy
+    end function energy_distribution_sample_
   end interface
 
   type :: EnergyDistributionContainer

--- a/src/geometry_header.F90
+++ b/src/geometry_header.F90
@@ -31,12 +31,10 @@ module geometry_header
     integer              :: outer            ! universe to tile outside the lat
     logical              :: is_3d            ! Lattice has cells on z axis
     integer, allocatable :: offset(:,:,:,:)  ! Distribcell offsets
-
-    contains
-
-    procedure(are_valid_indices_), deferred :: are_valid_indices
-    procedure(get_indices_),       deferred :: get_indices
-    procedure(get_local_xyz_),     deferred :: get_local_xyz
+  contains
+    procedure(lattice_are_valid_indices_), deferred :: are_valid_indices
+    procedure(lattice_get_indices_),       deferred :: get_indices
+    procedure(lattice_get_local_xyz_),     deferred :: get_local_xyz
   end type Lattice
 
   abstract interface
@@ -45,33 +43,33 @@ module geometry_header
 ! ARE_VALID_INDICES returns .true. if the given lattice indices fit within the
 ! bounds of the lattice.  Returns false otherwise.
 
-    function are_valid_indices_(this, i_xyz) result(is_valid)
+    function lattice_are_valid_indices_(this, i_xyz) result(is_valid)
       import Lattice
       class(Lattice), intent(in) :: this
       integer,        intent(in) :: i_xyz(3)
       logical                    :: is_valid
-    end function are_valid_indices_
+    end function lattice_are_valid_indices_
 
 !===============================================================================
 ! GET_INDICES returns the indices in a lattice for the given global xyz.
 
-    function get_indices_(this, global_xyz) result(i_xyz)
+    function lattice_get_indices_(this, global_xyz) result(i_xyz)
       import Lattice
       class(Lattice), intent(in) :: this
       real(8),        intent(in) :: global_xyz(3)
       integer                    :: i_xyz(3)
-    end function get_indices_
+    end function lattice_get_indices_
 
 !===============================================================================
 ! GET_LOCAL_XYZ returns the translated local version of the given global xyz.
 
-    function get_local_xyz_(this, global_xyz, i_xyz) result(local_xyz)
+    function lattice_get_local_xyz_(this, global_xyz, i_xyz) result(local_xyz)
       import Lattice
       class(Lattice), intent(in) :: this
       real(8),        intent(in) :: global_xyz(3)
       integer,        intent(in) :: i_xyz(3)
       real(8)                    :: local_xyz(3)
-    end function get_local_xyz_
+    end function lattice_get_local_xyz_
   end interface
 
 !===============================================================================

--- a/src/input_xml.F90
+++ b/src/input_xml.F90
@@ -131,15 +131,21 @@ contains
         if (run_CE) then
           call get_environment_variable("OPENMC_CROSS_SECTIONS", env_variable)
           if (len_trim(env_variable) == 0) then
-            call fatal_error("No cross_sections.xml file was specified in &
-                 &settings.xml or in the OPENMC_CROSS_SECTIONS environment &
-                 &variable. OpenMC needs such a file to identify where to &
-                 &find ACE cross section libraries. Please consult the user's &
-                 &guide at http://mit-crpg.github.io/openmc for information on &
-                 &how to set up ACE cross section libraries.")
-          else
-            path_cross_sections = trim(env_variable)
+            call get_environment_variable("CROSS_SECTIONS", env_variable)
+            if (len_trim(env_variable) == 0) then
+              call fatal_error("No cross_sections.xml file was specified in &
+                   &settings.xml or in the OPENMC_CROSS_SECTIONS environment &
+                   &variable. OpenMC needs such a file to identify where to &
+                   &find ACE cross section libraries. Please consult the user's &
+                   &guide at http://mit-crpg.github.io/openmc for information on &
+                   &how to set up ACE cross section libraries.")
+            else
+              call warning("The CROSS_SECTIONS environment variable is &
+                   &deprecated. Please update your environment to use &
+                   &OPENMC_CROSS_SECTIONS instead.")
+            end if
           end if
+          path_cross_sections = trim(env_variable)
         else
           call get_environment_variable("OPENMC_MG_CROSS_SECTIONS", env_variable)
           if (len_trim(env_variable) == 0) then

--- a/src/nuclide_header.F90
+++ b/src/nuclide_header.F90
@@ -33,17 +33,15 @@ module nuclide_header
     logical :: fissionable         ! nuclide is fissionable?
 
   contains
-    procedure(print_nuclide_), deferred :: print ! Writes nuclide info
+    procedure(nuclide_print_), deferred :: print ! Writes nuclide info
   end type Nuclide
 
   abstract interface
-
-    subroutine print_nuclide_(this, unit)
+    subroutine nuclide_print_(this, unit)
       import Nuclide
       class(Nuclide),intent(in)     :: this
       integer, optional, intent(in) :: unit
-    end subroutine print_nuclide_
-
+    end subroutine nuclide_print_
   end interface
 
   type, extends(Nuclide) :: NuclideCE

--- a/src/particle_header.F90
+++ b/src/particle_header.F90
@@ -217,7 +217,7 @@ contains
     integer,         intent(in)    :: type
     logical,         intent(in)    :: run_CE
 
-    integer :: n
+    integer(8) :: n
 
     ! Check to make sure that the hard-limit on secondary particles is not
     ! exceeded.

--- a/src/scattdata_header.F90
+++ b/src/scattdata_header.F90
@@ -20,22 +20,22 @@ module scattdata_header
     real(8), allocatable :: data(:,:,:) ! (Order/Nmu x Gout x Gin)
 
   contains
-    procedure(init_), deferred   :: init   ! Initializes ScattData
-    procedure(calc_f_), deferred :: calc_f ! Calculates f, given mu
-    procedure(sample_), deferred :: sample ! sample the scatter event
+    procedure(scattdata_init_), deferred   :: init   ! Initializes ScattData
+    procedure(scattdata_calc_f_), deferred :: calc_f ! Calculates f, given mu
+    procedure(scattdata_sample_), deferred :: sample ! sample the scatter event
   end type ScattData
 
   abstract interface
-    subroutine init_(this, order, energy, mult, coeffs)
+    subroutine scattdata_init_(this, order, energy, mult, coeffs)
       import ScattData
       class(ScattData), intent(inout) :: this          ! Object to work on
       integer, intent(in)             :: order         ! Data Order
       real(8), intent(in)             :: energy(:,:)   ! Energy Transfer Matrix
       real(8), intent(in)             :: mult(:,:)     ! Scatter Prod'n Matrix
       real(8), intent(in)             :: coeffs(:,:,:) ! Coefficients to use
-    end subroutine init_
+    end subroutine scattdata_init_
 
-    pure function calc_f_(this, gin, gout, mu) result(f)
+    pure function scattdata_calc_f_(this, gin, gout, mu) result(f)
       import ScattData
       class(ScattData), intent(in) :: this ! The ScattData to evaluate
       integer, intent(in)          :: gin  ! Incoming Energy Group
@@ -43,16 +43,16 @@ module scattdata_header
       real(8), intent(in)          :: mu   ! Angle of interest
       real(8)                      :: f    ! Return value of f(mu)
 
-    end function calc_f_
+    end function scattdata_calc_f_
 
-    subroutine sample_(this, gin, gout, mu, wgt)
+    subroutine scattdata_sample_(this, gin, gout, mu, wgt)
       import ScattData
       class(ScattData), intent(in)    :: this ! Scattering Object to Use
       integer,          intent(in)    :: gin  ! Incoming neutron group
       integer,          intent(out)   :: gout ! Sampled outgoin group
       real(8),          intent(out)   :: mu   ! Sampled change in angle
       real(8),          intent(inout) :: wgt  ! Particle weight
-    end subroutine sample_
+    end subroutine scattdata_sample_
   end interface
 
   type, extends(ScattData) :: ScattDataLegendre

--- a/src/secondary_header.F90
+++ b/src/secondary_header.F90
@@ -14,17 +14,17 @@ module secondary_header
 
   type, abstract :: AngleEnergy
   contains
-    procedure(iSampleAngleEnergy), deferred :: sample
+    procedure(angleenergy_sample_), deferred :: sample
   end type AngleEnergy
 
   abstract interface
-    subroutine iSampleAngleEnergy(this, E_in, E_out, mu)
+    subroutine angleenergy_sample_(this, E_in, E_out, mu)
       import AngleEnergy
       class(AngleEnergy), intent(in) :: this
       real(8), intent(in) :: E_in
       real(8), intent(out) :: E_out
       real(8), intent(out) :: mu
-    end subroutine iSampleAngleEnergy
+    end subroutine angleenergy_sample_
   end interface
 
   type :: AngleEnergyContainer
@@ -54,6 +54,7 @@ contains
     real(8), intent(out) :: E_out ! sampled outgoing energy
     real(8), intent(out) :: mu    ! sampled scattering cosine
 
+    integer :: i       ! loop counter
     integer :: n       ! number of angle-energy distributions
     real(8) :: prob    ! cumulative probability
     real(8) :: c       ! sampled cumulative probability

--- a/src/surface_header.F90
+++ b/src/surface_header.F90
@@ -19,34 +19,34 @@ module surface_header
   contains
     procedure :: sense
     procedure :: reflect
-    procedure(iEvaluate), deferred :: evaluate
-    procedure(iDistance), deferred :: distance
-    procedure(iNormal),   deferred :: normal
+    procedure(surface_evaluate_), deferred :: evaluate
+    procedure(surface_distance_), deferred :: distance
+    procedure(surface_normal_),   deferred :: normal
   end type Surface
 
   abstract interface
-    pure function iEvaluate(this, xyz) result(f)
+    pure function surface_evaluate_(this, xyz) result(f)
       import Surface
       class(Surface), intent(in) :: this
       real(8), intent(in) :: xyz(3)
       real(8) :: f
-    end function iEvaluate
+    end function surface_evaluate_
 
-    pure function iDistance(this, xyz, uvw, coincident) result(d)
+    pure function surface_distance_(this, xyz, uvw, coincident) result(d)
       import Surface
       class(Surface), intent(in) :: this
       real(8), intent(in) :: xyz(3)
       real(8), intent(in) :: uvw(3)
       logical, intent(in) :: coincident
       real(8) :: d
-    end function iDistance
+    end function surface_distance_
 
-    pure function iNormal(this, xyz) result(uvw)
+    pure function surface_normal_(this, xyz) result(uvw)
       import Surface
       class(Surface), intent(in) :: this
       real(8), intent(in) :: xyz(3)
       real(8) :: uvw(3)
-    end function iNormal
+    end function surface_normal_
   end interface
 
 !===============================================================================

--- a/src/tally.F90
+++ b/src/tally.F90
@@ -28,12 +28,12 @@ module tally
 
 !$omp threadprivate(position)
 
-  procedure(score_general_intfc),    pointer :: score_general => null()
-  procedure(get_scoring_bins_intfc), pointer :: get_scoring_bins => null()
+  procedure(score_general_),    pointer :: score_general => null()
+  procedure(get_scoring_bins_), pointer :: get_scoring_bins => null()
 
   abstract interface
-    subroutine score_general_intfc(p, t, start_index, filter_index, i_nuclide, &
-                                  atom_density, flux)
+    subroutine score_general_(p, t, start_index, filter_index, i_nuclide, &
+                              atom_density, flux)
       import Particle
       import TallyObject
       type(Particle),    intent(in)    :: p
@@ -43,15 +43,14 @@ module tally
       integer,            intent(in)   :: filter_index   ! for % results
       real(8),            intent(in)   :: flux           ! flux estimate
       real(8),            intent(in)   :: atom_density   ! atom/b-cm
-    end subroutine score_general_intfc
+    end subroutine score_general_
 
-    subroutine get_scoring_bins_intfc(p, i_tally, found_bin)
+    subroutine get_scoring_bins_(p, i_tally, found_bin)
       import Particle
       type(Particle), intent(in)  :: p
       integer,        intent(in)  :: i_tally
       logical,        intent(out) :: found_bin
-    end subroutine get_scoring_bins_intfc
-
+    end subroutine get_scoring_bins_
   end interface
 
 contains


### PR DESCRIPTION
This is a fairly trivial PR that just changes the names of abstract interfaces so that there is a common convention. I've actually adopted the convention that @nelsonag used for the MG mode work, typename_procedurename_. Trivial as this may be, it actually fixes a compile-time error with the IBM XLF compiler since we had two abstract interfaces named iSample that clashed through use association. There are also two compiler warnings I've avoided:

- Implicit variable use in secondary_header.F90
- narrowing conversion in particle_header.F90