### PR TITLE
Hotfix for MGXS Nuclide Density Lookups

### DIFF
--- a/openmc/mgxs/mgxs.py
+++ b/openmc/mgxs/mgxs.py
@@ -439,7 +439,7 @@ class MGXS(object):
         cv.check_type('nuclide', nuclide, basestring)
 
         # Get list of all nuclides in the spatial domain
-        nuclides = self.get_all_nuclides()
+        nuclides = self.domain.get_all_nuclides()
 
         if nuclide not in nuclides:
             msg = 'Unable to get density for nuclide "{0}" which is not in ' \


### PR DESCRIPTION
This fixes a bug I introduced in #619 for looking up nuclide densities.