### PR TITLE
Add sphinx.ext.viewcode extension for docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,6 +44,7 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.mathjax',
               'sphinx.ext.autosummary',
               'sphinx.ext.intersphinx',
+              'sphinx.ext.viewcode',
               'sphinx_numfig',
               'notebook_sphinxext']
 


### PR DESCRIPTION
This pull request enhances our Python API documentation to display links to source code next to classes and methods as requested in #432.