### PR TITLE
Minor input improvements

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -387,7 +387,7 @@ class Material(object):
 
         Parameters
         ----------
-        element : openmc.Element
+        element : openmc.Element or str
             Element to add
         percent : float
             Atom or weight percent
@@ -401,7 +401,7 @@ class Material(object):
                   'macroscopic data-set has already been added'.format(self._id)
             raise ValueError(msg)
 
-        if not isinstance(element, openmc.Element):
+        if not isinstance(element, (openmc.Element, str)):
             msg = 'Unable to add an Element to Material ID="{0}" with a ' \
                   'non-Element value "{1}"'.format(self._id, element)
             raise ValueError(msg)

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -281,7 +281,7 @@ class Material(object):
                   'macroscopic data-set has already been added'.format(self._id)
             raise ValueError(msg)
 
-        if not isinstance(nuclide, (openmc.Nuclide, str)):
+        if not isinstance(nuclide, (openmc.Nuclide, basestring)):
             msg = 'Unable to add a Nuclide to Material ID="{0}" with a ' \
                   'non-Nuclide value "{1}"'.format(self._id, nuclide)
             raise ValueError(msg)
@@ -401,7 +401,7 @@ class Material(object):
                   'macroscopic data-set has already been added'.format(self._id)
             raise ValueError(msg)
 
-        if not isinstance(element, (openmc.Element, str)):
+        if not isinstance(element, (openmc.Element, basestring)):
             msg = 'Unable to add an Element to Material ID="{0}" with a ' \
                   'non-Element value "{1}"'.format(self._id, element)
             raise ValueError(msg)

--- a/src/input_xml.F90
+++ b/src/input_xml.F90
@@ -38,8 +38,8 @@ contains
 
   subroutine read_input_xml()
 
+    call read_settings_xml()
     if (run_mode /= MODE_PLOTTING) then
-      call read_settings_xml()
       if (run_CE) then
         call read_ce_cross_sections_xml()
       else
@@ -92,18 +92,22 @@ contains
     type(NodeList), pointer :: node_scat_list => null()
     type(NodeList), pointer :: node_source_list => null()
 
-    ! Display output message
-    call write_message("Reading settings XML file...", 5)
-
     ! Check if settings.xml exists
     filename = trim(path_input) // "settings.xml"
     inquire(FILE=filename, EXIST=file_exists)
     if (.not. file_exists) then
-      call fatal_error("Settings XML file '" // trim(filename) // "' does not &
-           &exist! In order to run OpenMC, you first need a set of input files;&
-           & at a minimum, this includes settings.xml, geometry.xml, and &
-           &materials.xml. Please consult the user's guide at &
-           &http://mit-crpg.github.io/openmc for further information.")
+      if (run_mode /= MODE_PLOTTING) then
+        call fatal_error("Settings XML file '" // trim(filename) // "' does &
+             &not exist! In order to run OpenMC, you first need a set of input &
+             &files; at a minimum, this includes settings.xml, geometry.xml, &
+             &and materials.xml. Please consult the user's guide at &
+             &http://mit-crpg.github.io/openmc for further information.")
+      else
+        ! The settings.xml file is optional if we just want to make a plot.
+        return
+      end if
+    else
+      call write_message("Reading settings XML file...", 5)
     end if
 
     ! Parse settings.xml file

--- a/src/input_xml.F90
+++ b/src/input_xml.F90
@@ -38,8 +38,8 @@ contains
 
   subroutine read_input_xml()
 
-    call read_settings_xml()
     if (run_mode /= MODE_PLOTTING) then
+      call read_settings_xml()
       if (run_CE) then
         call read_ce_cross_sections_xml()
       else


### PR DESCRIPTION
Sorry to juggle the PRs.  This is the real one.  No more force pushes.

Two changes in this PR:  First, it allows you to add elements with this shortcut:
```python
# Old
b = openmc.Element('B')
material.add_element(b, 4e-3)
# New
material.add_element('B', 4e-3)
```
This has been possible for a long time with `add_nuclide`, and the appropriate code was already in place for `add_element`.  This case was just missed in the the `checkvalue`.

This PR also makes it so that settings.xml files are not read for plotting.  Now, only materials.xml and geometry.xml are needed for a plot.