### PR TITLE
Ability to read from attributes on HDF5 groups/datasets

### DIFF
--- a/src/initialize.F90
+++ b/src/initialize.F90
@@ -375,7 +375,7 @@ contains
 
           ! Check what type of file this is
           file_id = file_open(argv(i), 'r', parallel=.true.)
-          call read_dataset(file_id, 'filetype', filetype)
+          call read_dataset(filetype, file_id, 'filetype')
           call file_close(file_id)
 
           ! Set path and flag for type of run
@@ -401,7 +401,7 @@ contains
 
               ! Check file type is a source file
               file_id = file_open(argv(i), 'r', parallel=.true.)
-              call read_dataset(file_id, 'filetype', filetype)
+              call read_dataset(filetype, file_id, 'filetype')
               call file_close(file_id)
               if (filetype /= 'source') then
                 call fatal_error("Second file after restart flag must be a &

--- a/src/particle_restart.F90
+++ b/src/particle_restart.F90
@@ -71,7 +71,7 @@ contains
 
     integer :: int_scalar
     integer(HID_T) :: file_id
-    character(MAX_WORD_LEN) :: mode
+    character(MAX_WORD_LEN) :: tempstr
 
     ! Write meessage
     call write_message("Loading particle restart file " &
@@ -81,25 +81,25 @@ contains
     file_id = file_open(path_particle_restart, 'r')
 
     ! Read data from file
-    call read_dataset(file_id, 'filetype', int_scalar)
-    call read_dataset(file_id, 'revision', int_scalar)
-    call read_dataset(file_id, 'current_batch', current_batch)
-    call read_dataset(file_id, 'gen_per_batch', gen_per_batch)
-    call read_dataset(file_id, 'current_gen', current_gen)
-    call read_dataset(file_id, 'n_particles', n_particles)
-    call read_dataset(file_id, 'run_mode', mode)
-    select case (mode)
+    call read_dataset(tempstr, file_id, 'filetype')
+    call read_dataset(int_scalar, file_id, 'revision')
+    call read_dataset(current_batch, file_id, 'current_batch')
+    call read_dataset(gen_per_batch, file_id, 'gen_per_batch')
+    call read_dataset(current_gen, file_id, 'current_gen')
+    call read_dataset(n_particles, file_id, 'n_particles')
+    call read_dataset(tempstr, file_id, 'run_mode')
+    select case (tempstr)
     case ('k-eigenvalue')
       previous_run_mode = MODE_EIGENVALUE
     case ('fixed source')
       previous_run_mode = MODE_FIXEDSOURCE
     end select
-    call read_dataset(file_id, 'id', p%id)
-    call read_dataset(file_id, 'weight', p%wgt)
-    call read_dataset(file_id, 'energy', p%E)
-    call read_dataset(file_id, 'energy_group', p%g)
-    call read_dataset(file_id, 'xyz', p%coord(1)%xyz)
-    call read_dataset(file_id, 'uvw', p%coord(1)%uvw)
+    call read_dataset(p%id, file_id, 'id')
+    call read_dataset(p%wgt, file_id, 'weight')
+    call read_dataset(p%E, file_id, 'energy')
+    call read_dataset(p%g, file_id, 'energy_group')
+    call read_dataset(p%coord(1)%xyz, file_id, 'xyz')
+    call read_dataset(p%coord(1)%uvw, file_id, 'uvw')
 
     ! Set particle last attributes
     p%last_wgt = p%wgt

--- a/src/particle_restart.F90
+++ b/src/particle_restart.F90
@@ -34,7 +34,7 @@ contains
     verbosity = 10
 
     ! Initialize the particle to be tracked
-    call p%initialize()
+    call p % initialize()
 
     ! Read in the restart information
     call read_particle_restart(p, previous_run_mode)
@@ -46,9 +46,9 @@ contains
     select case (previous_run_mode)
     case (MODE_EIGENVALUE)
       particle_seed = ((current_batch - 1)*gen_per_batch + &
-           current_gen - 1)*n_particles + p%id
+           current_gen - 1)*n_particles + p % id
     case (MODE_FIXEDSOURCE)
-      particle_seed = p%id
+      particle_seed = p % id
     end select
 
     call set_particle_seed(particle_seed)
@@ -94,19 +94,19 @@ contains
     case ('fixed source')
       previous_run_mode = MODE_FIXEDSOURCE
     end select
-    call read_dataset(p%id, file_id, 'id')
-    call read_dataset(p%wgt, file_id, 'weight')
-    call read_dataset(p%E, file_id, 'energy')
-    call read_dataset(p%g, file_id, 'energy_group')
-    call read_dataset(p%coord(1)%xyz, file_id, 'xyz')
-    call read_dataset(p%coord(1)%uvw, file_id, 'uvw')
+    call read_dataset(p % id, file_id, 'id')
+    call read_dataset(p % wgt, file_id, 'weight')
+    call read_dataset(p % E, file_id, 'energy')
+    call read_dataset(p % g, file_id, 'energy_group')
+    call read_dataset(p % coord(1) % xyz, file_id, 'xyz')
+    call read_dataset(p % coord(1) % uvw, file_id, 'uvw')
 
     ! Set particle last attributes
-    p%last_wgt = p%wgt
-    p%last_xyz = p%coord(1)%xyz
-    p%last_uvw = p%coord(1)%uvw
-    p%last_E   = p%E
-    p%last_g   = p%g
+    p % last_wgt = p % wgt
+    p % last_xyz = p % coord(1)%xyz
+    p % last_uvw = p % coord(1)%uvw
+    p % last_E   = p % E
+    p % last_g   = p % g
 
     ! Close hdf5 file
     call file_close(file_id)

--- a/src/source.F90
+++ b/src/source.F90
@@ -53,7 +53,7 @@ contains
       file_id = file_open(path_source, 'r', parallel=.true.)
 
       ! Read the file type
-      call read_dataset(file_id, "filetype", filetype)
+      call read_dataset(filetype, file_id, "filetype")
 
       ! Check to make sure this is a source file
       if (filetype /= 'source') then

--- a/src/state_point.F90
+++ b/src/state_point.F90
@@ -782,16 +782,16 @@ contains
       ! Read in CMFD info
       if (int_array(1) == 1) then
         cmfd_group = open_group(file_id, "cmfd")
-        call read_dataset(cmfd%indices, cmfd_group, "indices")
-        call read_dataset(cmfd%k_cmfd(1:restart_batch), cmfd_group, "k_cmfd")
-        call read_dataset(cmfd%cmfd_src, cmfd_group, "cmfd_src")
-        call read_dataset(cmfd%entropy(1:restart_batch), cmfd_group, &
+        call read_dataset(cmfd % indices, cmfd_group, "indices")
+        call read_dataset(cmfd % k_cmfd(1:restart_batch), cmfd_group, "k_cmfd")
+        call read_dataset(cmfd % cmfd_src, cmfd_group, "cmfd_src")
+        call read_dataset(cmfd % entropy(1:restart_batch), cmfd_group, &
              "cmfd_entropy")
-        call read_dataset(cmfd%balance(1:restart_batch), cmfd_group, &
+        call read_dataset(cmfd % balance(1:restart_batch), cmfd_group, &
              "cmfd_balance")
-        call read_dataset(cmfd%dom(1:restart_batch), cmfd_group, &
+        call read_dataset(cmfd % dom(1:restart_batch), cmfd_group, &
              "cmfd_dominance")
-        call read_dataset(cmfd%src_cmp(1:restart_batch), cmfd_group, &
+        call read_dataset(cmfd % src_cmp(1:restart_batch), cmfd_group, &
              "cmfd_srccmp")
         call close_group(cmfd_group)
       end if

--- a/src/state_point.F90
+++ b/src/state_point.F90
@@ -703,25 +703,25 @@ contains
     file_id = file_open(path_state_point, 'r', parallel=.true.)
 
     ! Read filetype
-    call read_dataset(file_id, "filetype", word)
+    call read_dataset(word, file_id, "filetype")
     if (word /= 'statepoint') then
       call fatal_error("OpenMC tried to restart from a non-statepoint file.")
     end if
 
     ! Read revision number for state point file and make sure it matches with
     ! current version
-    call read_dataset(file_id, "revision", int_array(1))
+    call read_dataset(int_array(1), file_id, "revision")
     if (int_array(1) /= REVISION_STATEPOINT) then
       call fatal_error("State point version does not match current version &
            &in OpenMC.")
     end if
 
     ! Read and overwrite random number seed
-    call read_dataset(file_id, "seed", seed)
+    call read_dataset(seed, file_id, "seed")
 
     ! It is not impossible for a state point to be generated from a CE run but
     ! to be loaded in to an MG run (or vice versa), check to prevent that.
-    call read_dataset(file_id, "run_CE", sp_run_CE)
+    call read_dataset(sp_run_CE, file_id, "run_CE")
     if (sp_run_CE == 0 .and. run_CE) then
       call fatal_error("State point file is from multi-group run but &
                        & current run is continous-energy!")
@@ -731,24 +731,24 @@ contains
     end if
 
     ! Read and overwrite run information except number of batches
-    call read_dataset(file_id, "run_mode", word)
+    call read_dataset(word, file_id, "run_mode")
     select case(word)
     case ('fixed source')
       run_mode = MODE_FIXEDSOURCE
     case ('k-eigenvalue')
       run_mode = MODE_EIGENVALUE
     end select
-    call read_dataset(file_id, "n_particles", n_particles)
-    call read_dataset(file_id, "n_batches", int_array(1))
+    call read_dataset(n_particles, file_id, "n_particles")
+    call read_dataset(int_array(1), file_id, "n_batches")
 
     ! Take maximum of statepoint n_batches and input n_batches
     n_batches = max(n_batches, int_array(1))
 
     ! Read batch number to restart at
-    call read_dataset(file_id, "current_batch", restart_batch)
+    call read_dataset(restart_batch, file_id, "current_batch")
 
     ! Check for source in statepoint if needed
-    call read_dataset(file_id, "source_present", int_array(1))
+    call read_dataset(int_array(1), file_id, "source_present")
     if (int_array(1) == 1) then
       source_present = .true.
     else
@@ -762,37 +762,37 @@ contains
 
     ! Read information specific to eigenvalue run
     if (run_mode == MODE_EIGENVALUE) then
-      call read_dataset(file_id, "n_inactive", int_array(1))
-      call read_dataset(file_id, "gen_per_batch", gen_per_batch)
-      call read_dataset(file_id, "k_generation", &
-           k_generation(1:restart_batch*gen_per_batch))
-      call read_dataset(file_id, "entropy", &
-           entropy(1:restart_batch*gen_per_batch))
-      call read_dataset(file_id, "k_col_abs", k_col_abs)
-      call read_dataset(file_id, "k_col_tra", k_col_tra)
-      call read_dataset(file_id, "k_abs_tra", k_abs_tra)
-      call read_dataset(file_id, "k_combined", real_array(1:2))
+      call read_dataset(int_array(1), file_id, "n_inactive")
+      call read_dataset(gen_per_batch, file_id, "gen_per_batch")
+      call read_dataset(k_generation(1:restart_batch*gen_per_batch), &
+           file_id, "k_generation")
+      call read_dataset(entropy(1:restart_batch*gen_per_batch), &
+           file_id, "entropy")
+      call read_dataset(k_col_abs, file_id, "k_col_abs")
+      call read_dataset(k_col_tra, file_id, "k_col_tra")
+      call read_dataset(k_abs_tra, file_id, "k_abs_tra")
+      call read_dataset(real_array(1:2), file_id, "k_combined")
 
       ! Take maximum of statepoint n_inactive and input n_inactive
       n_inactive = max(n_inactive, int_array(1))
 
       ! Read in to see if CMFD was on
-      call read_dataset(file_id, "cmfd_on", int_array(1))
+      call read_dataset(int_array(1), file_id, "cmfd_on")
 
       ! Read in CMFD info
       if (int_array(1) == 1) then
         cmfd_group = open_group(file_id, "cmfd")
-        call read_dataset(cmfd_group, "indices", cmfd%indices)
-        call read_dataset(cmfd_group, "k_cmfd", cmfd%k_cmfd(1:restart_batch))
-        call read_dataset(cmfd_group, "cmfd_src", cmfd%cmfd_src)
-        call read_dataset(cmfd_group, "cmfd_entropy", &
-             cmfd%entropy(1:restart_batch))
-        call read_dataset(cmfd_group, "cmfd_balance", &
-             cmfd%balance(1:restart_batch))
-        call read_dataset(cmfd_group, "cmfd_dominance", &
-             cmfd%dom(1:restart_batch))
-        call read_dataset(cmfd_group, "cmfd_srccmp", &
-             cmfd%src_cmp(1:restart_batch))
+        call read_dataset(cmfd%indices, cmfd_group, "indices")
+        call read_dataset(cmfd%k_cmfd(1:restart_batch), cmfd_group, "k_cmfd")
+        call read_dataset(cmfd%cmfd_src, cmfd_group, "cmfd_src")
+        call read_dataset(cmfd%entropy(1:restart_batch), cmfd_group, &
+             "cmfd_entropy")
+        call read_dataset(cmfd%balance(1:restart_batch), cmfd_group, &
+             "cmfd_balance")
+        call read_dataset(cmfd%dom(1:restart_batch), cmfd_group, &
+             "cmfd_dominance")
+        call read_dataset(cmfd%src_cmp(1:restart_batch), cmfd_group, &
+             "cmfd_srccmp")
         call close_group(cmfd_group)
       end if
     end if
@@ -812,14 +812,14 @@ contains
 #endif
 
       ! Read number of realizations for global tallies
-      call read_dataset(file_id, "n_realizations", n_realizations, indep=.true.)
+      call read_dataset(n_realizations, file_id, "n_realizations", indep=.true.)
 
       ! Read global tally data
       call read_dataset(file_id, "global_tallies", global_tallies)
 
       ! Check if tally results are present
       tallies_group = open_group(file_id, "tallies")
-      call read_dataset(tallies_group, "tallies_present", int_array(1), &
+      call read_dataset(int_array(1), tallies_group, "tallies_present", &
                         indep=.true.)
 
       ! Read in sum and sum squared
@@ -832,8 +832,8 @@ contains
           tally_group = open_group(tallies_group, "tally " // &
                trim(to_str(tally % id)))
           call read_dataset(tally_group, "results", tally % results)
-          call read_dataset(tally_group, "n_realizations", &
-               tally % n_realizations)
+          call read_dataset(tally % n_realizations, tally_group, &
+               "n_realizations")
           call close_group(tally_group)
         end do TALLY_RESULTS
       end if
@@ -859,7 +859,7 @@ contains
         file_id = file_open(path_source_point, 'r', parallel=.true.)
 
         ! Read file type
-        call read_dataset(file_id, "filetype", int_array(1))
+        call read_dataset(int_array(1), file_id, "filetype")
 
       end if
 


### PR DESCRIPTION
I believe this is the last preparatory pull request in advance of my new `openmc.data` package which converts ACE files to HDF5 libraries. This is a relatively simple set of changes that allows us to read attributes on HDF5 groups and datasets. In the HDF5 data library format I will be proposing, I make extensive use at attributes, which have much lower space overhead than using datasets for everything. In addition to adding a `read_attribute` generic subroutine, this PR also changes the signature for `read_dataset`. I've moved the `buffer` argument to be the first, and now the third argument is an optional name. This allows for two types of use:

1. `call read_dataset(buffer, group_id, "dataset_name")` --- in this case, the second argument is a group and we are telling it to open, read, and close the dataset with a given name.
2. `call read_dataset(buffer, dataset_id)` --- in this case, we already have a dataset that was opened via `open_dataset` (also new). This is useful if we want to read attributes of the dataset too, so we only have to open/close it once rather than doing so repeatedly. 