### PR TITLE
Make sure to capture stderr when using openmc.run()

### DIFF
--- a/openmc/executor.py
+++ b/openmc/executor.py
@@ -10,7 +10,7 @@ if sys.version_info[0] >= 3:
 def _run(command, output, cwd):
     # Launch a subprocess
     p = subprocess.Popen(command, shell=True, cwd=cwd, stdout=subprocess.PIPE,
-                         universal_newlines=True)
+                         stderr=subprocess.STDOUT, universal_newlines=True)
 
     # Capture and re-print OpenMC output in real-time
     while True:


### PR DESCRIPTION
Right now if you're running OpenMC from the Python API and you reach an error, stderr is never shown. This pull request fixes that.