### PR TITLE
Improve clarity of constructing hexagonal lattices

### DIFF
--- a/docs/source/pythonapi/index.rst
+++ b/docs/source/pythonapi/index.rst
@@ -122,6 +122,16 @@ Many of the above classes are derived from several abstract classes:
    openmc.Region
    openmc.Lattice
 
+One function is also available to create a hexagonal region defined by the
+intersection of six surface half-spaces.
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+   :template: myfunction.rst
+
+   openmc.make_hexagon_region
+
 Constructing Tallies
 --------------------
 

--- a/docs/source/usersguide/input.rst
+++ b/docs/source/usersguide/input.rst
@@ -1033,6 +1033,20 @@ Each ``<cell>`` element can have the following attributes or sub-elements:
 
         <cell fill="..." rotation="0 0 90" />
 
+    The rotation applied is an intrinsic rotation whose Tait-Bryan angles are
+    given as those specified about the x, y, and z axes respectively. That is to
+    say, if the angles are :math:`(\phi, \theta, \psi)`, then the rotation
+    matrix applied is :math:`R_z(\psi) R_y(\theta) R_x(\phi)` or
+
+    .. math::
+
+       \left [ \begin{array}{ccc} \cos\theta \cos\psi & -\cos\theta \sin\psi +
+       \sin\phi \sin\theta \cos\psi & \sin\phi \sin\psi + \cos\phi \sin\theta
+       \cos\psi \\ \cos\theta \sin\psi & \cos\phi \cos\psi + \sin\phi \sin\theta
+       \sin\psi & -\sin\phi \cos\psi + \cos\phi \sin\theta \sin\psi \\
+       -\sin\theta & \sin\phi \cos\theta & \cos\phi \cos\theta \end{array}
+       \right ]
+
     *Default*: None
 
   :translation:

--- a/openmc/cell.py
+++ b/openmc/cell.py
@@ -23,7 +23,7 @@ def reset_auto_cell_id():
 
 
 class Cell(object):
-    """A region of space defined as the intersection of half-space created by
+    r"""A region of space defined as the intersection of half-space created by
     quadric surfaces.
 
     Parameters
@@ -48,11 +48,24 @@ class Cell(object):
         Indicates what the region of space is filled with
     region : openmc.Region
         Region of space that is assigned to the cell.
-    rotation : numpy.ndarray
+    rotation : Iterable of float
         If the cell is filled with a universe, this array specifies the angles
         in degrees about the x, y, and z axes that the filled universe should be
-        rotated.
-    translation : numpy.ndarray
+        rotated. The rotation applied is an intrinsic rotation with specified
+        Tait-Bryan angles. That is to say, if the angles are :math:`(\phi,
+        \theta, \psi)`, then the rotation matrix applied is :math:`R_z(\psi)
+        R_y(\theta) R_x(\phi)` or
+
+        .. math::
+
+           \left [ \begin{array}{ccc} \cos\theta \cos\psi & -\cos\theta \sin\psi
+           + \sin\phi \sin\theta \cos\psi & \sin\phi \sin\psi + \cos\phi
+           \sin\theta \cos\psi \\ \cos\theta \sin\psi & \cos\phi \cos\psi +
+           \sin\phi \sin\theta \sin\psi & -\sin\phi \cos\psi + \cos\phi
+           \sin\theta \sin\psi \\ -\sin\theta & \sin\phi \cos\theta & \cos\phi
+           \cos\theta \end{array} \right ]
+
+    translation : Iterable of float
         If the cell is filled with a universe, this array specifies a vector
         that is used to translate (shift) the universe.
     offsets : ndarray

--- a/openmc/cell.py
+++ b/openmc/cell.py
@@ -243,6 +243,10 @@ class Cell(object):
 
     @rotation.setter
     def rotation(self, rotation):
+        if not isinstance(self.fill, openmc.Universe):
+            raise RuntimeError('Cell rotation can only be applied if the cell '
+                               'is filled with a Universe')
+
         cv.check_type('cell rotation', rotation, Iterable, Real)
         cv.check_length('cell rotation', rotation, 3)
         self._rotation = rotation

--- a/openmc/element.py
+++ b/openmc/element.py
@@ -1,7 +1,7 @@
 import sys
 
 import openmc
-from openmc.checkvalue import check_type
+from openmc.checkvalue import check_type, check_length
 from openmc.data import natural_abundance
 
 if sys.version_info[0] >= 3:
@@ -99,7 +99,8 @@ class Element(object):
 
     @name.setter
     def name(self, name):
-        check_type('name', name, basestring)
+        check_type('element name', name, basestring)
+        check_length('element name', name, 1, 2)
         self._name = name
 
     @scattering.setter

--- a/openmc/stats/multivariate.py
+++ b/openmc/stats/multivariate.py
@@ -328,8 +328,8 @@ class Point(Spatial):
 
     Parameters
     ----------
-    xyz : Iterable of float
-        Cartesian coordinates of location
+    xyz : Iterable of float, optional
+        Cartesian coordinates of location. Defaults to (0., 0., 0.).
 
     Attributes
     ----------
@@ -338,7 +338,7 @@ class Point(Spatial):
 
     """
 
-    def __init__(self, xyz):
+    def __init__(self, xyz=(0., 0., 0.)):
         super(Point, self).__init__()
         self.xyz = xyz
 

--- a/openmc/summary.py
+++ b/openmc/summary.py
@@ -267,7 +267,7 @@ class Summary(object):
                     rotation = \
                       self._f['geometry/cells'][key]['rotation'][...]
                     rotation = np.asarray(rotation, dtype=np.int)
-                    cell.rotation = rotation
+                    cell._rotation = rotation
 
             # Store Cell fill information for after Universe/Lattice creation
             self._cell_fills[index] = (fill_type, fill)

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -2,11 +2,12 @@ from abc import ABCMeta
 from numbers import Real, Integral
 from xml.etree import ElementTree as ET
 import sys
+from math import sqrt
 
 import numpy as np
 
 from openmc.checkvalue import check_type, check_value, check_greater_than
-from openmc.region import Region
+from openmc.region import Region, Intersection
 
 if sys.version_info[0] >= 3:
     basestring = str
@@ -1503,3 +1504,45 @@ class Halfspace(Region):
     def __str__(self):
         return '-' + str(self.surface.id) if self.side == '-' \
             else str(self.surface.id)
+
+
+def make_hexagon_region(edge_length=1., orientation='y'):
+    """Create a hexagon region from six surface planes.
+
+    Parameters
+    ----------
+    edge_length : float
+        Length of a side of the hexagon in cm
+    orientation : {'x', 'y'}
+        An 'x' orientation means that two sides of the hexagon are parallel to
+        the x-axis and a 'y' orientation means that two sides of the hexagon are
+        parallel to the y-axis.
+
+    Returns
+    -------
+    openmc.Region
+        The inside of a hexagonal prism
+
+    """
+
+    l = edge_length
+
+    if orientation == 'x':
+        right = XPlane(x0=sqrt(3.)/2.*l)
+        left = XPlane(x0=-sqrt(3.)/2.*l)
+        c = sqrt(3.)/3.
+        ur = Plane(A=c, B=1., D=l)  # y = -x/sqrt(3) + a
+        ul = Plane(A=-c, B=1., D=l)  # y = x/sqrt(3) + a
+        lr = Plane(A=-c, B=1., D=-l) # y = x/sqrt(3) - a
+        ll = Plane(A=c, B=1., D=-l)  # y = -x/sqrt(3) - a
+        return Intersection(-right, +left, -ur, -ul, +lr, +ll)
+
+    elif orientation == 'y':
+        top = YPlane(y0=sqrt(3.)/2.*l)
+        bottom = YPlane(y0=-sqrt(3.)/2.*l)
+        c = sqrt(3.)
+        ur = Plane(A=c, B=1., D=c*l)  # y = -sqrt(3)*(x - a)
+        lr = Plane(A=-c, B=1., D=-c*l)  # y = sqrt(3)*(x + a)
+        ll = Plane(A=c, B=1., D=-c*l) # y = -sqrt(3)*(x + a)
+        ul = Plane(A=-c, B=1., D=c*l)  # y = sqrt(3)*(x + a)
+        return Intersection(-top, +bottom, -ur, +lr, +ll, -ul)


### PR DESCRIPTION
A user recently asked me how to create a hexagonal lattice and I realized that it's not at all obvious from our Python API documentation how one assigns universes. I've tried to rectify this situation somewhat by being more descriptive about the `universes` property. I've also added a new `HexLattice.show_indices()` method which returns a diagram of the proper indices for the universes property, e.g. printing `HexLattice.show_indices(5)` would display
```
                        (0, 0)
                  (0,23)      (0, 1)
            (0,22)      (1, 0)      (0, 2)
      (0,21)      (1,17)      (1, 1)      (0, 3)
(0,20)      (1,16)      (2, 0)      (1, 2)      (0, 4)
      (1,15)      (2,11)      (2, 1)      (1, 3)
(0,19)      (2,10)      (3, 0)      (2, 2)      (0, 5)
      (1,14)      (3, 5)      (3, 1)      (1, 4)
(0,18)      (2, 9)      (4, 0)      (2, 3)      (0, 6)
      (1,13)      (3, 4)      (3, 2)      (1, 5)
(0,17)      (2, 8)      (3, 3)      (2, 4)      (0, 7)
      (1,12)      (2, 7)      (2, 5)      (1, 6)
(0,16)      (1,11)      (2, 6)      (1, 7)      (0, 8)
      (0,15)      (1,10)      (1, 8)      (0, 9)
            (0,14)      (1, 9)      (0,10)
                  (0,13)      (0,11)
                        (0,12)
```

There are a few other little fixes/improvements: the description of cell rotation is now expanded, and a default argument for `openmc.stats.Point` was added.