### PR TITLE
Fix python api errors when setting material density using 'sum'

### DIFF
--- a/docs/source/usersguide/input.rst
+++ b/docs/source/usersguide/input.rst
@@ -1215,11 +1215,11 @@ Each ``material`` element can have the following attributes or sub-elements:
     An element with attributes/sub-elements called ``value`` and ``units``. The
     ``value`` attribute is the numeric value of the density while the ``units``
     can be "g/cm3", "kg/m3", "atom/b-cm", "atom/cm3", or "sum". The "sum" unit
-    indicates that values appearing in ``ao`` attributes for ``<nuclide>`` and
-    ``<element>`` sub-elements are to be interpreted as nuclide/element
-    densities in atom/b-cm, and the total density of the material is taken as
+    indicates that values appearing in ``ao`` or ``wo`` attributes for ``<nuclide>`` and
+    ``<element>`` sub-elements are to be interpreted as absolute nuclide/element
+    densities in atom/b-cm or g/cm3, and the total density of the material is taken as
     the sum of all nuclides/elements. The "sum" option cannot be used in
-    conjunction with weight percents.  The "macro" unit is used with
+    conjunction with atom or weight percents.  The "macro" unit is used with
     a ``macroscopic`` quantity to indicate that the density is already included
     in the library and thus not needed here.  However, if a value is provided
     for the ``value``, then this is treated as a number density multiplier on

--- a/docs/source/usersguide/input.rst
+++ b/docs/source/usersguide/input.rst
@@ -1215,11 +1215,10 @@ Each ``material`` element can have the following attributes or sub-elements:
     An element with attributes/sub-elements called ``value`` and ``units``. The
     ``value`` attribute is the numeric value of the density while the ``units``
     can be "g/cm3", "kg/m3", "atom/b-cm", "atom/cm3", or "sum". The "sum" unit
-    indicates that values appearing in ``ao`` or ``wo`` attributes for ``<nuclide>`` and
-    ``<element>`` sub-elements are to be interpreted as absolute nuclide/element
-    densities in atom/b-cm or g/cm3, and the total density of the material is taken as
-    the sum of all nuclides/elements. The "sum" option cannot be used in
-    conjunction with atom or weight percents.  The "macro" unit is used with
+    indicates that values appearing in ``ao`` or ``wo`` attributes for ``<nuclide>``
+    and ``<element>`` sub-elements are to be interpreted as absolute nuclide/element
+    densities in atom/b-cm or g/cm3, and the total density of the material is
+    taken as the sum of all nuclides/elements. The "macro" unit is used with
     a ``macroscopic`` quantity to indicate that the density is already included
     in the library and thus not needed here.  However, if a value is provided
     for the ``value``, then this is treated as a number density multiplier on

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -245,18 +245,24 @@ class Material(object):
 
         """
 
-        cv.check_type('the density for Material ID="{0}"'.format(self._id),
-                      density, Real)
         cv.check_value('density units', units, DENSITY_UNITS)
-
-        if density is None and units is not 'sum':
-            msg = 'Unable to set the density for Material ID="{0}" ' \
-                  'because a density must be set when not using ' \
-                  'sum unit'.format(self._id)
-            raise ValueError(msg)
-
-        self._density = density
         self._density_units = units
+
+        if units is 'sum':
+            if density is not None:
+                msg = 'Density "{0}" for Material ID="{1}" is ignored ' \
+                      'because the unit is "sum"'.format(density, self._id)
+                warnings.warn(msg)
+        else:
+            if density is None:
+                msg = 'Unable to set the density for Material ID="{0}" ' \
+                      'because a density must be set when not using ' \
+                      '"sum" unit'.format(self._id)
+                raise ValueError(msg)
+
+            cv.check_type('the density for Material ID="{0}"'.format(self._id),
+                          density, Real)
+            self._density = density
 
     @distrib_otf_file.setter
     def distrib_otf_file(self, filename):

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -251,16 +251,16 @@ class Material(object):
         if units is 'sum':
             if density is not None:
                 msg = 'Density "{0}" for Material ID="{1}" is ignored ' \
-                      'because the unit is "sum"'.format(density, self._id)
+                      'because the unit is "sum"'.format(density, self.id)
                 warnings.warn(msg)
         else:
             if density is None:
                 msg = 'Unable to set the density for Material ID="{0}" ' \
-                      'because a density must be set when not using ' \
-                      '"sum" unit'.format(self._id)
+                      'because a density value must be given when not using ' \
+                      '"sum" unit'.format(self.id)
                 raise ValueError(msg)
 
-            cv.check_type('the density for Material ID="{0}"'.format(self._id),
+            cv.check_type('the density for Material ID="{0}"'.format(self.id),
                           density, Real)
             self._density = density
 


### PR DESCRIPTION
This PR tries to fix a python api error of setting material density using 'sum'. The error occurs as the `set_density` function checks `density` argument no matter if one uses the `unit` "sum".
An additional modification is made to the openmc input guide on "sum" material density as well, as it seems "mass density" i.e. `wo` for every nuclide/element can also be used to calculate the total density of a material. As there is no check in the code and `wo` does make sense to me, I choose to change the documentation.