### PR TITLE
Increase MAX_EVENTS to 1 million

### DIFF
--- a/src/constants.F90
+++ b/src/constants.F90
@@ -37,7 +37,7 @@ module constants
   real(8), parameter :: FP_COINCIDENT = 1e-12_8
 
   ! Maximum number of collisions/crossings
-  integer, parameter :: MAX_EVENTS = 10000
+  integer, parameter :: MAX_EVENTS = 1000000
   integer, parameter :: MAX_SAMPLE = 100000
 
   ! Maximum number of secondary particles created


### PR DESCRIPTION
OpenMC currently limits the maximum number of events for a single particle to 10000 in order to prevent an infinite loop in the event that there is an error either in OpenMC itself or cross section data or a user's model. However, this limit is evidently too low for systems with very little absorption. A colleague of mine at ANL just showed me a model that results in an average of 10000-20000 events per particle. Increasing this parameter to 1 million should still help prevent infinite loops but allow reasonable models to proceed safely.