### PR TITLE
Hotfix for Library MGXS Getter Method Error Msg

### DIFF
--- a/openmc/mgxs/library.py
+++ b/openmc/mgxs/library.py
@@ -426,7 +426,7 @@ class Library(object):
         ----------
         domain : Material or Cell or Universe or Integral
             The material, cell, or universe object of interest (or its ID)
-        mgxs_type : {'total', 'transport', 'absorption', 'capture', 'fission', 'nu-fission', 'scatter', 'nu-scatter', 'scatter matrix', 'nu-scatter matrix', 'chi'}
+        mgxs_type : {'total', 'transport', 'absorption', 'capture', 'fission', 'nu-fission', 'kappa-fission', 'scatter', 'nu-scatter', 'scatter matrix', 'nu-scatter matrix', 'chi'}
             The type of multi-group cross section object to return
 
         Returns
@@ -457,7 +457,7 @@ class Library(object):
                     break
             else:
                 msg = 'Unable to find MGXS for {0} "{1}" in ' \
-                      'library'.format(self.domain_type, domain)
+                      'library'.format(self.domain_type, domain_id)
                 raise ValueError(msg)
         else:
             domain_id = domain.id

--- a/openmc/opencg_compatible.py
+++ b/openmc/opencg_compatible.py
@@ -11,6 +11,7 @@ except ImportError:
 import openmc
 from openmc.region import Intersection
 from openmc.surface import Halfspace
+import openmc.checkvalue as cv
 
 
 # A dictionary of all OpenMC Materials created
@@ -79,10 +80,7 @@ def get_opencg_material(openmc_material):
 
     """
 
-    if not isinstance(openmc_material, openmc.Material):
-        msg = 'Unable to create an OpenCG Material from "{0}" ' \
-              'which is not an OpenMC Material'.format(openmc_material)
-        raise ValueError(msg)
+    cv.check_type('openmc_material', openmc_material, openmc.Material)
 
     global OPENCG_MATERIALS
     material_id = openmc_material.id
@@ -119,10 +117,7 @@ def get_openmc_material(opencg_material):
 
     """
 
-    if not isinstance(opencg_material, opencg.Material):
-        msg = 'Unable to create an OpenMC Material from "{0}" ' \
-              'which is not an OpenCG Material'.format(opencg_material)
-        raise ValueError(msg)
+    cv.check_type('opencg_material', opencg_material, opencg.Material)
 
     global OPENMC_MATERIALS
     material_id = opencg_material.id
@@ -165,10 +160,7 @@ def is_opencg_surface_compatible(opencg_surface):
 
     """
 
-    if not isinstance(opencg_surface, opencg.Surface):
-        msg = 'Unable to check if OpenCG Surface is compatible' \
-              'since "{0}" is not a Surface'.format(opencg_surface)
-        raise ValueError(msg)
+    cv.check_type('opencg_surface', opencg_surface, opencg.Surface)
 
     if opencg_surface.type in ['x-squareprism',
                                'y-squareprism', 'z-squareprism']:
@@ -192,10 +184,7 @@ def get_opencg_surface(openmc_surface):
 
     """
 
-    if not isinstance(openmc_surface, openmc.Surface):
-        msg = 'Unable to create an OpenCG Surface from "{0}" ' \
-              'which is not an OpenMC Surface'.format(openmc_surface)
-        raise ValueError(msg)
+    cv.check_type('openmc_surface', openmc_surface, openmc.Surface)
 
     global OPENCG_SURFACES
     surface_id = openmc_surface.id
@@ -278,10 +267,7 @@ def get_openmc_surface(opencg_surface):
 
     """
 
-    if not isinstance(opencg_surface, opencg.Surface):
-        msg = 'Unable to create an OpenMC Surface from "{0}" which ' \
-              'is not an OpenCG Surface'.format(opencg_surface)
-        raise ValueError(msg)
+    cv.check_type('opencg_surface', opencg_surface, opencg.Surface)
 
     global openmc_surface
     surface_id = opencg_surface.id
@@ -369,10 +355,7 @@ def get_compatible_opencg_surfaces(opencg_surface):
 
     """
 
-    if not isinstance(opencg_surface, opencg.Surface):
-        msg = 'Unable to create an OpenMC Surface from "{0}" which ' \
-              'is not an OpenCG Surface'.format(opencg_surface)
-        raise ValueError(msg)
+    cv.check_type('opencg_surface', opencg_surface, opencg.Surface)
 
     global OPENMC_SURFACES
     surface_id = opencg_surface.id
@@ -451,10 +434,7 @@ def get_opencg_cell(openmc_cell):
 
     """
 
-    if not isinstance(openmc_cell, openmc.Cell):
-        msg = 'Unable to create an OpenCG Cell from "{0}" which ' \
-              'is not an OpenMC Cell'.format(openmc_cell)
-        raise ValueError(msg)
+    cv.check_type('openmc_cell', openmc_cell, openmc.Cell)
 
     global OPENCG_CELLS
     cell_id = openmc_cell.id
@@ -469,9 +449,9 @@ def get_opencg_cell(openmc_cell):
 
     fill = openmc_cell.fill
 
-    if (openmc_cell.fill_type == 'material'):
+    if openmc_cell.fill_type == 'material':
         opencg_cell.fill = get_opencg_material(fill)
-    elif (openmc_cell.fill_type == 'universe'):
+    elif openmc_cell.fill_type == 'universe':
         opencg_cell.fill = get_opencg_universe(fill)
     else:
         opencg_cell.fill = get_opencg_lattice(fill)
@@ -533,20 +513,10 @@ def get_compatible_opencg_cells(opencg_cell, opencg_surface, halfspace):
         OpenMC
 
     """
-    if not isinstance(opencg_cell, opencg.Cell):
-        msg = 'Unable to create compatible OpenMC Cell from "{0}" which ' \
-              'is not an OpenCG Cell'.format(opencg_cell)
-        raise ValueError(msg)
 
-    elif not isinstance(opencg_surface, opencg.Surface):
-        msg = 'Unable to create compatible OpenMC Cell since "{0}" is ' \
-              'not an OpenCG Surface'.format(opencg_surface)
-        raise ValueError(msg)
-
-    elif halfspace not in [-1, +1]:
-        msg = 'Unable to create compatible Cell since "{0}"' \
-              'is not a +/-1 halfspace'.format(halfspace)
-        raise ValueError(msg)
+    cv.check_type('opencg_cell', opencg_cell, opencg.Cell)
+    cv.check_type('opencg_surface', opencg_surface, opencg.Surface)
+    cv.check_value('halfspace', halfspace, (-1, +1))
 
     # Initialize an empty list for the new compatible cells
     compatible_cells = []
@@ -575,7 +545,7 @@ def get_compatible_opencg_cells(opencg_cell, opencg_surface, halfspace):
             num_clones = 8
 
             for clone_id in range(num_clones):
-                # Create a cloned OpenCG Cell with Surfaces compatible with OpenMC
+                # Create cloned OpenCG Cell with Surfaces compatible with OpenMC
                 clone = opencg_cell.clone()
                 compatible_cells.append(clone)
 
@@ -641,10 +611,7 @@ def make_opencg_cells_compatible(opencg_universe):
 
     """
 
-    if not isinstance(opencg_universe, opencg.Universe):
-        msg = 'Unable to make compatible OpenCG Cells for "{0}" which ' \
-              'is not an OpenCG Universe'.format(opencg_universe)
-        raise ValueError(msg)
+    cv.check_type('opencg_universe', opencg_universe, opencg.Universe)
 
     # Check all OpenCG Cells in this Universe for compatibility with OpenMC
     opencg_cells = opencg_universe.cells
@@ -700,10 +667,7 @@ def get_openmc_cell(opencg_cell):
 
     """
 
-    if not isinstance(opencg_cell, opencg.Cell):
-        msg = 'Unable to create an OpenMC Cell from "{0}" which ' \
-              'is not an OpenCG Cell'.format(opencg_cell)
-        raise ValueError(msg)
+    cv.check_type('opencg_cell', opencg_cell, opencg.Cell)
 
     global OPENMC_CELLS
     cell_id = opencg_cell.id
@@ -718,9 +682,9 @@ def get_openmc_cell(opencg_cell):
 
     fill = opencg_cell.fill
 
-    if (opencg_cell.type == 'universe'):
+    if opencg_cell.type == 'universe':
         openmc_cell.fill = get_openmc_universe(fill)
-    elif (opencg_cell.type == 'lattice'):
+    elif opencg_cell.type == 'lattice':
         openmc_cell.fill = get_openmc_lattice(fill)
     else:
         openmc_cell.fill = get_openmc_material(fill)
@@ -764,10 +728,7 @@ def get_opencg_universe(openmc_universe):
 
     """
 
-    if not isinstance(openmc_universe, openmc.Universe):
-        msg = 'Unable to create an OpenCG Universe from "{0}" which ' \
-              'is not an OpenMC Universe'.format(openmc_universe)
-        raise ValueError(msg)
+    cv.check_type('openmc_universe', openmc_universe, openmc.Universe)
 
     global OPENCG_UNIVERSES
     universe_id = openmc_universe.id
@@ -811,10 +772,7 @@ def get_openmc_universe(opencg_universe):
 
     """
 
-    if not isinstance(opencg_universe, opencg.Universe):
-        msg = 'Unable to create an OpenMC Universe from "{0}" which ' \
-              'is not an OpenCG Universe'.format(opencg_universe)
-        raise ValueError(msg)
+    cv.check_type('opencg_universe', opencg_universe, opencg.Universe)
 
     global OPENMC_UNIVERSES
     universe_id = opencg_universe.id
@@ -861,10 +819,7 @@ def get_opencg_lattice(openmc_lattice):
 
     """
 
-    if not isinstance(openmc_lattice, openmc.Lattice):
-        msg = 'Unable to create an OpenCG Lattice from "{0}" which ' \
-              'is not an OpenMC Lattice'.format(openmc_lattice)
-        raise ValueError(msg)
+    cv.check_type('openmc_lattice', openmc_lattice, openmc.Lattice)
 
     global OPENCG_LATTICES
     lattice_id = openmc_lattice.id
@@ -958,10 +913,7 @@ def get_openmc_lattice(opencg_lattice):
 
     """
 
-    if not isinstance(opencg_lattice, opencg.Lattice):
-        msg = 'Unable to create an OpenMC Lattice from "{0}" which ' \
-              'is not an OpenCG Lattice'.format(opencg_lattice)
-        raise ValueError(msg)
+    cv.check_type('opencg_lattice', opencg_lattice, opencg.Lattice)
 
     global OPENMC_LATTICES
     lattice_id = opencg_lattice.id
@@ -1032,10 +984,7 @@ def get_opencg_geometry(openmc_geometry):
 
     """
 
-    if not isinstance(openmc_geometry, openmc.Geometry):
-        msg = 'Unable to get OpenCG geometry from "{0}" which is ' \
-              'not an OpenMC Geometry object'.format(openmc_geometry)
-        raise ValueError(msg)
+    cv.check_type('openmc_geometry', openmc_geometry, openmc.Geometry)
 
     # Clear dictionaries and auto-generated IDs
     OPENMC_SURFACES.clear()
@@ -1072,10 +1021,7 @@ def get_openmc_geometry(opencg_geometry):
 
     """
 
-    if not isinstance(opencg_geometry, opencg.Geometry):
-        msg = 'Unable to get OpenMC geometry from "{0}" which is ' \
-              'not an OpenCG Geometry object'.format(opencg_geometry)
-        raise ValueError(msg)
+    cv.check_type('opencg_geometry', opencg_geometry, opencg.Geometry)
 
     # Deep copy the goemetry since it may be modified to make all Surfaces
     # compatible with OpenMC's specifications


### PR DESCRIPTION
This short PR introduces a one line fix for the `openmc.mgxs.Library.get_mgxs(...)` method. If a user requested an MGXS for a integer domain ID that does not exist in the `Library`, the error message is malformed. This PR fixes that issue. In addition, the `openmc.opencg_compatible` module now uses the `openmc.checkvalue` interface...just to net an overall reduction in the codebase for this PR :-)