### PR TITLE
Make Materials, Plots, and Tallies list-like

### DIFF
--- a/docs/source/pythonapi/examples/mgxs-part-i.ipynb
+++ b/docs/source/pythonapi/examples/mgxs-part-i.ipynb
@@ -212,10 +212,9 @@
    },
    "outputs": [],
    "source": [
-    "# Instantiate a Materials object, register all Materials, and export to XML\n",
-    "materials_file = openmc.Materials()\n",
+    "# Instantiate a Materials collection and export to XML\n",
+    "materials_file = openmc.Materials([inf_medium])\n",
     "materials_file.default_xs = '71c'\n",
-    "materials_file.add_material(inf_medium)\n",
     "materials_file.export_to_xml()"
    ]
   },
@@ -466,17 +465,14 @@
     "tallies_file = openmc.Tallies()\n",
     "\n",
     "# Add total tallies to the tallies file\n",
-    "for tally in total.tallies.values():\n",
-    "    tallies_file.add_tally(tally)\n",
+    "tallies_file += total.tallies.values()\n",
     "\n",
     "# Add absorption tallies to the tallies file\n",
-    "for tally in absorption.tallies.values():\n",
-    "    tallies_file.add_tally(tally)\n",
+    "tallies_file += absorption.tallies.values()\n",
     "\n",
     "# Add scattering tallies to the tallies file\n",
-    "for tally in scattering.tallies.values():\n",
-    "    tallies_file.add_tally(tally)\n",
-    "                \n",
+    "tallies_file += scattering.tallies.values()\n",
+    "\n",
     "# Export to \"tallies.xml\"\n",
     "tallies_file.export_to_xml()"
    ]

--- a/docs/source/pythonapi/examples/mgxs-part-ii.ipynb
+++ b/docs/source/pythonapi/examples/mgxs-part-ii.ipynb
@@ -133,11 +133,8 @@
    },
    "outputs": [],
    "source": [
-    "# Instantiate a Materials object, add Materials\n",
-    "materials_file = openmc.Materials()\n",
-    "materials_file.add_material(fuel)\n",
-    "materials_file.add_material(water)\n",
-    "materials_file.add_material(zircaloy)\n",
+    "# Instantiate a Materials collection\n",
+    "materials_file = openmc.Materials((fuel, water, zircaloy))\n",
     "materials_file.default_xs = '71c'\n",
     "\n",
     "# Export to \"materials.xml\"\n",
@@ -408,7 +405,7 @@
     "                \n",
     "        # Add OpenMC tallies to the tallies file for XML generation\n",
     "        for tally in xs_library[cell.id][rxn_type].tallies.values():\n",
-    "            tallies_file.add_tally(tally, merge=True)\n",
+    "            tallies_file.append(tally, merge=True)\n",
     "\n",
     "# Export to \"tallies.xml\"\n",
     "tallies_file.export_to_xml()"

--- a/docs/source/pythonapi/examples/mgxs-part-iii.ipynb
+++ b/docs/source/pythonapi/examples/mgxs-part-iii.ipynb
@@ -133,11 +133,8 @@
    },
    "outputs": [],
    "source": [
-    "# Instantiate a Materials object, add Materials\n",
-    "materials_file = openmc.Materials()\n",
-    "materials_file.add_material(fuel)\n",
-    "materials_file.add_material(water)\n",
-    "materials_file.add_material(zircaloy)\n",
+    "# Instantiate a Materials object\n",
+    "materials_file = openmc.Materials((fuel, water, zircaloy))\n",
     "materials_file.default_xs = '71c'\n",
     "\n",
     "# Export to \"materials.xml\"\n",
@@ -419,8 +416,7 @@
     "plot.color = 'mat'\n",
     "\n",
     "# Instantiate a Plots object, add Plot, and export to \"plots.xml\"\n",
-    "plot_file = openmc.Plots()\n",
-    "plot_file.add_plot(plot)\n",
+    "plot_file = openmc.Plots([plot])\n",
     "plot_file.export_to_xml()"
    ]
   },
@@ -685,9 +681,8 @@
     "tally.filters = [mesh_filter]\n",
     "tally.scores = ['fission', 'nu-fission']\n",
     "\n",
-    "# Add mesh and tally to Tallies\n",
-    "tallies_file.add_mesh(mesh)\n",
-    "tallies_file.add_tally(tally)"
+    "# Add tally to collection\n",
+    "tallies_file.append(tally)"
    ]
   },
   {

--- a/docs/source/pythonapi/examples/pandas-dataframes.ipynb
+++ b/docs/source/pythonapi/examples/pandas-dataframes.ipynb
@@ -108,11 +108,8 @@
    },
    "outputs": [],
    "source": [
-    "# Instantiate a Materials object, add Materials\n",
-    "materials_file = openmc.Materials()\n",
-    "materials_file.add_material(fuel)\n",
-    "materials_file.add_material(water)\n",
-    "materials_file.add_material(zircaloy)\n",
+    "# Instantiate a Materials collection\n",
+    "materials_file = openmc.Materials((fuel, water, zircaloy))\n",
     "materials_file.default_xs = '71c'\n",
     "\n",
     "# Export to \"materials.xml\"\n",
@@ -329,9 +326,8 @@
     "plot.pixels = [250, 250]\n",
     "plot.color = 'mat'\n",
     "\n",
-    "# Instantiate a Plots object, add Plot, and export to \"plots.xml\"\n",
-    "plot_file = openmc.Plots()\n",
-    "plot_file.add_plot(plot)\n",
+    "# Instantiate a Plots collection and export to \"plots.xml\"\n",
+    "plot_file = openmc.Plots([plot])\n",
     "plot_file.export_to_xml()"
    ]
   },
@@ -449,8 +445,7 @@
     "tally.scores = ['fission', 'nu-fission']\n",
     "\n",
     "# Add mesh and Tally to Tallies\n",
-    "tallies_file.add_mesh(mesh)\n",
-    "tallies_file.add_tally(tally)"
+    "tallies_file.append(tally)"
    ]
   },
   {
@@ -478,7 +473,7 @@
     "tally.nuclides = [u235, u238]\n",
     "\n",
     "# Add mesh and tally to Tallies\n",
-    "tallies_file.add_tally(tally)"
+    "tallies_file.append(tally)"
    ]
   },
   {
@@ -510,7 +505,7 @@
     "tally.triggers = [trigger]\n",
     "\n",
     "# Add mesh and tally to Tallies\n",
-    "tallies_file.add_tally(tally)"
+    "tallies_file.append(tally)"
    ]
   },
   {

--- a/docs/source/pythonapi/examples/post-processing.ipynb
+++ b/docs/source/pythonapi/examples/post-processing.ipynb
@@ -104,11 +104,8 @@
    },
    "outputs": [],
    "source": [
-    "# Instantiate a Materials object, add Materials\n",
-    "materials_file = openmc.Materials()\n",
-    "materials_file.add_material(fuel)\n",
-    "materials_file.add_material(water)\n",
-    "materials_file.add_material(zircaloy)\n",
+    "# Instantiate a Materials collection\n",
+    "materials_file = openmc.Materials((fuel, water, zircaloy))\n",
     "materials_file.default_xs = '71c'\n",
     "\n",
     "# Export to \"materials.xml\"\n",
@@ -298,9 +295,8 @@
     "plot.pixels = [250, 250]\n",
     "plot.color = 'mat'\n",
     "\n",
-    "# Instantiate a Plots object, add Plot, and export to \"plots.xml\"\n",
-    "plot_file = openmc.Plots()\n",
-    "plot_file.add_plot(plot)\n",
+    "# Instantiate a Plots collection and export to \"plots.xml\"\n",
+    "plot_file = openmc.Plots([plot])\n",
     "plot_file.export_to_xml()"
    ]
   },
@@ -393,17 +389,16 @@
     "mesh.dimension = [100, 100]\n",
     "mesh.lower_left = [-0.63, -0.63]\n",
     "mesh.upper_right = [0.63, 0.63]\n",
-    "tallies_file.add_mesh(mesh)\n",
     "\n",
     "# Create mesh filter for tally\n",
-    "mesh_filter = openmc.Filter(type='mesh', bins=[1])\n",
+    "mesh_filter = openmc.Filter(type='mesh')\n",
     "mesh_filter.mesh = mesh\n",
     "\n",
     "# Create mesh tally to score flux and fission rate\n",
     "tally = openmc.Tally(name='flux')\n",
     "tally.filters = [mesh_filter]\n",
     "tally.scores = ['flux', 'fission']\n",
-    "tallies_file.add_tally(tally)"
+    "tallies_file.append(tally)"
    ]
   },
   {

--- a/docs/source/pythonapi/examples/tally-arithmetic.ipynb
+++ b/docs/source/pythonapi/examples/tally-arithmetic.ipynb
@@ -15,16 +15,7 @@
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The autoreload extension is already loaded. To reload it, use:\n",
-      "  %reload_ext autoreload\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%load_ext autoreload\n",
     "%autoreload 2"
@@ -362,7 +353,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPoAAAD6AgMAAAD1grKuAAAABGdBTUEAALGPC/xhBQAAAAFzUkdC\nAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAxQTFRF\n////chIS6YCRTb/E6kGE+wAAAAFiS0dEAIgFHUgAAAAJcEhZcwAAAEgAAABIAEbJaz4AAALKSURB\nVGje7dpLcqQwDAbgHHE2YeEj+D4cwQucBUfo+3CEXoSp8OhuhF70T4qpKXmdr21LogK2Pj7A8QmN\nP+HDhw8fPnz48Kf6VH9G+66vy+je8k19jnf8C5dXIPv86ms56lPdjvaYbyodx3ze+XLE76cXFiD4\nzPji99z0/AJ4n1lfvJ6fnl0A6x+578efMSg1wPr172/jPO5yFXM+Ef78gdblM+WPHyguP//t1/g6\npA0wfln+ho/fwgYYn19C/xwDvwHGc9OvC+hs37DTrwuwfWanXxdQTC9Mvyygs3wjTL8uwPJpn/tN\nDbSGz7T0SBEWw4vLXzbQ6b6RoveIoO6TvPxlA63qs7z8ZQPF9F+SH22vbX8OQKf5Rtv+EgDNJ3X5\n8wZaxWd1+fMGiuFvir8bvjp8J/tGy/6jAmRvhW8fwL3vVT+o3grfPoB7r/IpALI3tz8FoJN84/NV\n873hB8UnM3xzANtf8nb4dwmg3grfFEDJO8JPE0i9Ff4pAYL3pI8mkHor/HMCeO9JH00g9SafEsh7\nT/ppARBvp48UwJnelT5SACd7O31TAlnvKx9SQCd7B58KgPO+8iMFuPWe9E8F8BveWX7bAjzX9y4/\n/Jve+fhsH6Ctv7n8PTzjvY/v9gEOHz58+PBX+6v/f/wPvnd54f3j6venE/yl769Xv7+j3x/o98/V\n32/o9+fl389Xnx+g5x/o+Qt6/oOeP6HnX+j5G3z+h54/ouefV5/foufP6Pk3ev4On/+j9w/o/Qd6\n/4Le/6D3T/D9V67Y/ZsVQBq+s+8f0ftP+P41axXguP9NWgDuu/Cdfv+N3r/D9/9TAID+A7T/Ae2/\ngPs/0P4TtP8F7r9J3AIO9P+g/Udw/9Oygbf7r9D+L7j/DO1/Q/vv4P4/tP8Q7n9E+y/h/k+0/xTu\nf4X7b+H+X7T/+BPuf3aM8OHDhw8fPnz4w/4vzcvgeY10sY0AAAAldEVYdGRhdGU6Y3JlYXRlADIw\nMTYtMDQtMTNUMTE6Mzk6MTQtMDQ6MDALPlLjAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE2LTA0LTEz\nVDExOjM5OjE0LTA0OjAwemPqXwAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPoAAAD6AgMAAAD1grKuAAAABGdBTUEAALGPC/xhBQAAACBjSFJN\nAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAADFBMVEX///9yEhLpgJFNv8Tq\nQYT7AAAAAWJLR0QAiAUdSAAAAAd0SU1FB+AEHgslKE7FoLIAAALKSURBVGje7dpLcqQwDAbgHHE2\nYeEj+D4cwQucBUfo+3CEXoSp8OhuhF70T4qpKXmdr21LogK2Pj7A8QmNP+HDhw8fPnz48Kf6VH9G\n+66vy+je8k19jnf8C5dXIPv86ms56lPdjvaYbyodx3ze+XLE76cXFiD4zPji99z0/AJ4n1lfvJ6f\nnl0A6x+578efMSg1wPr172/jPO5yFXM+Ef78gdblM+WPHyguP//t1/g6pA0wfln+ho/fwgYYn19C\n/xwDvwHGc9OvC+hs37DTrwuwfWanXxdQTC9Mvyygs3wjTL8uwPJpn/tNDbSGz7T0SBEWw4vLXzbQ\n6b6RoveIoO6TvPxlA63qs7z8ZQPF9F+SH22vbX8OQKf5Rtv+EgDNJ3X58wZaxWd1+fMGiuFvir8b\nvjp8J/tGy/6jAmRvhW8fwL3vVT+o3grfPoB7r/IpALI3tz8FoJN84/NV873hB8UnM3xzANtf8nb4\ndwmg3grfFEDJO8JPE0i9Ff4pAYL3pI8mkHor/HMCeO9JH00g9SafEsh7T/ppARBvp48UwJnelT5S\nACd7O31TAlnvKx9SQCd7B58KgPO+8iMFuPWe9E8F8BveWX7bAjzX9y4//Jve+fhsH6Ctv7n8PTzj\nvY/v9gEOHz58+PBX+6v/f/wPvnd54f3j6venE/yl769Xv7+j3x/o98/V32/o9+fl389Xnx+g5x/o\n+Qt6/oOeP6HnX+j5G3z+h54/ouefV5/foufP6Pk3ev4On/+j9w/o/Qd6/4Le/6D3T/D9V67Y/ZsV\nQBq+s+8f0ftP+P41axXguP9NWgDuu/Cdfv+N3r/D9/9TAID+A7T/Ae2/gPs/0P4TtP8F7r9J3AIO\n9P+g/Udw/9Oygbf7r9D+L7j/DO1/Q/vv4P4/tP8Q7n9E+y/h/k+0/xTuf4X7b+H+X7T/+BPuf3aM\n8OHDhw8fPnz4w/4vzcvgeY10sY0AAAAldEVYdGRhdGU6Y3JlYXRlADIwMTYtMDQtMzBUMDY6Mzc6\nNDAtMDU6MDAMbOxZAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE2LTA0LTMwVDA2OjM3OjQwLTA1OjAw\nfTFU5QAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<IPython.core.display.Image object>"
       ]
@@ -449,7 +440,7 @@
     "abs_rate = openmc.Tally(name='abs. rate')\n",
     "fiss_rate.scores = ['nu-fission']\n",
     "abs_rate.scores = ['absorption']\n",
-    "tallies_file += (fiss_rate, abs_rate)",
+    "tallies_file += (fiss_rate, abs_rate)"
    ]
   },
   {
@@ -562,12 +553,11 @@
       "                  888\n",
       "                  888\n",
       "\n",
-      "      Copyright:      2011-2015 Massachusetts Institute of Technology\n",
-      "      License:        http://mit-crpg.github.io/openmc/license.html\n",
+      "      Copyright:      2011-2016 Massachusetts Institute of Technology\n",
+      "      License:        http://openmc.readthedocs.org/en/latest/license.html\n",
       "      Version:        0.7.1\n",
-      "      Git SHA1:       eeb5091ca3a34cc85df73a3318cae2b6c7097413\n",
-      "      Date/Time:      2016-04-13 11:39:14\n",
-      "      MPI Processes:  1\n",
+      "      Git SHA1:       ae083cf5d491e6a778d5b762dad19c8d5fe45238\n",
+      "      Date/Time:      2016-04-30 06:37:41\n",
       "\n",
       " ===========================================================================\n",
       " ========================>     INITIALIZATION     <=========================\n",
@@ -623,20 +613,20 @@
       "\n",
       " =======================>     TIMING STATISTICS     <=======================\n",
       "\n",
-      " Total time for initialization     =  4.0300E-01 seconds\n",
-      "   Reading cross sections          =  8.6000E-02 seconds\n",
-      " Total time in simulation          =  1.4439E+01 seconds\n",
-      "   Time in transport only          =  1.4430E+01 seconds\n",
-      "   Time in inactive batches        =  2.2790E+00 seconds\n",
-      "   Time in active batches          =  1.2160E+01 seconds\n",
-      "   Time synchronizing fission bank =  2.0000E-03 seconds\n",
+      " Total time for initialization     =  7.0900E-01 seconds\n",
+      "   Reading cross sections          =  4.0400E-01 seconds\n",
+      " Total time in simulation          =  1.7108E+01 seconds\n",
+      "   Time in transport only          =  1.7093E+01 seconds\n",
+      "   Time in inactive batches        =  3.3970E+00 seconds\n",
+      "   Time in active batches          =  1.3711E+01 seconds\n",
+      "   Time synchronizing fission bank =  1.0000E-03 seconds\n",
       "     Sampling source sites         =  1.0000E-03 seconds\n",
-      "     SEND/RECV source sites        =  1.0000E-03 seconds\n",
+      "     SEND/RECV source sites        =  0.0000E+00 seconds\n",
       "   Time accumulating tallies       =  0.0000E+00 seconds\n",
       " Total time for finalization       =  1.0000E-03 seconds\n",
-      " Total time elapsed                =  1.4856E+01 seconds\n",
-      " Calculation Rate (inactive)       =  5484.86 neutrons/second\n",
-      " Calculation Rate (active)         =  3083.88 neutrons/second\n",
+      " Total time elapsed                =  1.7835E+01 seconds\n",
+      " Calculation Rate (inactive)       =  3679.72 neutrons/second\n",
+      " Calculation Rate (active)         =  2735.03 neutrons/second\n",
       "\n",
       " ============================>     RESULTS     <============================\n",
       "\n",
@@ -810,7 +800,7 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>0</td>\n",
+       "      <td>0.0</td>\n",
        "      <td>6.250000e-07</td>\n",
        "      <td>total</td>\n",
        "      <td>absorption</td>\n",
@@ -872,7 +862,7 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>0</td>\n",
+       "      <td>0.0</td>\n",
        "      <td>6.250000e-07</td>\n",
        "      <td>total</td>\n",
        "      <td>nu-fission</td>\n",
@@ -936,7 +926,7 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>0</td>\n",
+       "      <td>0.0</td>\n",
        "      <td>6.250000e-07</td>\n",
        "      <td>10000</td>\n",
        "      <td>total</td>\n",
@@ -1002,7 +992,7 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>0</td>\n",
+       "      <td>0.0</td>\n",
        "      <td>6.250000e-07</td>\n",
        "      <td>10000</td>\n",
        "      <td>total</td>\n",
@@ -1067,7 +1057,7 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>0</td>\n",
+       "      <td>0.0</td>\n",
        "      <td>6.250000e-07</td>\n",
        "      <td>10000</td>\n",
        "      <td>total</td>\n",
@@ -1610,21 +1600,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.5.1"
   }
  },
  "nbformat": 4,

--- a/docs/source/pythonapi/examples/tally-arithmetic.ipynb
+++ b/docs/source/pythonapi/examples/tally-arithmetic.ipynb
@@ -126,11 +126,8 @@
    },
    "outputs": [],
    "source": [
-    "# Instantiate a Materials object, add Materials\n",
-    "materials_file = openmc.Materials()\n",
-    "materials_file.add_material(fuel)\n",
-    "materials_file.add_material(water)\n",
-    "materials_file.add_material(zircaloy)\n",
+    "# Instantiate a Materials collection\n",
+    "materials_file = openmc.Materials((fuel, water, zircaloy))\n",
     "materials_file.default_xs = '71c'\n",
     "\n",
     "# Export to \"materials.xml\"\n",
@@ -321,9 +318,8 @@
     "plot.pixels = [250, 250]\n",
     "plot.color = 'mat'\n",
     "\n",
-    "# Instantiate a Plots object, add Plot, and export to \"plots.xml\"\n",
-    "plot_file = openmc.Plots()\n",
-    "plot_file.add_plot(plot)\n",
+    "# Instantiate a Plots collection and export to \"plots.xml\"\n",
+    "plot_file = openmc.Plots([plot])\n",
     "plot_file.export_to_xml()"
    ]
   },
@@ -421,7 +417,7 @@
     "tally.filters = [openmc.Filter(type='cell', bins=[fuel_cell.id, moderator_cell.id])]\n",
     "tally.filters.append(energy_filter)\n",
     "tally.scores = ['flux']\n",
-    "tallies_file.add_tally(tally)\n",
+    "tallies_file.append(tally)\n",
     "\n",
     "# Instantiate reaction rate Tally in fuel\n",
     "tally = openmc.Tally(name='fuel rxn rates')\n",
@@ -429,7 +425,7 @@
     "tally.filters.append(energy_filter)\n",
     "tally.scores = ['nu-fission', 'scatter']\n",
     "tally.nuclides = [u238, u235]\n",
-    "tallies_file.add_tally(tally)\n",
+    "tallies_file.append(tally)\n",
     "\n",
     "# Instantiate reaction rate Tally in moderator\n",
     "tally = openmc.Tally(name='moderator rxn rates')\n",
@@ -437,7 +433,7 @@
     "tally.filters.append(energy_filter)\n",
     "tally.scores = ['absorption', 'total']\n",
     "tally.nuclides = [o16, h1]\n",
-    "tallies_file.add_tally(tally)"
+    "tallies_file.append(tally)"
    ]
   },
   {
@@ -453,8 +449,7 @@
     "abs_rate = openmc.Tally(name='abs. rate')\n",
     "fiss_rate.scores = ['nu-fission']\n",
     "abs_rate.scores = ['absorption']\n",
-    "tallies_file.add_tally(fiss_rate)\n",
-    "tallies_file.add_tally(abs_rate)"
+    "tallies_file += (fiss_rate, abs_rate)",
    ]
   },
   {
@@ -469,7 +464,7 @@
     "therm_abs_rate = openmc.Tally(name='therm. abs. rate')\n",
     "therm_abs_rate.scores = ['absorption']\n",
     "therm_abs_rate.filters = [openmc.Filter(type='energy', bins=[0., 0.625e-6])]\n",
-    "tallies_file.add_tally(therm_abs_rate)"
+    "tallies_file.append(therm_abs_rate)"
    ]
   },
   {
@@ -485,7 +480,7 @@
     "fuel_therm_abs_rate.scores = ['absorption']\n",
     "fuel_therm_abs_rate.filters = [openmc.Filter(type='energy', bins=[0., 0.625e-6]),\n",
     "                               openmc.Filter(type='cell', bins=[fuel_cell.id])]\n",
-    "tallies_file.add_tally(fuel_therm_abs_rate)"
+    "tallies_file.append(fuel_therm_abs_rate)"
    ]
   },
   {
@@ -500,7 +495,7 @@
     "therm_fiss_rate = openmc.Tally(name='therm. fiss. rate')\n",
     "therm_fiss_rate.scores = ['nu-fission']\n",
     "therm_fiss_rate.filters = [openmc.Filter(type='energy', bins=[0., 0.625e-6])]\n",
-    "tallies_file.add_tally(therm_fiss_rate)"
+    "tallies_file.append(therm_fiss_rate)"
    ]
   },
   {
@@ -520,7 +515,7 @@
     "tally.filters.append(energy_filter)\n",
     "tally.scores = ['nu-fission', 'scatter']\n",
     "tally.nuclides = [h1, u238]\n",
-    "tallies_file.add_tally(tally)"
+    "tallies_file.append(tally)"
    ]
   },
   {

--- a/examples/python/basic/build-xml.py
+++ b/examples/python/basic/build-xml.py
@@ -31,10 +31,9 @@ fuel = openmc.Material(material_id=40, name='fuel')
 fuel.set_density('g/cc', 4.5)
 fuel.add_nuclide(u235, 1.)
 
-# Instantiate a Materials collection, register all Materials, and export to XML
-materials_file = openmc.Materials()
+# Instantiate a Materials collection and export to XML
+materials_file = openmc.Materials([moderator, fuel])
 materials_file.default_xs = '71c'
-materials_file.add_materials([moderator, fuel])
 materials_file.export_to_xml()
 
 
@@ -124,9 +123,6 @@ third_tally = openmc.Tally(tally_id=3, name='third tally')
 third_tally.filters = [cell_filter, energy_filter, energyout_filter]
 third_tally.scores = ['scatter', 'nu-scatter', 'nu-fission']
 
-# Instantiate a Tallies collection, register all Tallies, and export to XML
-tallies_file = openmc.Tallies()
-tallies_file.add_tally(first_tally)
-tallies_file.add_tally(second_tally)
-tallies_file.add_tally(third_tally)
+# Instantiate a Tallies collection and export to XML
+tallies_file = openmc.Tallies((first_tally, second_tally, third_tally))
 tallies_file.export_to_xml()

--- a/examples/python/boxes/build-xml.py
+++ b/examples/python/boxes/build-xml.py
@@ -36,10 +36,9 @@ moderator.add_nuclide(h1, 2.)
 moderator.add_nuclide(o16, 1.)
 moderator.add_s_alpha_beta('HH2O', '71t')
 
-# Instantiate a Materials collection, register all Materials, and export to XML
-materials_file = openmc.Materials()
+# Instantiate a Materials collection and export to XML
+materials_file = openmc.Materials([fuel1, fuel2, moderator])
 materials_file.default_xs = '71c'
-materials_file.add_materials([fuel1, fuel2, moderator])
 materials_file.export_to_xml()
 
 
@@ -129,7 +128,6 @@ plot.width = [20, 20]
 plot.pixels = [200, 200]
 plot.color = 'cell'
 
-# Instantiate a Plots collection, add Plot, and export to XML
-plot_file = openmc.Plots()
-plot_file.add_plot(plot)
+# Instantiate a Plots collection and export to XML
+plot_file = openmc.Plots([plot])
 plot_file.export_to_xml()

--- a/examples/python/lattice/hexagonal/build-xml.py
+++ b/examples/python/lattice/hexagonal/build-xml.py
@@ -35,10 +35,9 @@ iron = openmc.Material(material_id=3, name='iron')
 iron.set_density('g/cc', 7.9)
 iron.add_nuclide(fe56, 1.)
 
-# Instantiate a Materials collection, register all Materials, and export to XML
-materials_file = openmc.Materials()
+# Instantiate a Materials collection and export to XML
+materials_file = openmc.Materials([moderator, fuel, iron])
 materials_file.default_xs = '71c'
-materials_file.add_materials([moderator, fuel, iron])
 materials_file.export_to_xml()
 
 
@@ -152,9 +151,7 @@ plot_yz.pixels = [400, 400]
 plot_yz.color = 'mat'
 
 # Instantiate a Plots collection, add plots, and export to XML
-plot_file = openmc.Plots()
-plot_file.add_plot(plot_xy)
-plot_file.add_plot(plot_yz)
+plot_file = openmc.Plots((plot_xy, plot_yz))
 plot_file.export_to_xml()
 
 
@@ -167,7 +164,6 @@ tally = openmc.Tally(tally_id=1)
 tally.filters = [openmc.Filter(type='distribcell', bins=[cell2.id])]
 tally.scores = ['total']
 
-# Instantiate a Tallies collection, register Tally/Mesh, and export to XML
-tallies_file = openmc.Tallies()
-tallies_file.add_tally(tally)
+# Instantiate a Tallies collection and export to XML
+tallies_file = openmc.Tallies([tally])
 tallies_file.export_to_xml()

--- a/examples/python/lattice/nested/build-xml.py
+++ b/examples/python/lattice/nested/build-xml.py
@@ -30,10 +30,9 @@ moderator.add_nuclide(h1, 2.)
 moderator.add_nuclide(o16, 1.)
 moderator.add_s_alpha_beta('HH2O', '71t')
 
-# Instantiate a Materials collection, register all Materials, and export to XML
-materials_file = openmc.Materials()
+# Instantiate a Materials collection and export to XML
+materials_file = openmc.Materials((moderator, fuel))
 materials_file.default_xs = '71c'
-materials_file.add_materials([moderator, fuel])
 materials_file.export_to_xml()
 
 
@@ -150,9 +149,8 @@ plot.width = [4, 4]
 plot.pixels = [400, 400]
 plot.color = 'mat'
 
-# Instantiate a Plots object, add Plot, and export to XML
-plot_file = openmc.Plots()
-plot_file.add_plot(plot)
+# Instantiate a Plots object and export to XML
+plot_file = openmc.Plots([plot])
 plot_file.export_to_xml()
 
 
@@ -177,7 +175,5 @@ tally.filters = [mesh_filter]
 tally.scores = ['total']
 
 # Instantiate a Tallies collection, register Tally/Mesh, and export to XML
-tallies_file = openmc.Tallies()
-tallies_file.add_mesh(mesh)
-tallies_file.add_tally(tally)
+tallies_file = openmc.Tallies([tally])
 tallies_file.export_to_xml()

--- a/examples/python/lattice/simple/build-xml.py
+++ b/examples/python/lattice/simple/build-xml.py
@@ -30,10 +30,9 @@ moderator.add_nuclide(h1, 2.)
 moderator.add_nuclide(o16, 1.)
 moderator.add_s_alpha_beta('HH2O', '71t')
 
-# Instantiate a Materials collection, register all Materials, and export to XML
-materials_file = openmc.Materials()
+# Instantiate a Materials collection and export to XML
+materials_file = openmc.Materials([moderator, fuel])
 materials_file.default_xs = '71c'
-materials_file.add_materials([moderator, fuel])
 materials_file.export_to_xml()
 
 
@@ -142,9 +141,8 @@ plot.width = [4, 4]
 plot.pixels = [400, 400]
 plot.color = 'mat'
 
-# Instantiate a Plots collection, add Plot, and export to XML
-plot_file = openmc.Plots()
-plot_file.add_plot(plot)
+# Instantiate a Plots collection and export to XML
+plot_file = openmc.Plots([plot])
 plot_file.export_to_xml()
 
 
@@ -173,8 +171,6 @@ tally.filters = [mesh_filter]
 tally.scores = ['total']
 tally.triggers = [trigger]
 
-# Instantiate a Tallies collection, register Tally/Mesh, and export to XML
-tallies_file = openmc.Tallies()
-tallies_file.add_mesh(mesh)
-tallies_file.add_tally(tally)
+# Instantiate a Tallies collection and export to XML
+tallies_file = openmc.Tallies([tally])
 tallies_file.export_to_xml()

--- a/examples/python/pincell/build-xml.py
+++ b/examples/python/pincell/build-xml.py
@@ -100,10 +100,9 @@ borated_water.add_nuclide(o16, 2.4672e-2)
 borated_water.add_nuclide(o17, 6.0099e-5)
 borated_water.add_s_alpha_beta('HH2O', '71t')
 
-# Instantiate a Materials collection, register all Materials, and export to XML
-materials_file = openmc.Materials()
+# Instantiate a Materials collection and export to XML
+materials_file = openmc.Materials([uo2, helium, zircaloy, borated_water])
 materials_file.default_xs = '71c'
-materials_file.add_materials([uo2, helium, zircaloy, borated_water])
 materials_file.export_to_xml()
 
 
@@ -197,8 +196,6 @@ tally = openmc.Tally(tally_id=1, name='tally 1')
 tally.filters = [energy_filter, mesh_filter]
 tally.scores = ['flux', 'fission', 'nu-fission']
 
-# Instantiate a Tallies collection, register all Tallies, and export to XML
-tallies_file = openmc.Tallies()
-tallies_file.add_mesh(mesh)
-tallies_file.add_tally(tally)
+# Instantiate a Tallies collection and export to XML
+tallies_file = openmc.Tallies([tally])
 tallies_file.export_to_xml()

--- a/examples/python/pincell_multigroup/build-xml.py
+++ b/examples/python/pincell_multigroup/build-xml.py
@@ -81,10 +81,9 @@ water = openmc.Material(material_id=2, name='Water')
 water.set_density('macro', 1.0)
 water.add_macroscopic(h2o_data)
 
-# Instantiate a Materials collection, register all Materials, and export to XML
-materials_file = openmc.Materials()
+# Instantiate a Materials collection and export to XML
+materials_file = openmc.Materials([uo2, water])
 materials_file.default_xs = '300K'
-materials_file.add_materials([uo2, water])
 materials_file.export_to_xml()
 
 
@@ -167,14 +166,9 @@ mesh_filter.mesh = mesh
 
 # Instantiate the Tally
 tally = openmc.Tally(tally_id=1, name='tally 1')
-tally.add_filter(energy_filter)
-tally.add_filter(mesh_filter)
-tally.add_score('flux')
-tally.add_score('fission')
-tally.add_score('nu-fission')
+tally.filters = [energy_filter, mesh_filter]
+tally.scores = ['flux', 'fission', 'nu-fission']
 
 # Instantiate a Tallies collection, register all Tallies, and export to XML
-tallies_file = openmc.Tallies()
-tallies_file.add_mesh(mesh)
-tallies_file.add_tally(tally)
+tallies_file = openmc.Tallies([tally])
 tallies_file.export_to_xml()

--- a/examples/python/reflective/build-xml.py
+++ b/examples/python/reflective/build-xml.py
@@ -23,10 +23,9 @@ fuel = openmc.Material(material_id=1, name='fuel')
 fuel.set_density('g/cc', 4.5)
 fuel.add_nuclide(u235, 1.)
 
-# Instantiate a Materials collection, register Material, and export to XML
-materials_file = openmc.Materials()
+# Instantiate a Materials collection and export to XML
+materials_file = openmc.Materials([fuel])
 materials_file.default_xs = '71c'
-materials_file.add_material(fuel)
 materials_file.export_to_xml()
 
 

--- a/openmc/checkvalue.py
+++ b/openmc/checkvalue.py
@@ -1,3 +1,4 @@
+import copy
 from collections import Iterable
 from numbers import Integral, Real
 
@@ -57,7 +58,7 @@ def check_type(name, value, expected_type, expected_iter_type=None):
         else:
             msg = 'Unable to set "{0}" to "{1}" which is not of type "{2}"'.format(
                 name, value, expected_type.__name__)
-        raise ValueError(msg)
+        raise TypeError(msg)
 
     if expected_iter_type:
         for item in value:
@@ -71,7 +72,7 @@ def check_type(name, value, expected_type, expected_iter_type=None):
                     msg = 'Unable to set "{0}" to "{1}" since each item must be ' \
                           'of type "{2}"'.format(name, value,
                                                  expected_iter_type.__name__)
-                raise ValueError(msg)
+                raise TypeError(msg)
 
 
 def check_iterable_type(name, value, expected_type, min_depth=1, max_depth=1):
@@ -122,7 +123,7 @@ def check_iterable_type(name, value, expected_type, min_depth=1, max_depth=1):
             if len(tree) < min_depth:
                 msg = 'Error setting "{0}": The item at {1} does not meet the '\
                       'minimum depth of {2}'.format(name, ind_str, min_depth)
-                raise ValueError(msg)
+                raise TypeError(msg)
 
             # This item is okay.  Move on to the next item.
             index[-1] += 1
@@ -140,7 +141,7 @@ def check_iterable_type(name, value, expected_type, min_depth=1, max_depth=1):
                     msg = 'Error setting {0}: Found an iterable at {1}, items '\
                           'in that iterable exceed the maximum depth of {2}' \
                           .format(name, ind_str, max_depth)
-                    raise ValueError(msg)
+                    raise TypeError(msg)
 
             else:
                 # This item is completely unexpected.
@@ -148,7 +149,7 @@ def check_iterable_type(name, value, expected_type, min_depth=1, max_depth=1):
                       "item at {2} is of type '{3}'"\
                       .format(name, expected_type.__name__, ind_str,
                               type(current_item).__name__)
-                raise ValueError(msg)
+                raise TypeError(msg)
 
 
 def check_length(name, value, length_min, length_max=None):
@@ -277,6 +278,21 @@ class CheckedList(list):
         self.name = name
         for item in items:
             self.append(item)
+
+    def __add__(self, other):
+        new_instance = copy.copy(self)
+        new_instance += other
+        return new_instance
+
+    def __radd__(self, other):
+        return self + other
+
+    def __iadd__(self, other):
+        check_type('CheckedList add operand', other, Iterable,
+                   self.expected_type)
+        for item in other:
+            self.append(item)
+        return self
 
     def append(self, item):
         """Append item to list

--- a/openmc/mgxs/library.py
+++ b/openmc/mgxs/library.py
@@ -370,7 +370,7 @@ class Library(object):
             for mgxs_type in self.mgxs_types:
                 mgxs = self.get_mgxs(domain, mgxs_type)
                 for tally_id, tally in mgxs.tallies.items():
-                    tallies_file.add_tally(tally, merge=merge)
+                    tallies_file.append(tally, merge=merge)
 
     def load_from_statepoint(self, statepoint):
         """Extracts tallies in an OpenMC StatePoint with the data needed to

--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -2,6 +2,7 @@ from collections import Iterable
 from numbers import Real, Integral
 from xml.etree import ElementTree as ET
 import sys
+import warnings
 
 import numpy as np
 
@@ -401,18 +402,38 @@ class Plot(object):
         return element
 
 
-class Plots(object):
-    """Collection of Plots used for an OpenMC simulation. Corresponds directly to
-    the plots.xml input file.
+class Plots(cv.CheckedList):
+    """Collection of Plots used for an OpenMC simulation.
+
+    This class corresponds directly to the plots.xml input file. It can be
+    thought of as a normal Python list where each member is a :class:`Plot`. It
+    behaves like a list as the following example demonstrates:
+
+    >>> xz_plot = openmc.Plot()
+    >>> big_plot = openmc.Plot()
+    >>> small_plot = openmc.Plot()
+    >>> p = openmc.Plots((xz_plot, big_plot))
+    >>> p.append(small_plot)
+    >>> small_plot = p.pop()
+
+    Parameters
+    ----------
+    plots : Iterable of openmc.Plot
+        Plots to add to the collection
 
     """
 
-    def __init__(self):
-        self._plots = []
+    def __init__(self, plots=None):
+        super(Plots, self).__init__(Plot, 'plots collection')
         self._plots_file = ET.Element("plots")
+        if plots is not None:
+            self += plots
 
     def add_plot(self, plot):
         """Add a plot to the file.
+
+        .. deprecated:: 0.8
+            Use :meth:`Plots.append` instead.
 
         Parameters
         ----------
@@ -420,15 +441,40 @@ class Plots(object):
             Plot to add
 
         """
+        warnings.warn("Plots.add_plot(...) has been deprecated and may be "
+                      "removed in a future version. Use Plots.append(...) "
+                      "instead.", DeprecationWarning)
+        self.append(plot)
 
-        if not isinstance(plot, Plot):
-            msg = 'Unable to add a non-Plot "{0}" to the Plots instance'.format(plot)
-            raise ValueError(msg)
+    def append(self, plot):
+        """Append plot to collection
 
-        self._plots.append(plot)
+        Parameters
+        ----------
+        plot : openmc.Plot
+            Plot to append
+
+        """
+        super(Plots, self).append(plot)
+
+    def insert(self, index, plot):
+        """Insert plot before index
+
+        Parameters
+        ----------
+        index : int
+            Index in list
+        plot : openmc.Plot
+            Plot to insert
+
+        """
+        super(Plots, self).insert(index, plot)
 
     def remove_plot(self, plot):
         """Remove a plot from the file.
+
+        .. deprecated:: 0.8
+            Use :meth:`Plots.remove` instead.
 
         Parameters
         ----------
@@ -436,8 +482,10 @@ class Plots(object):
             Plot to remove
 
         """
-
-        self._plots.remove(plot)
+        warnings.warn("Plots.remove_plot(...) has been deprecated and may be "
+                      "removed in a future version. Use Plots.remove(...) "
+                      "instead.", DeprecationWarning)
+        self.remove(plot)
 
     def colorize(self, geometry, seed=1):
         """Generate a consistent color scheme for each domain in each plot.
@@ -455,7 +503,7 @@ class Plots(object):
 
         """
 
-        for plot in self._plots:
+        for plot in self:
             plot.colorize(geometry, seed)
 
 
@@ -481,11 +529,11 @@ class Plots(object):
 
         """
 
-        for plot in self._plots:
+        for plot in self:
             plot.highlight_domains(geometry, domains, seed, alpha, background)
 
     def _create_plot_subelements(self):
-        for plot in self._plots:
+        for plot in self:
             xml_element = plot.get_plot_xml()
 
             if len(plot._name) > 0:

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -3419,65 +3419,108 @@ class Tally(object):
         return new_tally
 
 
-class Tallies(object):
-    """Collection of Tallies used for an OpenMC simulation. Corresponds directly to
-    the tallies.xml input file.
+class Tallies(cv.CheckedList):
+    """Collection of Tallies used for an OpenMC simulation.
+
+    This class corresponds directly to the tallies.xml input file. It can be
+    thought of as a normal Python list where each member is a :class:`Tally`. It
+    behaves like a list as the following example demonstrates:
+
+    >>> t1 = openmc.Tally()
+    >>> t2 = openmc.Tally()
+    >>> t3 = openmc.Tally()
+    >>> tallies = openmc.Tallies([t1])
+    >>> tallies.append(t2)
+    >>> tallies += [t3]
+
+    Parameters
+    ----------
+    tallies : Iterable of openmc.Tally
+        Tallies to add to the collection
 
     """
 
-    def __init__(self):
-        self._tallies = []
-        self._meshes = []
+    def __init__(self, tallies=None):
+        super(Tallies, self).__init__(Tally, 'tallies collection')
         self._tallies_file = ET.Element("tallies")
-
-    @property
-    def tallies(self):
-        return self._tallies
-
-    @property
-    def meshes(self):
-        return self._meshes
+        if tallies is not None:
+            self += tallies
 
     def add_tally(self, tally, merge=False):
-        """Add a tally to the file
+        """Append tally to collection
+
+        .. deprecated:: 0.8
+            Use :meth:`Tallies.append` instead.
 
         Parameters
         ----------
         tally : openmc.Tally
-            Tally to add to file
+            Tally to add
         merge : bool
             Indicate whether the tally should be merged with an existing tally,
             if possible. Defaults to False.
 
         """
+        warnings.warn("Tallies.add_tally(...) has been deprecated and may be "
+                      "removed in a future version. Use Tallies.append(...) "
+                      "instead.", DeprecationWarning)
+        self.append(tally, merge)
 
+    def append(self, tally, merge=False):
+        """Append tally to collection
+
+        Parameters
+        ----------
+        tally : openmc.Tally
+            Tally to append
+        merge : bool
+            Indicate whether the tally should be merged with an existing tally,
+            if possible. Defaults to False.
+
+        """
         if not isinstance(tally, Tally):
             msg = 'Unable to add a non-Tally "{0}" to the Tallies instance'.format(tally)
-            raise ValueError(msg)
+            raise TypeError(msg)
 
         if merge:
             merged = False
 
             # Look for a tally to merge with this one
-            for i, tally2 in enumerate(self._tallies):
+            for i, tally2 in enumerate(self):
 
                 # If a mergeable tally is found
                 if tally2.can_merge(tally):
                     # Replace tally 2 with the merged tally
                     merged_tally = tally2.merge(tally)
-                    self._tallies[i] = merged_tally
+                    self[i] = merged_tally
                     merged = True
                     break
 
             # If not mergeable tally was found, simply add this tally
             if not merged:
-                self._tallies.append(tally)
+                super(Tallies, self).append(tally)
 
         else:
-            self._tallies.append(tally)
+            super(Tallies, self).append(tally)
+
+    def insert(self, index, item):
+        """Insert tally before index
+
+        Parameters
+        ----------
+        index : int
+            Index in list
+        item : openmc.Tally
+            Tally to insert
+
+        """
+        super(Tallies, self).insert(index, item)
 
     def remove_tally(self, tally):
-        """Remove a tally from the file
+        """Remove a tally from the collection
+
+        .. deprecated:: 0.8
+            Use :meth:`Tallies.remove` instead.
 
         Parameters
         ----------
@@ -3485,8 +3528,11 @@ class Tallies(object):
             Tally to remove
 
         """
+        warnings.warn("Tallies.remove_tally(...) has been deprecated and may "
+                      "be removed in a future version. Use Tallies.remove(...) "
+                      "instead.", DeprecationWarning)
 
-        self._tallies.remove(tally)
+        self.remove(tally)
 
     def merge_tallies(self):
         """Merge any mergeable tallies together. Note that n-way merges are
@@ -3494,8 +3540,8 @@ class Tallies(object):
 
         """
 
-        for i, tally1 in enumerate(self._tallies):
-            for j, tally2 in enumerate(self._tallies):
+        for i, tally1 in enumerate(self):
+            for j, tally2 in enumerate(self):
                 # Do not merge the same tally with itself
                 if i == j:
                     continue
@@ -3504,16 +3550,20 @@ class Tallies(object):
                 if tally1.can_merge(tally2):
                     # Replace tally 1 with the merged tally
                     merged_tally = tally1.merge(tally2)
-                    self._tallies[i] = merged_tally
+                    self[i] = merged_tally
 
                     # Remove tally 2 since it is no longer needed
-                    self._tallies.pop(j)
+                    self.pop(j)
 
                     # Continue iterating from the first loop
                     break
 
     def add_mesh(self, mesh):
         """Add a mesh to the file
+
+        .. deprecated:: 0.8
+            Meshes that appear in a tally are automatically added to the
+            collection.
 
         Parameters
         ----------
@@ -3522,14 +3572,16 @@ class Tallies(object):
 
         """
 
-        if not isinstance(mesh, Mesh):
-            msg = 'Unable to add a non-Mesh "{0}" to the Tallies instance'.format(mesh)
-            raise ValueError(msg)
-
-        self._meshes.append(mesh)
+        warnings.warn("Tallies.add_mesh(...) has been deprecated and may be "
+                      "removed in a future version. Meshes that appear in a "
+                      "tally are automatically added to the collection.",
+                      DeprecationWarning)
 
     def remove_mesh(self, mesh):
         """Remove a mesh from the file
+
+        .. deprecated:: 0.8
+            Meshes do not need to be managed explicitly.
 
         Parameters
         ----------
@@ -3537,21 +3589,26 @@ class Tallies(object):
             Mesh to remove from the file
 
         """
-
-        self._meshes.remove(mesh)
+        warnings.warn("Tallies.remove_mesh(...) has been deprecated and may be "
+                      "removed in a future version. Meshes do not need to be "
+                      "managed explicitly.", DeprecationWarning)
 
     def _create_tally_subelements(self):
-        for tally in self._tallies:
+        for tally in self:
             xml_element = tally.get_tally_xml()
             self._tallies_file.append(xml_element)
 
     def _create_mesh_subelements(self):
-        for mesh in self._meshes:
-            if len(mesh._name) > 0:
-                self._tallies_file.append(ET.Comment(mesh._name))
+        already_written = set()
+        for tally in self:
+            for f in tally.filters:
+                if f.type == 'mesh' and f.mesh not in already_written:
+                    if len(f.mesh.name) > 0:
+                        self._tallies_file.append(ET.Comment(f.mesh.name))
 
-            xml_element = mesh.get_mesh_xml()
-            self._tallies_file.append(xml_element)
+                    xml_element = f.mesh.get_mesh_xml()
+                    self._tallies_file.append(xml_element)
+                    already_written.add(f.mesh)
 
     def export_to_xml(self):
         """Create a tallies.xml file that can be used for a simulation.

--- a/tests/input_set.py
+++ b/tests/input_set.py
@@ -267,9 +267,9 @@ class InputSet(object):
 
         # Define the materials file.
         self.materials.default_xs = '71c'
-        self.materials.add_materials((fuel, clad, cold_water, hot_water,
-             rpv_steel, lower_rad_ref, upper_rad_ref, bot_plate, bot_nozzle,
-             top_nozzle, top_fa, bot_fa))
+        self.materials += (fuel, clad, cold_water, hot_water, rpv_steel,
+                           lower_rad_ref, upper_rad_ref, bot_plate,
+                           bot_nozzle, top_nozzle, top_fa, bot_fa)
 
         # Define surfaces.
         s1 = openmc.ZCylinder(R=0.41, surface_id=1)
@@ -590,7 +590,7 @@ class MGInputSet(InputSet):
 
         # Define the materials file.
         self.materials.default_xs = '71c'
-        self.materials.add_materials((uo2, clad, water))
+        self.materials += (uo2, clad, water)
 
         # Define surfaces.
 

--- a/tests/test_asymmetric_lattice/test_asymmetric_lattice.py
+++ b/tests/test_asymmetric_lattice/test_asymmetric_lattice.py
@@ -54,12 +54,11 @@ class AsymmetricLatticeTestHarness(PyAPITestHarness):
 
         # Initialize the tallies
         tally = openmc.Tally(name='distribcell tally', tally_id=27)
-        tally.add_filter(distrib_filter)
-        tally.add_score('nu-fission')
+        tally.filters.append(distrib_filter)
+        tally.scores.append('nu-fission')
 
         # Initialize the tallies file
-        tallies_file = openmc.Tallies()
-        tallies_file.add_tally(tally)
+        tallies_file = openmc.Tallies([tally])
 
         # Assign the tallies file to the input set
         self._input_set.tallies = tallies_file

--- a/tests/test_distribmat/test_distribmat.py
+++ b/tests/test_distribmat/test_distribmat.py
@@ -28,9 +28,8 @@ class DistribmatTestHarness(PyAPITestHarness):
         light_fuel.set_density('g/cc', 2.0)
         light_fuel.add_nuclide('U-235', 1.0)
 
-        mats_file = openmc.Materials()
+        mats_file = openmc.Materials([moderator, dense_fuel, light_fuel])
         mats_file.default_xs = '71c'
-        mats_file.add_materials([moderator, dense_fuel, light_fuel])
         mats_file.export_to_xml()
 
 

--- a/tests/test_mg_max_order/test_mg_max_order.py
+++ b/tests/test_mg_max_order/test_mg_max_order.py
@@ -27,7 +27,7 @@ class MGNuclideInputSet(MGInputSet):
 
         # Define the materials file.
         self.materials.default_xs = '71c'
-        self.materials.add_materials((uo2, clad, water))
+        self.materials += (uo2, clad, water)
 
         # Define surfaces.
 

--- a/tests/test_mg_nuclide/test_mg_nuclide.py
+++ b/tests/test_mg_nuclide/test_mg_nuclide.py
@@ -26,7 +26,7 @@ class MGNuclideInputSet(MGInputSet):
 
         # Define the materials file.
         self.materials.default_xs = '71c'
-        self.materials.add_materials((uo2, clad, water))
+        self.materials += (uo2, clad, water)
 
         # Define surfaces.
 

--- a/tests/test_mg_tallies/test_mg_tallies.py
+++ b/tests/test_mg_tallies/test_mg_tallies.py
@@ -27,24 +27,15 @@ class MGTalliesTestHarness(PyAPITestHarness):
         mat_filter = openmc.Filter(type='material', bins=[1,2,3])
 
         tally1 = openmc.Tally(tally_id=1)
-        tally1.add_filter(mesh_filter)
-        tally1.add_score('total')
-        tally1.add_score('absorption')
-        tally1.add_score('flux')
-        tally1.add_score('fission')
-        tally1.add_score('nu-fission')
+        tally1.filters = [mesh_filter]
+        tally1.scores = ['total', 'absorption', 'flux',
+                         'fission', 'nu-fission']
 
         tally2 = openmc.Tally(tally_id=2)
-        tally2.add_filter(mat_filter)
-        tally2.add_filter(energy_filter)
-        tally2.add_filter(energyout_filter)
-        tally2.add_score('scatter')
-        tally2.add_score('nu-scatter')
+        tally2.filters = [mat_filter, energy_filter, energyout_filter]
+        tally2.scores = ['scatter', 'nu-scatter']
 
-        self._input_set.tallies = openmc.Tallies()
-        self._input_set.tallies.add_mesh(mesh)
-        self._input_set.tallies.add_tally(tally1)
-        self._input_set.tallies.add_tally(tally2)
+        self._input_set.tallies = openmc.Tallies([tally1, tally2])
 
         super(MGTalliesTestHarness, self)._build_inputs()
 

--- a/tests/test_resonance_scattering/test_resonance_scattering.py
+++ b/tests/test_resonance_scattering/test_resonance_scattering.py
@@ -17,9 +17,8 @@ class ResonanceScatteringTestHarness(PyAPITestHarness):
         mat.add_nuclide('Pu-239', 0.02)
         mat.add_nuclide('H-1', 20.0)
 
-        mats_file = openmc.Materials()
+        mats_file = openmc.Materials([mat])
         mats_file.default_xs = '71c'
-        mats_file.add_material(mat)
         mats_file.export_to_xml()
 
         # Geometry

--- a/tests/test_source/test_source.py
+++ b/tests/test_source/test_source.py
@@ -16,8 +16,7 @@ class SourceTestHarness(PyAPITestHarness):
         mat1 = openmc.Material(material_id=1)
         mat1.set_density('g/cm3', 4.5)
         mat1.add_nuclide(openmc.Nuclide('U-235', '71c'), 1.0)
-        materials = openmc.Materials()
-        materials.add_material(mat1)
+        materials = openmc.Materials([mat1])
         materials.export_to_xml()
 
         sphere = openmc.Sphere(surface_id=1, R=10.0, boundary_type='vacuum')

--- a/tests/test_tallies/test_tallies.py
+++ b/tests/test_tallies/test_tallies.py
@@ -42,7 +42,8 @@ class TalliesTestHarness(PyAPITestHarness):
         mesh_2x2.lower_left  = [-182.07, -182.07]
         mesh_2x2.upper_right = [182.07,  182.07]
         mesh_2x2.dimension = [2, 2]
-        mesh_filter = Filter(type='mesh', bins=(1,))
+        mesh_filter = Filter(type='mesh')
+        mesh_filter.mesh = mesh_2x2
         azimuthal_tally4 = Tally()
         azimuthal_tally4.filters = [azimuthal_filter2, mesh_filter]
         azimuthal_tally4.scores = ['flux']
@@ -171,32 +172,18 @@ class TalliesTestHarness(PyAPITestHarness):
         all_nuclide_tallies[0].estimator = 'collision'
 
         self._input_set.tallies = Tallies()
-        self._input_set.tallies.add_tally(azimuthal_tally1)
-        self._input_set.tallies.add_tally(azimuthal_tally2)
-        self._input_set.tallies.add_tally(azimuthal_tally3)
-        self._input_set.tallies.add_tally(azimuthal_tally4)
-        self._input_set.tallies.add_tally(cellborn_tally)
-        self._input_set.tallies.add_tally(dg_tally)
-        self._input_set.tallies.add_tally(energy_tally)
-        self._input_set.tallies.add_tally(energyout_tally)
-        self._input_set.tallies.add_tally(transfer_tally)
-        self._input_set.tallies.add_tally(material_tally)
-        self._input_set.tallies.add_tally(mu_tally1)
-        self._input_set.tallies.add_tally(mu_tally2)
-        self._input_set.tallies.add_tally(mu_tally3)
-        self._input_set.tallies.add_tally(polar_tally1)
-        self._input_set.tallies.add_tally(polar_tally2)
-        self._input_set.tallies.add_tally(polar_tally3)
-        self._input_set.tallies.add_tally(polar_tally4)
-        self._input_set.tallies.add_tally(universe_tally)
-        [self._input_set.tallies.add_tally(t) for t in score_tallies]
-        [self._input_set.tallies.add_tally(t) for t in flux_tallies]
-        self._input_set.tallies.add_tally(scatter_tally1)
-        self._input_set.tallies.add_tally(scatter_tally2)
-        [self._input_set.tallies.add_tally(t) for t in total_tallies]
-        self._input_set.tallies.add_tally(questionable_tally)
-        [self._input_set.tallies.add_tally(t) for t in all_nuclide_tallies]
-        self._input_set.tallies.add_mesh(mesh_2x2)
+        self._input_set.tallies += (
+            [azimuthal_tally1, azimuthal_tally2, azimuthal_tally3,
+             azimuthal_tally4, cellborn_tally, dg_tally, energy_tally,
+             energyout_tally, transfer_tally, material_tally, mu_tally1,
+             mu_tally2, mu_tally3, polar_tally1, polar_tally2, polar_tally3,
+             polar_tally4, universe_tally])
+        self._input_set.tallies += score_tallies
+        self._input_set.tallies += flux_tallies
+        self._input_set.tallies += (scatter_tally1, scatter_tally2)
+        self._input_set.tallies += total_tallies
+        self._input_set.tallies.append(questionable_tally)
+        self._input_set.tallies += all_nuclide_tallies
 
         self._input_set.export()
 

--- a/tests/test_tally_aggregation/test_tally_aggregation.py
+++ b/tests/test_tally_aggregation/test_tally_aggregation.py
@@ -15,9 +15,6 @@ class TallyAggregationTestHarness(PyAPITestHarness):
         # The summary.h5 file needs to be created to read in the tallies
         self._input_set.settings.output = {'summary': True}
 
-        # Initialize the tallies file
-        tallies_file = openmc.Tallies()
-
         # Initialize the nuclides
         u235 = openmc.Nuclide('U-235')
         u238 = openmc.Nuclide('U-238')
@@ -33,7 +30,7 @@ class TallyAggregationTestHarness(PyAPITestHarness):
         tally.filters = [energy_filter, distrib_filter]
         tally.scores = ['nu-fission', 'total']
         tally.nuclides = [u235, u238, pu239]
-        tallies_file.add_tally(tally)
+        tallies_file = openmc.Tallies([tally])
 
         # Export tallies to file
         self._input_set.tallies = tallies_file

--- a/tests/test_tally_arithmetic/test_tally_arithmetic.py
+++ b/tests/test_tally_arithmetic/test_tally_arithmetic.py
@@ -43,14 +43,13 @@ class TallyArithmeticTestHarness(PyAPITestHarness):
         tally.filters = [material_filter, energy_filter, distrib_filter]
         tally.scores = ['nu-fission', 'total']
         tally.nuclides = [u235, pu239]
-        tallies_file.add_tally(tally)
+        tallies_file.append(tally)
 
         tally = openmc.Tally(name='tally 2')
         tally.filters = [energy_filter, mesh_filter]
         tally.scores = ['total', 'fission']
         tally.nuclides = [u238, u235]
-        tallies_file.add_tally(tally)
-        tallies_file.add_mesh(mesh)
+        tallies_file.append(tally)
 
         # Export tallies to file
         self._input_set.tallies = tallies_file

--- a/tests/test_tally_slice_merge/test_tally_slice_merge.py
+++ b/tests/test_tally_slice_merge/test_tally_slice_merge.py
@@ -70,9 +70,7 @@ class TallySliceMergeTestHarness(PyAPITestHarness):
             distribcell_tally.add_nuclide(nuclide)
 
         # Add tallies to a Tallies object
-        tallies_file = openmc.Tallies()
-        tallies_file.add_tally(tallies[0])
-        tallies_file.add_tally(distribcell_tally)
+        tallies_file = openmc.Tallies((tallies[0], distribcell_tally))
 
         # Export tallies to file
         self._input_set.tallies = tallies_file


### PR DESCRIPTION
This pull request makes `Materials`, `Plots`, and `Tallies` behave like lists, e.g.
```Python
m1 = openmc.Material()
m2 = openmc.Material()
m34 = [openmc.Material(), openmc.Material()]
collection = openmc.Materials([m1])
collection.append(m2)
collection += m34
```
For tallies, there is now no need to add meshes directly; instead, `export_to_xml()` looks through all filters of all tallies and adds meshes to the XML file when needed. Under the hood, these classes are now subclasses of CheckedList, so all the usual type-checking benefits are there.

Tests, examples, and notebooks have all been updated accordingly.