### PR TITLE
Updated Jupyter Notebook Links on Website

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,7 +13,9 @@ OpenMC was originally developed by members of the `Computational Reactor Physics
 Group`_ at the `Massachusetts Institute of Technology`_ starting
 in 2011. Various universities, laboratories, and other organizations now
 contribute to the development of OpenMC. For more information on OpenMC, feel
-free to send a message to the User's Group `mailing list`_. Documentation for the latest version of the develop branch can be found on `Read the Docs`_.
+free to send a message to the User's Group `mailing list`_. Documentation for
+the latest developmental version of the develop branch can be found on
+`Read the Docs`_.
 
 .. _Computational Reactor Physics Group: http://crpg.mit.edu
 .. _Massachusetts Institute of Technology: http://web.mit.edu

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,11 +13,12 @@ OpenMC was originally developed by members of the `Computational Reactor Physics
 Group`_ at the `Massachusetts Institute of Technology`_ starting
 in 2011. Various universities, laboratories, and other organizations now
 contribute to the development of OpenMC. For more information on OpenMC, feel
-free to send a message to the User's Group `mailing list`_.
+free to send a message to the User's Group `mailing list`_. Documentation for the latest version of the develop branch can be found on `Read the Docs`_.
 
 .. _Computational Reactor Physics Group: http://crpg.mit.edu
 .. _Massachusetts Institute of Technology: http://web.mit.edu
 .. _mailing list: https://groups.google.com/forum/?fromgroups=#!forum/openmc-users
+.. _Read the Docs: http://openmc.readthedocs.io/en/latest/
 
 .. only:: html
 

--- a/docs/source/pythonapi/index.rst
+++ b/docs/source/pythonapi/index.rst
@@ -13,6 +13,20 @@ online. We recommend going through the modules from Codecademy_ and/or the
 `Scipy lectures`_. The full API documentation serves to provide more information
 on a given module or class.
 
+-------------------------
+Example Jupyter Notebooks
+-------------------------
+
+.. toctree::
+    :maxdepth: 1
+
+    examples/post-processing
+    examples/pandas-dataframes
+    examples/tally-arithmetic
+    examples/mgxs-part-i
+    examples/mgxs-part-ii
+    examples/mgxs-part-iii
+
 ------------------------------------
 :mod:`openmc` -- Basic Functionality
 ------------------------------------
@@ -270,20 +284,6 @@ Multi-group Cross Section Libraries
     :template: myclass.rst
 
     openmc.mgxs.Library
-
--------------------------
-Example Jupyter Notebooks
--------------------------
-
-.. toctree::
-    :maxdepth: 1
-
-    examples/post-processing
-    examples/pandas-dataframes
-    examples/tally-arithmetic
-    examples/mgxs-part-i
-    examples/mgxs-part-ii
-    examples/mgxs-part-iii
 
 .. _Jupyter: https://jupyter.org/
 .. _NumPy: http://www.numpy.org/


### PR DESCRIPTION
This PR moves the Jupyter Notebooks to the top of the Python API documentation as discussed in #432. In addition it adds a link to the Read the Docs site to the home page.