### PR TITLE
Addition of NuFissionMatrixXS and MultiplicityMatrix MGXS classes in MGXS Python API

### DIFF
--- a/docs/source/pythonapi/examples/mgxs-part-iii.ipynb
+++ b/docs/source/pythonapi/examples/mgxs-part-iii.ipynb
@@ -939,7 +939,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `NuFissionXS` object supports all of the methods described previously the `openmc.mgxs` tutorials, such as [Pandas](http://pandas.pydata.org/) `DataFrames`:"
+    "The `NuFissionXS` object supports all of the methods described previously in the `openmc.mgxs` tutorials, such as [Pandas](http://pandas.pydata.org/) `DataFrames`:\n",
+    "Note that since so few histories were simulated, we should expect a few division-by-error errors as some tallies have not yet scored any results."
    ]
   },
   {
@@ -1597,7 +1598,7 @@
  "metadata": {
   "kernelspec": {
    "display_name": "Python 2",
-   "language": "python",
+   "language": "python2",
    "name": "python2"
   },
   "language_info": {

--- a/docs/source/pythonapi/examples/mgxs-part-iv.ipynb
+++ b/docs/source/pythonapi/examples/mgxs-part-iv.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This Notebook illustrates the use of the openmc.mgxs.Library class specifically for application in OpenMC's multi-group mode. This example notebook follows the same process as was done in MGXS Part III, but instead uses OpenMC as the multi-group solver. This Notebook illustrates the following features:\n",
+    "This Notebook illustrates the use of the openmc.mgxs.Library class specifically for application in OpenMC's multi-group mode. This example notebook follows the same process as was done in MGXS Part III, but instead uses OpenMC as the multi-group solver. During this process, this notebook will illustrate the following features:\n",
     "\n",
     "   - Calculation of multi-group cross sections for a fuel assembly\n",
     "   - Automated creation and storage of MGXS with openmc.mgxs.Library\n",
@@ -334,7 +334,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "With the geometry and materials finished, we now just need to define simulation parameters. In this case, we will use 10 inactive batches and 40 active batches each with 2500 particles."
+    "With the geometry and materials finished, we now just need to define simulation parameters. In this case, we will use 10 inactive batches and 40 active batches each with 5000 particles."
    ]
   },
   {
@@ -433,7 +433,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPoAAAD6AgMAAAD1grKuAAAABGdBTUEAALGPC/xhBQAAACBjSFJN\nAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAADFBMVEX////pgJFyEhJNv8RV\nUZDeAAAAAWJLR0QAiAUdSAAAAAd0SU1FB+AFERUOBQ7RtjIAAAWFSURBVGje7Zs7cttADIZ9CSvX\ncrP0iCxUqbBc8Ag6xR6BhV2EvYvwFD4CCx1ABT1jMdgndpegRQnOrCbjpPlGESISC4A/gd27e8H5\n83CX3b4+iKJrRHkS4vkghMPBonRYWGwtfgD2YN+dRDUOoh6lACw0Noi9w2fESuEoAR/uVuMolX03\n9oXGT7F3eFL2iEfhUX1f4cPdL/ishs+68ai+udE4xPhexbjX2FfjGNoPj/DPNX4Tsd+EODr8FvsV\ndf1Hd9P2VvCi4+s/aXvrf+upAD+1/9GV1mkOH5X9vV6THtfvACslcaUCbESL61drBPtdI8SrFMWr\nELsXCkuFDYW75gbiP7d9Cf7bAYI/aCwUShrBvh30+lWQkzVgZ/HD4OixNCgcQpJ3BxU/Ln91elKo\nM5VEE38QtJ+Yv6cQ9xjKNYayyl8TypP8DfJnQ2H/b/N3ye9P83cT33SQv/sQh9gV7zZ/0dNj5HQa\nC5vVzv9+/WFN2w8KVaZ2BwL1+pv4g0x1QRfjq0dB4Q3kT277oP6VNL6gKxNU9a8zK+WLbi/Wwpdi\nhbboKqyxFOulHMj6v4W/AXbmUeAxrv9J/CqEBXaRKsXaodD4nsYvkT/G6H1D4SR/iPy1Roj9JsQ5\ne18/7EUHv1+Fvx/Xj5V9Ugb5K8TW4TZEEdcvoz/up0VTe9qsVIppKVX6a7D6y9ZvwEKjrtQxPtv6\nfXII9vCxKOGaIeAIfEF8IvAG8ie3vRK9rRQl+PPpSctbhfpTUCpviH+kxsZgpT91+snoX1l49KK3\niUQvICRy5aUw6l8leoVwoo3Uv1rKreF/UFLY6d9QP4L9Wf2r7EP9GOSfcsjZ56f60kz+XmVPXv+R\nuP49ff0T/53Rv6n/7m2lvXT9Wqd/VUz8hvh5M/ED6ILmt4mfHYZSaePnTWpsf/SvqV9O6dLYYClL\nEetnoH/LBLFoBvrX189uTv8++kot5vTvQD4/9jP690g9P/4z/bvo/XVG/xYoZZx+8fr3MxAtsf7t\nUOkG2JqsTtCIpgCt/qX1226KqZS7gfzJbe+c9jLrtIZ8lXD+s4umlW6AKIVrlML2/cXjgPFjlJqI\nRC+Fj0bVJe+vSh56pSdR6YkQ1ygF10Wqf0FeLta/iKn9Mv1L24ti2e+7W4n1b3T/W+L+t9H9T/Sv\nVboUmqJJon1/hZq8LnzRDlDrX1u0xRT1+6vEpomMmyYkqi95vIH8yW1PN+122KkLcNLKi/WTF01z\n/cNASrWE/l3ev6T17zX909z9X27/euK/Rf3zWP+Waf9eEv37KkWJ+rfDl6ZglNDa+cEBhwYDvkoN\nP/rX69814NaI3imq0l7OYDy/qSdDGwr7r+Y3VbzoKZr6XX2lfxfOb87qXzr+b1j/Xlp/nP6dn98M\ncdH7cn7zjPObKsYWS3Eb9w8n85smHtqQuPuZ30T2dlIT6F9xFl+n8xslegL9a4c2KRr9W4rp/GYq\numiM9Nec/j2v/yj9u1h//hv9e93vc++f63/u+rPjL3f+5Lbn1j9m/eXWf+7zh/v8+2b9e/Hzn6s/\nuPqHrb8g71n6L3f+5Lbnvn8w33+4718/+5d47//c/gO7/5E7/nPbc/tv3P4fs//I7X9y+6/fqH+v\n6j9z+9/c/ju3/8+eP+TOn9z23PkXc/7Gnf9x5483q38Xzn+582fu/Js9fy8kb/6fO39y23P3n3S8\n/S/c/Tfc/T83uX/pgv1XE/9duP+Lu/+Mvf8td/znti8kb/8ld/9nx9t/Sjw/Ltr/yt1/+337f6/b\nf0zoB3nJ/ucVc/81d/83e/957vzJbc89/8A8f8E9/5HE78XnT/4H/cs5f8Q9/8Q9f8U+/5U7f3Lb\nc88fdrzzjyvm+cuf/Uu887/c88fs88954/8vO4SjPC+2QRIAAAAldEVYdGRhdGU6Y3JlYXRlADIw\nMTYtMDUtMTdUMjE6MTQ6MDUtMDQ6MDCzw4K8AAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE2LTA1LTE3\nVDIxOjE0OjA1LTA0OjAwwp46AAAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPoAAAD6AgMAAAD1grKuAAAABGdBTUEAALGPC/xhBQAAACBjSFJN\nAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAADFBMVEX////pgJFyEhJNv8RV\nUZDeAAAAAWJLR0QAiAUdSAAAAAd0SU1FB+AFFhUdFe9e330AAAWFSURBVGje7Zs7cttADIZ9CSvX\ncrP0iCxUqbBc8Ag6xR6BhV2EvYvwFD4CCx1ABT1jMdgndpegRQnOrCbjpPlGESISC4A/gd27e8H5\n83CX3b4+iKJrRHkS4vkghMPBonRYWGwtfgD2YN+dRDUOoh6lACw0Noi9w2fESuEoAR/uVuMolX03\n9oXGT7F3eFL2iEfhUX1f4cPdL/ishs+68ai+udE4xPhexbjX2FfjGNoPj/DPNX4Tsd+EODr8FvsV\ndf1Hd9P2VvCi4+s/aXvrf+upAD+1/9GV1mkOH5X9vV6THtfvACslcaUCbESL61drBPtdI8SrFMWr\nELsXCkuFDYW75gbiP7d9Cf7bAYI/aCwUShrBvh30+lWQkzVgZ/HD4OixNCgcQpJ3BxU/Ln91elKo\nM5VEE38QtJ+Yv6cQ9xjKNYayyl8TypP8DfJnQ2H/b/N3ye9P83cT33SQv/sQh9gV7zZ/0dNj5HQa\nC5vVzv9+/WFN2w8KVaZ2BwL1+pv4g0x1QRfjq0dB4Q3kT277oP6VNL6gKxNU9a8zK+WLbi/Wwpdi\nhbboKqyxFOulHMj6v4W/AXbmUeAxrv9J/CqEBXaRKsXaodD4nsYvkT/G6H1D4SR/iPy1Roj9JsQ5\ne18/7EUHv1+Fvx/Xj5V9Ugb5K8TW4TZEEdcvoz/up0VTe9qsVIppKVX6a7D6y9ZvwEKjrtQxPtv6\nfXII9vCxKOGaIeAIfEF8IvAG8ie3vRK9rRQl+PPpSctbhfpTUCpviH+kxsZgpT91+snoX1l49KK3\niUQvICRy5aUw6l8leoVwoo3Uv1rKreF/UFLY6d9QP4L9Wf2r7EP9GOSfcsjZ56f60kz+XmVPXv+R\nuP49ff0T/53Rv6n/7m2lvXT9Wqd/VUz8hvh5M/ED6ILmt4mfHYZSaePnTWpsf/SvqV9O6dLYYClL\nEetnoH/LBLFoBvrX189uTv8++kot5vTvQD4/9jP690g9P/4z/bvo/XVG/xYoZZx+8fr3MxAtsf7t\nUOkG2JqsTtCIpgCt/qX1226KqZS7gfzJbe+c9jLrtIZ8lXD+s4umlW6AKIVrlML2/cXjgPFjlJqI\nRC+Fj0bVJe+vSh56pSdR6YkQ1ygF10Wqf0FeLta/iKn9Mv1L24ti2e+7W4n1b3T/W+L+t9H9T/Sv\nVboUmqJJon1/hZq8LnzRDlDrX1u0xRT1+6vEpomMmyYkqi95vIH8yW1PN+122KkLcNLKi/WTF01z\n/cNASrWE/l3ev6T17zX909z9X27/euK/Rf3zWP+Waf9eEv37KkWJ+rfDl6ZglNDa+cEBhwYDvkoN\nP/rX69814NaI3imq0l7OYDy/qSdDGwr7r+Y3VbzoKZr6XX2lfxfOb87qXzr+b1j/Xlp/nP6dn98M\ncdH7cn7zjPObKsYWS3Eb9w8n85smHtqQuPuZ30T2dlIT6F9xFl+n8xslegL9a4c2KRr9W4rp/GYq\numiM9Nec/j2v/yj9u1h//hv9e93vc++f63/u+rPjL3f+5Lbn1j9m/eXWf+7zh/v8+2b9e/Hzn6s/\nuPqHrb8g71n6L3f+5Lbnvn8w33+4718/+5d47//c/gO7/5E7/nPbc/tv3P4fs//I7X9y+6/fqH+v\n6j9z+9/c/ju3/8+eP+TOn9z23PkXc/7Gnf9x5483q38Xzn+582fu/Js9fy8kb/6fO39y23P3n3S8\n/S/c/Tfc/T83uX/pgv1XE/9duP+Lu/+Mvf8td/znti8kb/8ld/9nx9t/Sjw/Ltr/yt1/+337f6/b\nf0zoB3nJ/ucVc/81d/83e/957vzJbc89/8A8f8E9/5HE78XnT/4H/cs5f8Q9/8Q9f8U+/5U7f3Lb\nc88fdrzzjyvm+cuf/Uu887/c88fs88954/8vO4SjPC+2QRIAAAAldEVYdGRhdGU6Y3JlYXRlADIw\nMTYtMDUtMjJUMjE6Mjk6MjEtMDQ6MDBAdsrxAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE2LTA1LTIy\nVDIxOjI5OjIxLTA0OjAwMStyTQAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<IPython.core.display.Image object>"
       ]
@@ -499,8 +499,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, we must specify to the Library which types of cross sections to compute. OpenMC's multi-group mode can accept isotropic flux-weighted cross sections or angle-dependent cross sections, as well as supporting anisotropic scattering represented by either Legendre polynomials, histogram, or tabular angular distributions.  At this time the MGXS Library class only supports the generation of isotropic flux-weighted cross sections and P0 scattering, so that is what will be used for this example.  Therefore, we will create the following multi-group cross sections needed to run an OpenMC simulation to verify the accuracy of our cross sections: \"transport\", \"absorption\", \"nu-fission\", '\"fission\", \"nu-scatter matrix\", \"scatter matrix\", and \"chi\".\n",
-    "\"scatter matrix\" is needed in addition to \"nu-scatter matrix\" because OpenMC's multi-group mode can treat scattering multiplication (i.e., (n,xn) reactions)) explicitly instead of adjusting the absorption cross section to maintain neutron balance, and using this explicit treatment would require tallying of both types of scattering matrices."
+    "Now, we must specify to the Library which types of cross sections to compute. OpenMC's multi-group mode can accept isotropic flux-weighted cross sections or angle-dependent cross sections, as well as supporting anisotropic scattering represented by either Legendre polynomials, histogram, or tabular angular distributions.  At this time the MGXS Library class only supports the generation of isotropic flux-weighted cross sections and P0 scattering, so that is what will be used for this example.  Therefore, we will create the following multi-group cross sections needed to run an OpenMC simulation to verify the accuracy of our cross sections: \"total\", \"absorption\", \"nu-fission\", '\"fission\", \"nu-scatter matrix\", \"multiplicity matrix\", and \"chi\".\n",
+    "\"multiplicity matrix\" is needed to provide OpenMC's multi-group mode with additional information needed to accurately treat scattering multiplication (i.e., (n,xn) reactions)) explicitly."
    ]
   },
   {
@@ -513,7 +513,7 @@
    "source": [
     "# Specify multi-group cross section types to compute\n",
     "mgxs_lib.mgxs_types = ['total', 'absorption', 'nu-fission', 'fission',\n",
-    "                       'nu-scatter matrix', 'scatter matrix', 'chi']"
+    "                       'nu-scatter matrix', 'multiplicity matrix', 'chi']"
    ]
   },
   {
@@ -565,7 +565,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we will set the scattering order that we wish to use.  For this problem we will use P3 scattering."
+    "Now we will set the scattering order that we wish to use.  For this problem we will use P3 scattering.  A warning is expected telling us that the default behavior (a P0 correction on the scattering data) is over-ridden by our choice of using a Legendre expansion to treat anisotropic scattering."
    ]
   },
   {
@@ -681,24 +681,24 @@
     "tally.scores = ['fission']\n",
     "\n",
     "# Add tally to collection\n",
-    "tallies_file.append(tally)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 26,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
+    "tallies_file.append(tally, merge=True)\n",
+    "\n",
     "# Export all tallies to a \"tallies.xml\" file\n",
     "tallies_file.export_to_xml()"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "Time to run the calculation and get our results!"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 26,
    "metadata": {
     "collapsed": false
    },
@@ -723,8 +723,8 @@
       "      Copyright:      2011-2016 Massachusetts Institute of Technology\n",
       "      License:        http://openmc.readthedocs.io/en/latest/license.html\n",
       "      Version:        0.7.1\n",
-      "      Git SHA1:       058ba68895a2f880402fda3d58cfb14b162931d9\n",
-      "      Date/Time:      2016-05-17 21:14:05\n",
+      "      Git SHA1:       b7cc8a3a1460a9662fd3e8d11a6c0cf5902946c2\n",
+      "      Date/Time:      2016-05-22 21:29:21\n",
       "      OpenMP Threads: 4\n",
       "\n",
       " ===========================================================================\n",
@@ -811,20 +811,20 @@
       "\n",
       " =======================>     TIMING STATISTICS     <=======================\n",
       "\n",
-      " Total time for initialization     =  1.4530E+00 seconds\n",
-      "   Reading cross sections          =  1.1470E+00 seconds\n",
-      " Total time in simulation          =  1.8747E+01 seconds\n",
-      "   Time in transport only          =  1.8639E+01 seconds\n",
-      "   Time in inactive batches        =  2.1690E+00 seconds\n",
-      "   Time in active batches          =  1.6578E+01 seconds\n",
-      "   Time synchronizing fission bank =  6.0000E-03 seconds\n",
-      "     Sampling source sites         =  4.0000E-03 seconds\n",
-      "     SEND/RECV source sites        =  2.0000E-03 seconds\n",
-      "   Time accumulating tallies       =  0.0000E+00 seconds\n",
+      " Total time for initialization     =  1.4810E+00 seconds\n",
+      "   Reading cross sections          =  1.1840E+00 seconds\n",
+      " Total time in simulation          =  1.9619E+01 seconds\n",
+      "   Time in transport only          =  1.9512E+01 seconds\n",
+      "   Time in inactive batches        =  2.1770E+00 seconds\n",
+      "   Time in active batches          =  1.7442E+01 seconds\n",
+      "   Time synchronizing fission bank =  1.0000E-02 seconds\n",
+      "     Sampling source sites         =  6.0000E-03 seconds\n",
+      "     SEND/RECV source sites        =  4.0000E-03 seconds\n",
+      "   Time accumulating tallies       =  1.0000E-03 seconds\n",
       " Total time for finalization       =  0.0000E+00 seconds\n",
-      " Total time elapsed                =  2.0209E+01 seconds\n",
-      " Calculation Rate (inactive)       =  23052.1 neutrons/second\n",
-      " Calculation Rate (active)         =  12064.2 neutrons/second\n",
+      " Total time elapsed                =  2.1110E+01 seconds\n",
+      " Calculation Rate (inactive)       =  22967.4 neutrons/second\n",
+      " Calculation Rate (active)         =  11466.6 neutrons/second\n",
       "\n",
       " ============================>     RESULTS     <============================\n",
       "\n",
@@ -842,7 +842,7 @@
        "0"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -861,7 +861,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 27,
    "metadata": {
     "collapsed": false
    },
@@ -886,7 +886,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 28,
    "metadata": {
     "collapsed": false
    },
@@ -905,7 +905,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 29,
    "metadata": {
     "collapsed": false
    },
@@ -924,7 +924,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 30,
    "metadata": {
     "collapsed": false
    },
@@ -952,12 +952,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We will now use the `Library` to produce a multi-group cross section data set for use by the OpenMC multi-group solver.  "
+    "We will now use the `Library` to produce a multi-group cross section data set for use by the OpenMC multi-group solver.  \n",
+    "Note that since we have ran so few histories, is not unreasonable to expect some divisions by zero errors.  This will show up as a runtime warning in the following step."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 31,
    "metadata": {
     "collapsed": false
    },
@@ -997,7 +998,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 32,
    "metadata": {
     "collapsed": false
    },
@@ -1047,7 +1048,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 33,
    "metadata": {
     "collapsed": true
    },
@@ -1072,7 +1073,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 34,
    "metadata": {
     "collapsed": false,
     "scrolled": true
@@ -1098,8 +1099,8 @@
       "      Copyright:      2011-2016 Massachusetts Institute of Technology\n",
       "      License:        http://openmc.readthedocs.io/en/latest/license.html\n",
       "      Version:        0.7.1\n",
-      "      Git SHA1:       058ba68895a2f880402fda3d58cfb14b162931d9\n",
-      "      Date/Time:      2016-05-17 21:14:26\n",
+      "      Git SHA1:       b7cc8a3a1460a9662fd3e8d11a6c0cf5902946c2\n",
+      "      Date/Time:      2016-05-22 21:29:43\n",
       "      OpenMP Threads: 4\n",
       "\n",
       " ===========================================================================\n",
@@ -1183,20 +1184,20 @@
       "\n",
       " =======================>     TIMING STATISTICS     <=======================\n",
       "\n",
-      " Total time for initialization     =  4.6000E-02 seconds\n",
-      "   Reading cross sections          =  8.0000E-03 seconds\n",
-      " Total time in simulation          =  1.4524E+01 seconds\n",
-      "   Time in transport only          =  1.4457E+01 seconds\n",
-      "   Time in inactive batches        =  1.3350E+00 seconds\n",
-      "   Time in active batches          =  1.3189E+01 seconds\n",
-      "   Time synchronizing fission bank =  7.0000E-03 seconds\n",
-      "     Sampling source sites         =  5.0000E-03 seconds\n",
-      "     SEND/RECV source sites        =  2.0000E-03 seconds\n",
+      " Total time for initialization     =  3.4000E-02 seconds\n",
+      "   Reading cross sections          =  3.0000E-03 seconds\n",
+      " Total time in simulation          =  1.4720E+01 seconds\n",
+      "   Time in transport only          =  1.4678E+01 seconds\n",
+      "   Time in inactive batches        =  1.3020E+00 seconds\n",
+      "   Time in active batches          =  1.3418E+01 seconds\n",
+      "   Time synchronizing fission bank =  6.0000E-03 seconds\n",
+      "     Sampling source sites         =  3.0000E-03 seconds\n",
+      "     SEND/RECV source sites        =  3.0000E-03 seconds\n",
       "   Time accumulating tallies       =  0.0000E+00 seconds\n",
       " Total time for finalization       =  0.0000E+00 seconds\n",
-      " Total time elapsed                =  1.4579E+01 seconds\n",
-      " Calculation Rate (inactive)       =  37453.2 neutrons/second\n",
-      " Calculation Rate (active)         =  15164.2 neutrons/second\n",
+      " Total time elapsed                =  1.4763E+01 seconds\n",
+      " Calculation Rate (inactive)       =  38402.5 neutrons/second\n",
+      " Calculation Rate (active)         =  14905.4 neutrons/second\n",
       "\n",
       " ============================>     RESULTS     <============================\n",
       "\n",
@@ -1214,7 +1215,7 @@
        "0"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1237,7 +1238,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 35,
    "metadata": {
     "collapsed": false
    },
@@ -1257,7 +1258,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 36,
    "metadata": {
     "collapsed": true
    },
@@ -1275,7 +1276,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 37,
    "metadata": {
     "collapsed": false
    },
@@ -1302,7 +1303,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This shows a nontrivial pcm bias between the two methods.  Some degree of mismatch is expected simply to the very few histories being used in these example problems.  An additional mismatch is always inherent in the practical application of multi-group theory due to the high degree of approximations inherent in that method."
+    "This shows a small but nontrivial pcm bias between the two methods.  Some degree of mismatch is expected simply to the very few histories being used in these example problems.  An additional mismatch is always inherent in the practical application of multi-group theory due to the high degree of approximations inherent in that method."
    ]
   },
   {
@@ -1323,7 +1324,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 38,
    "metadata": {
     "collapsed": false
    },
@@ -1349,7 +1350,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 39,
    "metadata": {
     "collapsed": false
    },
@@ -1375,7 +1376,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 40,
    "metadata": {
     "collapsed": false
    },
@@ -1383,10 +1384,10 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.text.Text at 0x7f7dbaf3e5f8>"
+       "<matplotlib.text.Text at 0x7f4e8bedf400>"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -1394,7 +1395,7 @@
      "data": {
       "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXQAAADDCAYAAACS2+oqAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJztnXeYFeX1xz8HUJSmoIJiA8WOokSwm43RtUSjiQ1LbAnq\nzySYaGzR6IrGHns0tih2YzcxidjWXlAUS2woIoiggoqKorDn98fMwmXZe88su5e7O3w/z7PP3jvv\nd9733HfOnHmnnHnN3RFCCNH2aVdpA4QQQrQMCuhCCJETFNCFECInKKALIUROUEAXQoicoIAuhBA5\nodUFdDN7zcy2rrQdizJm9m8z+0Uz1r/czE5sSZsWRcyszsxWK1Ge231FPriAuHv4B+wLjAK+BD4E\n7ge2yLJuUO+1wPDm1lPJv/Q3zASmp39fAi9V2q4Mdp8CfFdg83TgD5W2qwk2TwOeBDZtwvqPAocs\nBDvfB74FejRY/jJQB6ySsZ7ZwGoFftakfQVYDDgZeDPdxhPSfXe7Sm/LRranfLAF/sIRupkdBZwP\nnA70BFYBLgN+Gq27CHG2u3dL/7q6+0Yt3YCZtW/pOoFbC2zu5u7nlaGNluZWd+8GLAvUArdX1pxG\ncWAcsE/9AjPrDyyRlmXFmmnHncAuwP5Ad6AvcBGwU6ONlcfHIuSDLUlwNOlGcuT8eQnN4sCFJCP3\nicAFwGJp2Q9JRgVHAVNSzUFp2VCSI923JEe7e9Pl44BtCo6GtwEjUs2rwMCCtutIRzDp93lGMWkb\n7wCfAvcAK6TLV03XbdfYkRNYnWRDfQ58DNxS4vcXHTkVtHMAMD6t648F5QYcD4wFPgFuBZZusO4h\n6bq16fIDSEaAnwAn1fcX0Av4GuheUP8P0jbbFxlpXB+NIkr1Rbqtp6RlLwPrNmU7FGzDw4C3ganA\npcHo6PqC7+uQjGKXSb8vDfwztXNq+rl3WnY6MAuYkfrSxenytYGRqf4NYM+C+ncCXk/1E4CjMo7C\nxgF/BJ4vWHYucEJq7yqNjdaAA4EnGvo3GfaVRmzYNvWHFTLYeiwwBviG5DLsOqltn5Hsc7s05hsl\nbP4t8G66Hc7Juj3lg833wWiEvhnQMe2AYpwEDAY2AAakn08qKF8e6Ar0Bn4F/NXMlnL3q4CbSDZ4\nN3fftUj9uwA3A0ulnfPXgrKiox0z2wY4A9gDWAH4gCRghusCpwEPuPvSwErAJSW0WdgCWINkJzvZ\nzNZKlx9JcqazFUn/fEZy9lPI1iQbfHszW4fk9+9D8puWStfD3aeQ7AR7Fay7H4nzz26G7Y32hZlV\nA1sC/dKyvUkcch4ybAeAn5AcfDYE9krrLomZLU4STKaS9BskwejvwMokZ5IzSP3F3U8CngB+k/rb\nMDPrRLIj3Ugy2toHuCztZ4CrgaGejMb6A49EdhXwLNDVzNYys3Yk2+VG4lH3fH7ZhH2lkB8Dz7n7\nRxm0Q4AdSYJRO+A+4L/AcsAw4CYzW6MJNu8GDEz/djWzQzLYUAr5YEYfjAL6MsCn7l5XQrMvcKq7\nT3X3qcCpQOHNjO+A09x9trv/B/gKWKuReorxpLs/4Mnh6gaSA0c9pXaOfYFr3H2Mu39PMjrazMxW\nydDm98CqZraiu3/n7k8H+mPMbJqZfZb+v7agzIGatJ5XSEZCA9KyQ4ET3f2j1MbhwB5pAKhf9xR3\n/8bdZ5I45H3u/oy7zyK5PlrI9aR9n9axD0mfFWPvBnYv34S++J7kQL2umZm7v5UeVBqSZTuc6e5f\nuvsEkoPShpHNJDvKL4E96v3T3ae5+93uPtPdvwbOJDkgFmNnYJy7X+8JL5NcptgjLf8OWM/Murr7\nF2l5U7iBZIffjuQ69qQmrt8clgUm138xs+7pdv7czL5poL3I3SelPrYp0Nndz3b3We7+KPAvCi4f\nZeCstL8mkpy9l1pXPtiCPhgF9KnAsgUBpjF6kxzx6hmfLptTR4MDwgygS9BuIZMLPs8AlgjsKbRr\nfP2XtHOnAitmWPcYkr553sxeNbODAczsBDP70symm1nhSPpcd+/h7t3T/wc3qK/QyQp//6rA3akj\nTwP+R+KkvQr0Exv8pgkFv+kb5h2R3AusY2Z9gGrgc3d/ocTvvK2B3ZMb0TTaF+mOfinJ6GOymf3N\nzBrbrlm2Q7H+KWozyf2c14CN6wvMbEkzu8LM3jezz4HHgKXNrNiBf1Vg0/r+N7PPSHb++v7fnWTk\nNt7MHjWzTUvY1Rg3pvUdRHKwLRupX9b75kokfbxCfbm7f+bu3UlGoYs3WL2oj6WMJ9t+01h9DeNB\nQ+SDLeiDUWB8huS63W4lNB+mRhUamHUk0pQbRI0xA+hU8L3w6D6p0C4z60xyxjGR5NoixdZ194/d\n/VB3XxE4nOQUaDV3P9Pn3rw5opm2Q3Ig3DF15Hqn7tzgNLmwjz4iOeWs/01Lpr+p3u6ZwD9IboLt\nT+nReSaK9UVadqm7bwysR3LWdUwjVZTaDs2xa1pqT42Z1Tv/0SSXtgalp+D1I6P6namhv00guTdR\n2P/d3P03aRsvuvtuJJce7iXp26bY+AHJNeodgbsakXxNcf+dr7qgra4FvjkReBgYZGaNBdOGwaWw\n7kkklwsKWYVkP89qc+H6q9DMMxP5YHYfLBnQ3X06yU2Av5rZrunRp4OZ7WhmZ6WyW4GTzGxZM1sW\n+BPZA8kUkps+TaHQGV8C9jWzdma2A8lN2HpuBg42sw3MrCPJNbRn3X2Cu39K4qD7p+seQnLjJWnA\nbA8zqz96f05y02RBr0OXuix0BXBG/amfmS1nZoVPDzVc9w5gFzPb1MwWI7m81ZAbSEaEu5CMEJtF\nsb4ws43NbLCZdSC5mfYtjfdR0e3QXNvc/S2Sa73HpYu6prZMN7MeQE2DVRr627+ANc1s/9SvF0t/\n19rp533NrJsn9yC+JLmh1VQOIblx2fAyByQ38X6e7lf9SE7fi9GkfcXdHyS5dHBPup0WS7fVZpQ+\nODwHfG1mx6Z9UkVyWeCWJth8jJktbWYrk9wnani9uknIB7P7YHjpwt0vIHlK5SSSO7cfAEcw90bp\n6cALQP314ReAP5eqsuDzNSTXh6aZ2V2NlEfr/47kpuJnJNfp7i6w+xGSg8tdJMG7L8nNn3qGktzd\n/5TkTvVTBWWDgOfMbHr6O4e5+3iKc2x6qjs9Pe39uIi9Db9fRHLUHWlmXwBPk9xUbnRdd/8fyRME\nt5GMOr4g2SYzCzRPkzj86HSEuCAUtlusL7oBV5E8izuOpB/ne+Qsw3Yo1T9ZOA8Ymg4mLiQZPX5K\n0pf/bqC9CNjTzKaa2YXu/hXJpakhJP05CTiLuZckfgGMS0+dDyW5yZyFOb/B3ce5++jGykie0Pie\n5LLitcx/AG7uvvJzkoBxI8k+8h7JfrJ9kTZIrzH/lOTpik9JLmn8wt3fyWgzJD79IjCa5EGGvwd2\nNoZ8MKFJPmjuzb3qISpFeur4Ocld/vEFyx8GbnL3BdmRhFhgzKyOxB/fq7QtiyKtLvVflMbMdk5P\ndzsDfwFeaRDMBwEbkYzihRCLEArobY9dSU7LJpJc959z6mhm15E803pkeidfiIWNTvkriC65CCFE\nTtAIXQghckKHclSaPkJ4IckB4xp3P7sRjU4NRFlx9+a+3Go+5NuiNVDMt1v8koslWZxvk7xLYhLJ\na3eHuPubDXTOcQVtP1kDW9bMW9mIDA1ekEGTJWn51QyaFxr01T01sFvNvMsOjnMVLqg7PdT8/u2/\nlSy/eM2hYR3DHrlq/oUjauDAmjlfV/rxO/NrGvDynDcVFOdqfhVqvqNjqLnCD5tv2fSai+lWM2zO\n9w+fL/VakZRNrcUDepN8+/iC5OgnamCrmjlf+57xv7Ctce+uGxs0OcPPezjev7v84ZP5ls3887l0\nPHFujs7/dbo8rOfcYQ3fRDE/Ay55NtT099dCzU1HNOJvo2pgUM2cr49ftvH8mgZs/ZdSidQpx8R9\nuHXdyFDz+AM7zLvgxhrYv2beZTuWrqO6GkaOLO7b5bjkMhh4x93Hp8+03kpyI0+Ito58W7RqyhHQ\nV2Ted0FMpGnvgRCitSLfFq2aclxDb+xUoPFzlidr5n7uuHQZTCkza1dV2oKmM6Cq0hY0mY5Vm8Si\nF2thdG25Tcnu20/UzP3cBn27/VabV9qEptO7qtIWNI0NqjIKa9M/GDu2tLIcAX0iyQt56lmJYi/n\naXjNvK3RFgP6hlWVtqDJZAroP6hK/uq5prHX3DSb7L5dcM28LdJh6y0qbULTWbGq0hY0jcwBvSr9\ng3794L33ivt2OS65jAL6mdmqlrwAfgjJC/OFaOvIt0WrpsVH6O4+28x+Q5KxWP9o1xst3Y4QCxv5\ntmjtlOU5dHf/L02blUiINoF8W7RmKpb6b2ZOn6DtbWPb7LQZocYv7RRqZg+JJzxfYvnPQ03XpaeH\nmk06PBdq1gkGfhd9fGRYx5E9Lwo1VfZoqHmHNUPNmHlmBmycZ9gs1HxO91CzQoZpMl9pt1lZEouy\nkCQWlZq1MfZZ7LNYs1v8gM1md8bToJ5EnBfxk5PjerocN//z7A2p7hw/r33X9fFbik854PhQ04f3\nQ83hX8TP18/8TeyT/CiWXHRwnDtyZPuVSpZXV6/OyJEHLNTn0IUQQlQABXQhhMgJCuhCCJETFNCF\nECInKKALIUROUEAXQoicoIAuhBA5QQFdCCFyQlkyRTNzblA+M67isJ6lJ4IA6HXGH0KNdY1zUGYe\n2zXUVPF0qOntjb/PqZDzOLFk+Vo9Dwjr6E88UcBmPjrUPMtGoeb358fb4a6jg7f3A+dwbKjZ2f4V\nal4JFWXmlyXKrolXf3x2/Jr1frwbano9Fye62SazQ83sp+PEu5073R5q7iBOGhp1QJyk9iXdQs02\nPBlqNlmqb6j58IY4geuWDLPoXMWhoYZNBpUuXxsYWXzf1whdCCFyggK6EELkBAV0IYTICQroQgiR\nExTQhRAiJyigCyFETlBAF0KInFDZ59D7BOVd4iou/eyYUNNudqnJBlKujI9tH9Ej1CxvF4Sa3f3O\nUOOPlJ7A4vkfx5NX7O53hBoGx88Xb7JUXA0Pxn38s6vjPv7rr44INXeyewaD/pJBUz6GXnlx0bKr\nZg4L1+/EN6FmeTJMgtEr7vNhnBNq9n5ow1Bzhp0Qai71/4SaXtYn1Nzue4aabT6MfXutiaGEtTcZ\nF7f1VtxW+8/j5/3ZMMiHWb10sUboQgiRExTQhRAiJyigCyFETlBAF0KInKCALoQQOUEBXQghcoIC\nuhBC5AQFdCGEyAnm7pVp2MxH1a1bUjPowxfCeuq+6RRqBq3+WKh54fEfhhqfEUpgQAbNIxk0QY7G\nERPjxJm3vV+o2aZdPJHCiY+GEuqeiicIefGPpbc3QHebFmqu5LBQc67V4O6xUWXAzHyduuK+O3Zq\nvF1GLBtPYJLl540Ps/fg+OfjJDU6x5Kj1vtzqDn/8dITtwAM3zpOFjx5XDQ7DvBsLBmxf6w5sDqD\nG10Sx9Hr+u0dak7jTyXLt6Iz17frW9S3NUIXQoicoIAuhBA5QQFdCCFyggK6EELkBAV0IYTICQro\nQgiRExTQhRAiJyigCyFETijLjEVm9j7wBVAHfO/ugxvTDbFbS9Yzunc8SwoWz5QzmPNDzTc/iJMH\nluiSYcaRF+Nj5C37xck8++x/d8nyr/yqsI4HP94t1Fhd3H9+T/ybnjpho1CzJXGiGI/FbW3yw+fi\nespEVt9+o33x2a3s7XgqriHL3BMb80ncV/5VhqSYwbEP2MtxW3957qS4ra3jtk7O8Ltu7BPPWrV/\n39tDzYHfZhjTxpOQQb/4d43n+FAzbs3SyXdrbFl6/XJNQVcHVLl7hjmyhGhTyLdFq6Vcl1ysjHUL\nUUnk26LVUi7HdOABMxtlZkPL1IYQlUC+LVot5brksrm7Tzaz5YAHzewNd3+yTG0JsTCRb4tWS1kC\nurtPTv9/YmZ3A4OB+Zx+Ws1lcz4vWTWIJasGlcMcsQjwWu1UXq+N39TYXLL6Nn5hwZdNwTYtu20i\np8yohW9qARj7Umlpiwd0M+sEtHP3r8ysM1ANnNqYtkfNES3dvFhE6V+1DP2rlpnz/fZTx7Z4G03x\nbex3Ld6+WETpVJX8Af02gvfGDC8qLccIvRdwt5l5Wv9N7j6yDO0IsbCRb4tWTYsHdHcfB2R4gFyI\ntoV8W7R2Kjpj0dW+T0nNMkwN6/mP7xhqetqUULOv3xJqXvCNQ80v3roz1HjHUMKYfqUTQmrr4gcs\nOvq3oebwY26IjamOfWT57caFmsnPrRa31TFuq93bcRIHQ9pVdMaiPWdfV7T89svj2YhmT2gfao48\n88xQM5kVQs1t4w4KNU/3jY9jHYgT7wa/+WqomdU79oG1ur0eat67qH+osfXjtrx3KOHttVYONWs/\nMT6u6JnSLlvdF0YOMc1YJIQQeUcBXQghcoICuhBC5AQFdCGEyAkK6EIIkRMU0IUQIicooAshRE5Q\nQBdCiJxQ0cQiu7V0IsKs9eJE1s36PxJq7iGeuee3XBJqdueOUNPVvww12379aKjp+PvS5XdfFSdU\nrcSEULO0fx5qXmRgqNmqkfdTzWfPyvHLs3y/UMIuZ/0j1Nzfbq+KJhbt7LcVLf/aO4V1rMikUPOl\nxTMfLZshOe9sPzbUjLJGJ2aah/7+WqihfewDK2bIvxmz8hqhprd/FNfDgFCzJDNCzRbvB2/NAtbs\n83KoGft6aXuqu8DIvkosEkKI3KOALoQQOUEBXQghcoICuhBC5AQFdCGEyAkK6EIIkRMU0IUQIico\noAshRE6oaGLRkLprSmp28n+H9exvt8eNXRwft54ftn6oGcyYuK0RcVu3H7BzqNnT7isteDBu57vB\ncV7N4kvFs8ywSdyW/zNuy3pmaGtc3Nabq60aata18RVNLLLziv/WWRvGCXO2TdxX5/PrUHPMXy4N\nNbOPztBNf4q3y6GnXRRqruS3oeb59nFbHWfHiUUDeCvU3MEuoWb3P8VxyE6Lt1e7v4cS9jzk+pLl\nA+jNSe2qlVgkhBB5RwFdCCFyggK6EELkBAV0IYTICQroQgiRExTQhRAiJyigCyFETlBAF0KInBBn\nOJSRt610csD6tnJYxz5114WaW34W2zKdbqHGT20fasaeslJsD/uEmj36lW7rvLFxUslavB1qtqBz\nqLn/uT1DzQyWDDXtOSDU9O27RaiZRO9QAxmmvSkj+x5VPGmuw82zwvXHECfOjLTzQs09R1eHmo38\ntFDz/knxDEp8F0s+XezmUHPXZXE9kzLMxMR68f66x5FxYuX9w38U29M+buuO2TuEmods25LlXSk9\nS5VG6EIIkRMU0IUQIicooAshRE5QQBdCiJyggC6EEDlBAV0IIXKCAroQQuQEBXQhhMgJCzxjkZld\nA+wMTHH3DdJl3YHbgFWB94G93P2LIuv7T+tKJxn88/G9QztmrRLnRp3S57hQs7f9I9S866uHmo+t\nZ6hZzd8LNT++4pmS5XWbhlVw7IDhoea0r08ONUu8Gbd16w9+GmqG7BjMwgS899/lQ83u3BVqxtjm\nCzxjUUv4Nl3rijdwS2xD9U73hpqRN+8aapbYeVrcVreRoea+9+J9ccvVHgo1D3+xfahZ7PRQwvXn\nxsluXdrFs5ntfmzclm8da16JJyHj6bo4se7wA0rPWMT61bQ7bmRZZiy6Fmi4dY4HHnL3tYBHgBOa\nUb8QlUK+LdokCxzQ3f1J4LMGi3cFRqSfRwC7LWj9QlQK+bZoq7T0NfSe7j4FwN0nA8u1cP1CVAr5\ntmj16KaoEELkhJZ+2+IUM+vl7lPMbHng41LiN2vumPN52ap1WbZq3RY2RywqfFU7mq9qR5eziSb5\nNjNr5n5uXwUdqspomsgztZOhdkr6ZfLYktrmBnRL/+q5DzgIOBs4ECh5q37tmj2a2bwQCV2qBtKl\nauCc71NO/Xtzq2yWb9OxprntCwFA1fLJHwDr92P4Q8WfklvgSy5mdjPwNLCmmX1gZgcDZwHbmdlb\nwLbpdyHaFPJt0VZZ4BG6u+9bpKj0G9qFaOXIt0VbZYETi5rdsJk/VLdZSc2Pbn82rmfP2aHGb4pP\nRI7e78+h5vwMjx5Ptu6h5lvvGGr6MLlkuW0V/6a6w+K8Gts/7j+7I0Nb37ZMW3wSt/VIz9J+A7Ct\nPbPAiUXNxcwcu7Jo+bmzXg7rONouDTU3EifX7HdjnISVZbt8/0W8XTo8l8EHquO2pi0et/Xpd/Fs\nZmtmmLXKHovb8qcyuNEfM/j2xXFb9nAg2KgaG16exCIhhBCtCAV0IYTICQroQgiRExTQhRAiJyig\nCyFETlBAF0KInKCALoQQOUEBXQghckJLv5yrSWz37ydLlh+7ZzzjzhkXtQ81NxwZJ2Csbu+GmvHe\nK9R0ILZnrK0Rah7zISXLt3siTmBa7ouGr/Sen7fpF2p67xEnQnXfb2aoqdsp7pvvOocSaqiJRfPN\nT7GQ8V8VLbrSxoSrH3tFnPB39WGLhZoZGV6XNKl9vF3WeDquZ/iOsc0nPxy31WOruK0eB04INR9e\nt2yoWWl63Bb949/1SoY+3ODBuCk7vsRMV0C1Q6lxuEboQgiRExTQhRAiJyigCyFETlBAF0KInKCA\nLoQQOUEBXQghcoICuhBC5AQFdCGEyAkVTSzyJ0vPBPLUTzYP69ht2C2h5l72CjVDiWeImWI9Q83h\nfkWo2XbcU6GGF0sXT9tjibCKV3vEzQzsW3zC2Xr81gwzttxUOiEC4Eb2DjUDiGfzyaIpnbK2EOhf\nvOgIuzxcfeSh1aHmYG4ONSM63xpqDown4uLATf4WaobOin3fJr4Uavy42J6x260Yavpd/mHc1toZ\nfHubeDaimbM3CDU/5U9xW0cH9vQD/lW8WCN0IYTICQroQgiRExTQhRAiJyigCyFETlBAF0KInKCA\nLoQQOUEBXQghcoICuhBC5ISKJhaxSemH6J88dbuwCts1nk3E741nE/n1yfEsQhvyZqj5P+Lko8vf\nODrUsEfpZIYeO8TH4u7LZUiaGBsnTdiDcVvtx8TbYdiAjULNwf+LE2EOX++CUFNxbi/e979/OU7S\nsfvj/nzkhC1CzQFXZ/CBg2MfuO7ieB+6YNjhoWbLlYOMOcAejv1t9VUmhRomxMluNi5uq26b+Lcf\n9OioUFPtI0MN0cRpwYxeGqELIUROUEAXQoicoIAuhBA5QQFdCCFyggK6EELkBAV0IYTICQroQgiR\nExTQhRAiJ5h7nMDQ6Ipm1wA7A1PcfYN02SnAUODjVPZHd/9vkfWdHUs/+H/A/XECxl1f7x5qftc5\nTkR51dYPNdvUPRq39VI8a8sDA7cONevxesnyERwY1vEz7g41q3w9IdRc2PnIUHPiyPNDzYDtnw01\nPXxqqBlTt2GomdZhZdw9Q1bN/LSIb29aYr/aMt7n/nzOUaGmm00PNdv7A6Fm9Ulxks4HvZcNNaMY\nHGp2P/DfoebsEcNCzfr+SqjZ6fXaUPNG/z6hZkmfEWr63PlxqBm052OhZrp3K1m+JV24rl2/or7d\nnBH6tcD2jSw/390Hpn+NOrwQrRz5tmiTLHBAd/cngc8aKVqgUZEQrQX5tmirlOMa+q/N7GUzu9rM\nlipD/UJUCvm2aNW09Mu5LgOGu7ub2enA+cAvi6rfqZn7uUcVLFPVwuaIRYXva5/h+8eeKWcTTfPt\nCTVzP3ergqWqymmbyDEzakfxTe0LALzE4iW1LRrQ3f2Tgq9XAf8sucIaNS3ZvFiEWaxqMxar2mzO\n929Pa9k3MjbZt1euadH2xaJLp6pBdKoaBMBGdGHM8EuKapt7ycUouK5oZssXlP0ceK2Z9QtRKeTb\nos2xwCN0M7sZqAKWMbMPgFOAH5nZhkAd8D5wWAvYKMRCRb4t2ioLHNDdfd9GFl/bDFuEaBXIt0Vb\nZYETi5rdsJkfWXdGSc32FidFXOsHh5p3WS3UjD5ny1CTYcIimJXhybYMsyxxZ6C5bXhYxQ/qtgk1\nl3icxLH5yS+FGr6PJZyT4XevnmWWpYcyNFa9wIlFzcXMnA4lfmu/DJXckaGvMgzH9lprRKh5wmPf\nP8yuDDVZunv4/WeGmu12vi/U/IIbQs0M7xRqDn887p+Tf3hCqPm7HxLXQ7zPDr3rxpLl1T1h5Nbt\nypJYJIQQohWhgC6EEDlBAV0IIXKCAroQQuSEVhPQJ9a+V2kTms5HtZW2oMl8WZvhBmdrY0ZtpS1o\nHnW1lbagycysfa7SJjSZN2o/iUWtiLdqp7R4nQrozWFybaUtaDJf1r5caROazje1lbageXhtpS1o\nMt8poJedXAd0IYQQzaOlX87VJFZibjZ1N7rM8z1ZtmZYR196hJrF6BIb0yuW8M28XyeNg96rNtDM\nzlDP0hk0fYPygSuEVazdyO/+jsXnWd6ZdcJ6BvYOJTArg2ZgBs1K8y+a9Cb0XrtgQbeuYTWjR2do\nq4wM3Gju50kfQu8VCwpXzlDBEhk07WNJX5YJNZ/Tcb5lY2lPv4LlK7DifJqGeIa3Cw/M8I7KfsSi\nHo3klizJR/Ms75ShEwdmCA1Zfnv/RvqwIcvQZ57vS/LBfMsGBrGhXxcYWaK8oolFFWlYLDJUNLFI\niDJSzLcrFtCFEEK0LLqGLoQQOUEBXQghckKrCOhmtoOZvWlmb5vZcZW2Jwtm9r6ZjTGzl8zs+Urb\n0xhmdo2ZTTGzVwqWdTezkWb2lpk90JqmUiti7ylmNtHMRqd/O1TSxqbS1nxbfl0eFpZvVzygm1k7\n4FKSWdbXA/Yxs7VLr9UqqAOq3H0jdx9caWOK0Njs9ccDD7n7WsAjQPwquYVHY/YCnO/uA9O//y5s\noxaUNurb8uvysFB8u+IBHRgMvOPu4939e+BWYNcK25QFo3X0X1GKzF6/K1D/ztARwG4L1agSFLEX\nyPA8XOukLfq2/LoMLCzfbg0bbkVgQsH3iemy1o4DD5jZKDMbWmljmkBPd58C4O6TgeUqbE8Wfm1m\nL5vZ1a3tVDqgLfq2/Hrh0qK+3RoCemNHqLbwLOXm7r4xsBPJRskwQ4ZYAC4DVnf3DYHJwPkVtqcp\ntEXfll/3XIupAAABIElEQVQvPFrct1tDQJ8IrFLwfSVgUoVsyUw6CqifDf5uktPrtsAUM+sFcyY+\n/rjC9pTE3T/xuckSVwGDKmlPE2lzvi2/XniUw7dbQ0AfBfQzs1XNbHFgCBDPQVVBzKyTmXVJP3cG\nqmm9s8DPM3s9Sd8elH4+ELh3YRsUMI+96c5Zz89pvf3cGG3Kt+XXZafsvl3Rd7kAuPtsM/sNySsK\n2gHXuPsbFTYrohdwd5ri3QG4yd1LvWKhIhSZvf4s4HYzOwT4ANizchbOSxF7f2RmG5I8ffE+cFjF\nDGwibdC35ddlYmH5tlL/hRAiJ7SGSy5CCCFaAAV0IYTICQroQgiRExTQhRAiJyigCyFETlBAF0KI\nnKCALoQQOUEBXQghcsL/A1cunn39vbPfAAAAAElFTkSuQmCC\n",
       "text/plain": [
-       "<matplotlib.figure.Figure at 0x7f7dbafa9128>"
+       "<matplotlib.figure.Figure at 0x7f4e8bf51668>"
       ]
      },
      "metadata": {},

--- a/docs/source/pythonapi/examples/mgxs-part-iv.ipynb
+++ b/docs/source/pythonapi/examples/mgxs-part-iv.ipynb
@@ -433,7 +433,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPoAAAD6AgMAAAD1grKuAAAABGdBTUEAALGPC/xhBQAAACBjSFJN\nAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAADFBMVEX////pgJFyEhJNv8RV\nUZDeAAAAAWJLR0QAiAUdSAAAAAd0SU1FB+AFFhUdFe9e330AAAWFSURBVGje7Zs7cttADIZ9CSvX\ncrP0iCxUqbBc8Ag6xR6BhV2EvYvwFD4CCx1ABT1jMdgndpegRQnOrCbjpPlGESISC4A/gd27e8H5\n83CX3b4+iKJrRHkS4vkghMPBonRYWGwtfgD2YN+dRDUOoh6lACw0Noi9w2fESuEoAR/uVuMolX03\n9oXGT7F3eFL2iEfhUX1f4cPdL/ishs+68ai+udE4xPhexbjX2FfjGNoPj/DPNX4Tsd+EODr8FvsV\ndf1Hd9P2VvCi4+s/aXvrf+upAD+1/9GV1mkOH5X9vV6THtfvACslcaUCbESL61drBPtdI8SrFMWr\nELsXCkuFDYW75gbiP7d9Cf7bAYI/aCwUShrBvh30+lWQkzVgZ/HD4OixNCgcQpJ3BxU/Ln91elKo\nM5VEE38QtJ+Yv6cQ9xjKNYayyl8TypP8DfJnQ2H/b/N3ye9P83cT33SQv/sQh9gV7zZ/0dNj5HQa\nC5vVzv9+/WFN2w8KVaZ2BwL1+pv4g0x1QRfjq0dB4Q3kT277oP6VNL6gKxNU9a8zK+WLbi/Wwpdi\nhbboKqyxFOulHMj6v4W/AXbmUeAxrv9J/CqEBXaRKsXaodD4nsYvkT/G6H1D4SR/iPy1Roj9JsQ5\ne18/7EUHv1+Fvx/Xj5V9Ugb5K8TW4TZEEdcvoz/up0VTe9qsVIppKVX6a7D6y9ZvwEKjrtQxPtv6\nfXII9vCxKOGaIeAIfEF8IvAG8ie3vRK9rRQl+PPpSctbhfpTUCpviH+kxsZgpT91+snoX1l49KK3\niUQvICRy5aUw6l8leoVwoo3Uv1rKreF/UFLY6d9QP4L9Wf2r7EP9GOSfcsjZ56f60kz+XmVPXv+R\nuP49ff0T/53Rv6n/7m2lvXT9Wqd/VUz8hvh5M/ED6ILmt4mfHYZSaePnTWpsf/SvqV9O6dLYYClL\nEetnoH/LBLFoBvrX189uTv8++kot5vTvQD4/9jP690g9P/4z/bvo/XVG/xYoZZx+8fr3MxAtsf7t\nUOkG2JqsTtCIpgCt/qX1226KqZS7gfzJbe+c9jLrtIZ8lXD+s4umlW6AKIVrlML2/cXjgPFjlJqI\nRC+Fj0bVJe+vSh56pSdR6YkQ1ygF10Wqf0FeLta/iKn9Mv1L24ti2e+7W4n1b3T/W+L+t9H9T/Sv\nVboUmqJJon1/hZq8LnzRDlDrX1u0xRT1+6vEpomMmyYkqi95vIH8yW1PN+122KkLcNLKi/WTF01z\n/cNASrWE/l3ev6T17zX909z9X27/euK/Rf3zWP+Waf9eEv37KkWJ+rfDl6ZglNDa+cEBhwYDvkoN\nP/rX69814NaI3imq0l7OYDy/qSdDGwr7r+Y3VbzoKZr6XX2lfxfOb87qXzr+b1j/Xlp/nP6dn98M\ncdH7cn7zjPObKsYWS3Eb9w8n85smHtqQuPuZ30T2dlIT6F9xFl+n8xslegL9a4c2KRr9W4rp/GYq\numiM9Nec/j2v/yj9u1h//hv9e93vc++f63/u+rPjL3f+5Lbn1j9m/eXWf+7zh/v8+2b9e/Hzn6s/\nuPqHrb8g71n6L3f+5Lbnvn8w33+4718/+5d47//c/gO7/5E7/nPbc/tv3P4fs//I7X9y+6/fqH+v\n6j9z+9/c/ju3/8+eP+TOn9z23PkXc/7Gnf9x5483q38Xzn+582fu/Js9fy8kb/6fO39y23P3n3S8\n/S/c/Tfc/T83uX/pgv1XE/9duP+Lu/+Mvf8td/znti8kb/8ld/9nx9t/Sjw/Ltr/yt1/+337f6/b\nf0zoB3nJ/ucVc/81d/83e/957vzJbc89/8A8f8E9/5HE78XnT/4H/cs5f8Q9/8Q9f8U+/5U7f3Lb\nc88fdrzzjyvm+cuf/Uu887/c88fs88954/8vO4SjPC+2QRIAAAAldEVYdGRhdGU6Y3JlYXRlADIw\nMTYtMDUtMjJUMjE6Mjk6MjEtMDQ6MDBAdsrxAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE2LTA1LTIy\nVDIxOjI5OjIxLTA0OjAwMStyTQAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPoAAAD6AgMAAAD1grKuAAAABGdBTUEAALGPC/xhBQAAACBjSFJN\nAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAADFBMVEX////pgJFyEhJNv8RV\nUZDeAAAAAWJLR0QAiAUdSAAAAAd0SU1FB+AFGBM0Bsv0CskAAAWFSURBVGje7Zs7cttADIZ9CSvX\ncrP0iCxUqbBc8Ag6xR6BhV2EvYvwFD4CCx1ABT1jMdgndpegRQnOrCbjpPlGESISC4A/gd27e8H5\n83CX3b4+iKJrRHkS4vkghMPBonRYWGwtfgD2YN+dRDUOoh6lACw0Noi9w2fESuEoAR/uVuMolX03\n9oXGT7F3eFL2iEfhUX1f4cPdL/ishs+68ai+udE4xPhexbjX2FfjGNoPj/DPNX4Tsd+EODr8FvsV\ndf1Hd9P2VvCi4+s/aXvrf+upAD+1/9GV1mkOH5X9vV6THtfvACslcaUCbESL61drBPtdI8SrFMWr\nELsXCkuFDYW75gbiP7d9Cf7bAYI/aCwUShrBvh30+lWQkzVgZ/HD4OixNCgcQpJ3BxU/Ln91elKo\nM5VEE38QtJ+Yv6cQ9xjKNYayyl8TypP8DfJnQ2H/b/N3ye9P83cT33SQv/sQh9gV7zZ/0dNj5HQa\nC5vVzv9+/WFN2w8KVaZ2BwL1+pv4g0x1QRfjq0dB4Q3kT277oP6VNL6gKxNU9a8zK+WLbi/Wwpdi\nhbboKqyxFOulHMj6v4W/AXbmUeAxrv9J/CqEBXaRKsXaodD4nsYvkT/G6H1D4SR/iPy1Roj9JsQ5\ne18/7EUHv1+Fvx/Xj5V9Ugb5K8TW4TZEEdcvoz/up0VTe9qsVIppKVX6a7D6y9ZvwEKjrtQxPtv6\nfXII9vCxKOGaIeAIfEF8IvAG8ie3vRK9rRQl+PPpSctbhfpTUCpviH+kxsZgpT91+snoX1l49KK3\niUQvICRy5aUw6l8leoVwoo3Uv1rKreF/UFLY6d9QP4L9Wf2r7EP9GOSfcsjZ56f60kz+XmVPXv+R\nuP49ff0T/53Rv6n/7m2lvXT9Wqd/VUz8hvh5M/ED6ILmt4mfHYZSaePnTWpsf/SvqV9O6dLYYClL\nEetnoH/LBLFoBvrX189uTv8++kot5vTvQD4/9jP690g9P/4z/bvo/XVG/xYoZZx+8fr3MxAtsf7t\nUOkG2JqsTtCIpgCt/qX1226KqZS7gfzJbe+c9jLrtIZ8lXD+s4umlW6AKIVrlML2/cXjgPFjlJqI\nRC+Fj0bVJe+vSh56pSdR6YkQ1ygF10Wqf0FeLta/iKn9Mv1L24ti2e+7W4n1b3T/W+L+t9H9T/Sv\nVboUmqJJon1/hZq8LnzRDlDrX1u0xRT1+6vEpomMmyYkqi95vIH8yW1PN+122KkLcNLKi/WTF01z\n/cNASrWE/l3ev6T17zX909z9X27/euK/Rf3zWP+Waf9eEv37KkWJ+rfDl6ZglNDa+cEBhwYDvkoN\nP/rX69814NaI3imq0l7OYDy/qSdDGwr7r+Y3VbzoKZr6XX2lfxfOb87qXzr+b1j/Xlp/nP6dn98M\ncdH7cn7zjPObKsYWS3Eb9w8n85smHtqQuPuZ30T2dlIT6F9xFl+n8xslegL9a4c2KRr9W4rp/GYq\numiM9Nec/j2v/yj9u1h//hv9e93vc++f63/u+rPjL3f+5Lbn1j9m/eXWf+7zh/v8+2b9e/Hzn6s/\nuPqHrb8g71n6L3f+5Lbnvn8w33+4718/+5d47//c/gO7/5E7/nPbc/tv3P4fs//I7X9y+6/fqH+v\n6j9z+9/c/ju3/8+eP+TOn9z23PkXc/7Gnf9x5483q38Xzn+582fu/Js9fy8kb/6fO39y23P3n3S8\n/S/c/Tfc/T83uX/pgv1XE/9duP+Lu/+Mvf8td/znti8kb/8ld/9nx9t/Sjw/Ltr/yt1/+337f6/b\nf0zoB3nJ/ucVc/81d/83e/957vzJbc89/8A8f8E9/5HE78XnT/4H/cs5f8Q9/8Q9f8U+/5U7f3Lb\nc88fdrzzjyvm+cuf/Uu887/c88fs88954/8vO4SjPC+2QRIAAAAldEVYdGRhdGU6Y3JlYXRlADIw\nMTYtMDUtMjRUMTk6NTI6MDYtMDQ6MDBj3IIkAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE2LTA1LTI0\nVDE5OjUyOjA2LTA0OjAwEoE6mAAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<IPython.core.display.Image object>"
       ]
@@ -724,7 +724,7 @@
       "      License:        http://openmc.readthedocs.io/en/latest/license.html\n",
       "      Version:        0.7.1\n",
       "      Git SHA1:       b7cc8a3a1460a9662fd3e8d11a6c0cf5902946c2\n",
-      "      Date/Time:      2016-05-22 21:29:21\n",
+      "      Date/Time:      2016-05-24 19:52:06\n",
       "      OpenMP Threads: 4\n",
       "\n",
       " ===========================================================================\n",
@@ -811,20 +811,20 @@
       "\n",
       " =======================>     TIMING STATISTICS     <=======================\n",
       "\n",
-      " Total time for initialization     =  1.4810E+00 seconds\n",
-      "   Reading cross sections          =  1.1840E+00 seconds\n",
-      " Total time in simulation          =  1.9619E+01 seconds\n",
-      "   Time in transport only          =  1.9512E+01 seconds\n",
-      "   Time in inactive batches        =  2.1770E+00 seconds\n",
-      "   Time in active batches          =  1.7442E+01 seconds\n",
-      "   Time synchronizing fission bank =  1.0000E-02 seconds\n",
-      "     Sampling source sites         =  6.0000E-03 seconds\n",
-      "     SEND/RECV source sites        =  4.0000E-03 seconds\n",
-      "   Time accumulating tallies       =  1.0000E-03 seconds\n",
+      " Total time for initialization     =  1.4330E+00 seconds\n",
+      "   Reading cross sections          =  1.1310E+00 seconds\n",
+      " Total time in simulation          =  1.8040E+01 seconds\n",
+      "   Time in transport only          =  1.7983E+01 seconds\n",
+      "   Time in inactive batches        =  2.0740E+00 seconds\n",
+      "   Time in active batches          =  1.5966E+01 seconds\n",
+      "   Time synchronizing fission bank =  8.0000E-03 seconds\n",
+      "     Sampling source sites         =  5.0000E-03 seconds\n",
+      "     SEND/RECV source sites        =  3.0000E-03 seconds\n",
+      "   Time accumulating tallies       =  0.0000E+00 seconds\n",
       " Total time for finalization       =  0.0000E+00 seconds\n",
-      " Total time elapsed                =  2.1110E+01 seconds\n",
-      " Calculation Rate (inactive)       =  22967.4 neutrons/second\n",
-      " Calculation Rate (active)         =  11466.6 neutrons/second\n",
+      " Total time elapsed                =  1.9482E+01 seconds\n",
+      " Calculation Rate (inactive)       =  24108.0 neutrons/second\n",
+      " Calculation Rate (active)         =  12526.6 neutrons/second\n",
       "\n",
       " ============================>     RESULTS     <============================\n",
       "\n",
@@ -953,7 +953,7 @@
    "metadata": {},
    "source": [
     "We will now use the `Library` to produce a multi-group cross section data set for use by the OpenMC multi-group solver.  \n",
-    "Note that since we have ran so few histories, is not unreasonable to expect some divisions by zero errors.  This will show up as a runtime warning in the following step."
+    "Note that since this simulation included so few histories, it is reasonable to expect some divisions by zero errors.  This will show up as a runtime warning in the following step."
    ]
   },
   {
@@ -1100,7 +1100,7 @@
       "      License:        http://openmc.readthedocs.io/en/latest/license.html\n",
       "      Version:        0.7.1\n",
       "      Git SHA1:       b7cc8a3a1460a9662fd3e8d11a6c0cf5902946c2\n",
-      "      Date/Time:      2016-05-22 21:29:43\n",
+      "      Date/Time:      2016-05-24 19:52:26\n",
       "      OpenMP Threads: 4\n",
       "\n",
       " ===========================================================================\n",
@@ -1184,20 +1184,20 @@
       "\n",
       " =======================>     TIMING STATISTICS     <=======================\n",
       "\n",
-      " Total time for initialization     =  3.4000E-02 seconds\n",
-      "   Reading cross sections          =  3.0000E-03 seconds\n",
-      " Total time in simulation          =  1.4720E+01 seconds\n",
-      "   Time in transport only          =  1.4678E+01 seconds\n",
-      "   Time in inactive batches        =  1.3020E+00 seconds\n",
-      "   Time in active batches          =  1.3418E+01 seconds\n",
-      "   Time synchronizing fission bank =  6.0000E-03 seconds\n",
-      "     Sampling source sites         =  3.0000E-03 seconds\n",
+      " Total time for initialization     =  3.6000E-02 seconds\n",
+      "   Reading cross sections          =  7.0000E-03 seconds\n",
+      " Total time in simulation          =  1.4412E+01 seconds\n",
+      "   Time in transport only          =  1.4376E+01 seconds\n",
+      "   Time in inactive batches        =  1.2750E+00 seconds\n",
+      "   Time in active batches          =  1.3137E+01 seconds\n",
+      "   Time synchronizing fission bank =  1.0000E-02 seconds\n",
+      "     Sampling source sites         =  7.0000E-03 seconds\n",
       "     SEND/RECV source sites        =  3.0000E-03 seconds\n",
       "   Time accumulating tallies       =  0.0000E+00 seconds\n",
       " Total time for finalization       =  0.0000E+00 seconds\n",
-      " Total time elapsed                =  1.4763E+01 seconds\n",
-      " Calculation Rate (inactive)       =  38402.5 neutrons/second\n",
-      " Calculation Rate (active)         =  14905.4 neutrons/second\n",
+      " Total time elapsed                =  1.4458E+01 seconds\n",
+      " Calculation Rate (inactive)       =  39215.7 neutrons/second\n",
+      " Calculation Rate (active)         =  15224.2 neutrons/second\n",
       "\n",
       " ============================>     RESULTS     <============================\n",
       "\n",
@@ -1384,7 +1384,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.text.Text at 0x7f4e8bedf400>"
+       "<matplotlib.text.Text at 0x7f83decbba20>"
       ]
      },
      "execution_count": 40,
@@ -1395,7 +1395,7 @@
      "data": {
       "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXQAAADDCAYAAACS2+oqAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJztnXeYFeX1xz8HUJSmoIJiA8WOokSwm43RtUSjiQ1LbAnq\nzySYaGzR6IrGHns0tih2YzcxidjWXlAUS2woIoiggoqKorDn98fMwmXZe88su5e7O3w/z7PP3jvv\nd9733HfOnHmnnHnN3RFCCNH2aVdpA4QQQrQMCuhCCJETFNCFECInKKALIUROUEAXQoicoIAuhBA5\nodUFdDN7zcy2rrQdizJm9m8z+0Uz1r/czE5sSZsWRcyszsxWK1Ge231FPriAuHv4B+wLjAK+BD4E\n7ge2yLJuUO+1wPDm1lPJv/Q3zASmp39fAi9V2q4Mdp8CfFdg83TgD5W2qwk2TwOeBDZtwvqPAocs\nBDvfB74FejRY/jJQB6ySsZ7ZwGoFftakfQVYDDgZeDPdxhPSfXe7Sm/LRranfLAF/sIRupkdBZwP\nnA70BFYBLgN+Gq27CHG2u3dL/7q6+0Yt3YCZtW/pOoFbC2zu5u7nlaGNluZWd+8GLAvUArdX1pxG\ncWAcsE/9AjPrDyyRlmXFmmnHncAuwP5Ad6AvcBGwU6ONlcfHIuSDLUlwNOlGcuT8eQnN4sCFJCP3\nicAFwGJp2Q9JRgVHAVNSzUFp2VCSI923JEe7e9Pl44BtCo6GtwEjUs2rwMCCtutIRzDp93lGMWkb\n7wCfAvcAK6TLV03XbdfYkRNYnWRDfQ58DNxS4vcXHTkVtHMAMD6t648F5QYcD4wFPgFuBZZusO4h\n6bq16fIDSEaAnwAn1fcX0Av4GuheUP8P0jbbFxlpXB+NIkr1Rbqtp6RlLwPrNmU7FGzDw4C3ganA\npcHo6PqC7+uQjGKXSb8vDfwztXNq+rl3WnY6MAuYkfrSxenytYGRqf4NYM+C+ncCXk/1E4CjMo7C\nxgF/BJ4vWHYucEJq7yqNjdaAA4EnGvo3GfaVRmzYNvWHFTLYeiwwBviG5DLsOqltn5Hsc7s05hsl\nbP4t8G66Hc7Juj3lg833wWiEvhnQMe2AYpwEDAY2AAakn08qKF8e6Ar0Bn4F/NXMlnL3q4CbSDZ4\nN3fftUj9uwA3A0ulnfPXgrKiox0z2wY4A9gDWAH4gCRghusCpwEPuPvSwErAJSW0WdgCWINkJzvZ\nzNZKlx9JcqazFUn/fEZy9lPI1iQbfHszW4fk9+9D8puWStfD3aeQ7AR7Fay7H4nzz26G7Y32hZlV\nA1sC/dKyvUkcch4ybAeAn5AcfDYE9krrLomZLU4STKaS9BskwejvwMokZ5IzSP3F3U8CngB+k/rb\nMDPrRLIj3Ugy2toHuCztZ4CrgaGejMb6A49EdhXwLNDVzNYys3Yk2+VG4lH3fH7ZhH2lkB8Dz7n7\nRxm0Q4AdSYJRO+A+4L/AcsAw4CYzW6MJNu8GDEz/djWzQzLYUAr5YEYfjAL6MsCn7l5XQrMvcKq7\nT3X3qcCpQOHNjO+A09x9trv/B/gKWKuReorxpLs/4Mnh6gaSA0c9pXaOfYFr3H2Mu39PMjrazMxW\nydDm98CqZraiu3/n7k8H+mPMbJqZfZb+v7agzIGatJ5XSEZCA9KyQ4ET3f2j1MbhwB5pAKhf9xR3\n/8bdZ5I45H3u/oy7zyK5PlrI9aR9n9axD0mfFWPvBnYv34S++J7kQL2umZm7v5UeVBqSZTuc6e5f\nuvsEkoPShpHNJDvKL4E96v3T3ae5+93uPtPdvwbOJDkgFmNnYJy7X+8JL5NcptgjLf8OWM/Murr7\nF2l5U7iBZIffjuQ69qQmrt8clgUm138xs+7pdv7czL5poL3I3SelPrYp0Nndz3b3We7+KPAvCi4f\nZeCstL8mkpy9l1pXPtiCPhgF9KnAsgUBpjF6kxzx6hmfLptTR4MDwgygS9BuIZMLPs8AlgjsKbRr\nfP2XtHOnAitmWPcYkr553sxeNbODAczsBDP70symm1nhSPpcd+/h7t3T/wc3qK/QyQp//6rA3akj\nTwP+R+KkvQr0Exv8pgkFv+kb5h2R3AusY2Z9gGrgc3d/ocTvvK2B3ZMb0TTaF+mOfinJ6GOymf3N\nzBrbrlm2Q7H+KWozyf2c14CN6wvMbEkzu8LM3jezz4HHgKXNrNiBf1Vg0/r+N7PPSHb++v7fnWTk\nNt7MHjWzTUvY1Rg3pvUdRHKwLRupX9b75kokfbxCfbm7f+bu3UlGoYs3WL2oj6WMJ9t+01h9DeNB\nQ+SDLeiDUWB8huS63W4lNB+mRhUamHUk0pQbRI0xA+hU8L3w6D6p0C4z60xyxjGR5NoixdZ194/d\n/VB3XxE4nOQUaDV3P9Pn3rw5opm2Q3Ig3DF15Hqn7tzgNLmwjz4iOeWs/01Lpr+p3u6ZwD9IboLt\nT+nReSaK9UVadqm7bwysR3LWdUwjVZTaDs2xa1pqT42Z1Tv/0SSXtgalp+D1I6P6namhv00guTdR\n2P/d3P03aRsvuvtuJJce7iXp26bY+AHJNeodgbsakXxNcf+dr7qgra4FvjkReBgYZGaNBdOGwaWw\n7kkklwsKWYVkP89qc+H6q9DMMxP5YHYfLBnQ3X06yU2Av5rZrunRp4OZ7WhmZ6WyW4GTzGxZM1sW\n+BPZA8kUkps+TaHQGV8C9jWzdma2A8lN2HpuBg42sw3MrCPJNbRn3X2Cu39K4qD7p+seQnLjJWnA\nbA8zqz96f05y02RBr0OXuix0BXBG/amfmS1nZoVPDzVc9w5gFzPb1MwWI7m81ZAbSEaEu5CMEJtF\nsb4ws43NbLCZdSC5mfYtjfdR0e3QXNvc/S2Sa73HpYu6prZMN7MeQE2DVRr627+ANc1s/9SvF0t/\n19rp533NrJsn9yC+JLmh1VQOIblx2fAyByQ38X6e7lf9SE7fi9GkfcXdHyS5dHBPup0WS7fVZpQ+\nODwHfG1mx6Z9UkVyWeCWJth8jJktbWYrk9wnani9uknIB7P7YHjpwt0vIHlK5SSSO7cfAEcw90bp\n6cALQP314ReAP5eqsuDzNSTXh6aZ2V2NlEfr/47kpuJnJNfp7i6w+xGSg8tdJMG7L8nNn3qGktzd\n/5TkTvVTBWWDgOfMbHr6O4e5+3iKc2x6qjs9Pe39uIi9Db9fRHLUHWlmXwBPk9xUbnRdd/8fyRME\nt5GMOr4g2SYzCzRPkzj86HSEuCAUtlusL7oBV5E8izuOpB/ne+Qsw3Yo1T9ZOA8Ymg4mLiQZPX5K\n0pf/bqC9CNjTzKaa2YXu/hXJpakhJP05CTiLuZckfgGMS0+dDyW5yZyFOb/B3ce5++jGykie0Pie\n5LLitcx/AG7uvvJzkoBxI8k+8h7JfrJ9kTZIrzH/lOTpik9JLmn8wt3fyWgzJD79IjCa5EGGvwd2\nNoZ8MKFJPmjuzb3qISpFeur4Ocld/vEFyx8GbnL3BdmRhFhgzKyOxB/fq7QtiyKtLvVflMbMdk5P\ndzsDfwFeaRDMBwEbkYzihRCLEArobY9dSU7LJpJc959z6mhm15E803pkeidfiIWNTvkriC65CCFE\nTtAIXQghckKHclSaPkJ4IckB4xp3P7sRjU4NRFlx9+a+3Go+5NuiNVDMt1v8koslWZxvk7xLYhLJ\na3eHuPubDXTOcQVtP1kDW9bMW9mIDA1ekEGTJWn51QyaFxr01T01sFvNvMsOjnMVLqg7PdT8/u2/\nlSy/eM2hYR3DHrlq/oUjauDAmjlfV/rxO/NrGvDynDcVFOdqfhVqvqNjqLnCD5tv2fSai+lWM2zO\n9w+fL/VakZRNrcUDepN8+/iC5OgnamCrmjlf+57xv7Ctce+uGxs0OcPPezjev7v84ZP5ls3887l0\nPHFujs7/dbo8rOfcYQ3fRDE/Ay55NtT099dCzU1HNOJvo2pgUM2cr49ftvH8mgZs/ZdSidQpx8R9\nuHXdyFDz+AM7zLvgxhrYv2beZTuWrqO6GkaOLO7b5bjkMhh4x93Hp8+03kpyI0+Ito58W7RqyhHQ\nV2Ted0FMpGnvgRCitSLfFq2aclxDb+xUoPFzlidr5n7uuHQZTCkza1dV2oKmM6Cq0hY0mY5Vm8Si\nF2thdG25Tcnu20/UzP3cBn27/VabV9qEptO7qtIWNI0NqjIKa9M/GDu2tLIcAX0iyQt56lmJYi/n\naXjNvK3RFgP6hlWVtqDJZAroP6hK/uq5prHX3DSb7L5dcM28LdJh6y0qbULTWbGq0hY0jcwBvSr9\ng3794L33ivt2OS65jAL6mdmqlrwAfgjJC/OFaOvIt0WrpsVH6O4+28x+Q5KxWP9o1xst3Y4QCxv5\ntmjtlOU5dHf/L02blUiINoF8W7RmKpb6b2ZOn6DtbWPb7LQZocYv7RRqZg+JJzxfYvnPQ03XpaeH\nmk06PBdq1gkGfhd9fGRYx5E9Lwo1VfZoqHmHNUPNmHlmBmycZ9gs1HxO91CzQoZpMl9pt1lZEouy\nkCQWlZq1MfZZ7LNYs1v8gM1md8bToJ5EnBfxk5PjerocN//z7A2p7hw/r33X9fFbik854PhQ04f3\nQ83hX8TP18/8TeyT/CiWXHRwnDtyZPuVSpZXV6/OyJEHLNTn0IUQQlQABXQhhMgJCuhCCJETFNCF\nECInKKALIUROUEAXQoicoIAuhBA5QQFdCCFyQlkyRTNzblA+M67isJ6lJ4IA6HXGH0KNdY1zUGYe\n2zXUVPF0qOntjb/PqZDzOLFk+Vo9Dwjr6E88UcBmPjrUPMtGoeb358fb4a6jg7f3A+dwbKjZ2f4V\nal4JFWXmlyXKrolXf3x2/Jr1frwbano9Fye62SazQ83sp+PEu5073R5q7iBOGhp1QJyk9iXdQs02\nPBlqNlmqb6j58IY4geuWDLPoXMWhoYZNBpUuXxsYWXzf1whdCCFyggK6EELkBAV0IYTICQroQgiR\nExTQhRAiJyigCyFETlBAF0KInFDZ59D7BOVd4iou/eyYUNNudqnJBlKujI9tH9Ej1CxvF4Sa3f3O\nUOOPlJ7A4vkfx5NX7O53hBoGx88Xb7JUXA0Pxn38s6vjPv7rr44INXeyewaD/pJBUz6GXnlx0bKr\nZg4L1+/EN6FmeTJMgtEr7vNhnBNq9n5ow1Bzhp0Qai71/4SaXtYn1Nzue4aabT6MfXutiaGEtTcZ\nF7f1VtxW+8/j5/3ZMMiHWb10sUboQgiRExTQhRAiJyigCyFETlBAF0KInKCALoQQOUEBXQghcoIC\nuhBC5AQFdCGEyAnm7pVp2MxH1a1bUjPowxfCeuq+6RRqBq3+WKh54fEfhhqfEUpgQAbNIxk0QY7G\nERPjxJm3vV+o2aZdPJHCiY+GEuqeiicIefGPpbc3QHebFmqu5LBQc67V4O6xUWXAzHyduuK+O3Zq\nvF1GLBtPYJLl540Ps/fg+OfjJDU6x5Kj1vtzqDn/8dITtwAM3zpOFjx5XDQ7DvBsLBmxf6w5sDqD\nG10Sx9Hr+u0dak7jTyXLt6Iz17frW9S3NUIXQoicoIAuhBA5QQFdCCFyggK6EELkBAV0IYTICQro\nQgiRExTQhRAiJyigCyFETijLjEVm9j7wBVAHfO/ugxvTDbFbS9Yzunc8SwoWz5QzmPNDzTc/iJMH\nluiSYcaRF+Nj5C37xck8++x/d8nyr/yqsI4HP94t1Fhd3H9+T/ybnjpho1CzJXGiGI/FbW3yw+fi\nespEVt9+o33x2a3s7XgqriHL3BMb80ncV/5VhqSYwbEP2MtxW3957qS4ra3jtk7O8Ltu7BPPWrV/\n39tDzYHfZhjTxpOQQb/4d43n+FAzbs3SyXdrbFl6/XJNQVcHVLl7hjmyhGhTyLdFq6Vcl1ysjHUL\nUUnk26LVUi7HdOABMxtlZkPL1IYQlUC+LVot5brksrm7Tzaz5YAHzewNd3+yTG0JsTCRb4tWS1kC\nurtPTv9/YmZ3A4OB+Zx+Ws1lcz4vWTWIJasGlcMcsQjwWu1UXq+N39TYXLL6Nn5hwZdNwTYtu20i\np8yohW9qARj7Umlpiwd0M+sEtHP3r8ysM1ANnNqYtkfNES3dvFhE6V+1DP2rlpnz/fZTx7Z4G03x\nbex3Ld6+WETpVJX8Af02gvfGDC8qLccIvRdwt5l5Wv9N7j6yDO0IsbCRb4tWTYsHdHcfB2R4gFyI\ntoV8W7R2Kjpj0dW+T0nNMkwN6/mP7xhqetqUULOv3xJqXvCNQ80v3roz1HjHUMKYfqUTQmrr4gcs\nOvq3oebwY26IjamOfWT57caFmsnPrRa31TFuq93bcRIHQ9pVdMaiPWdfV7T89svj2YhmT2gfao48\n88xQM5kVQs1t4w4KNU/3jY9jHYgT7wa/+WqomdU79oG1ur0eat67qH+osfXjtrx3KOHttVYONWs/\nMT6u6JnSLlvdF0YOMc1YJIQQeUcBXQghcoICuhBC5AQFdCGEyAkK6EIIkRMU0IUQIicooAshRE5Q\nQBdCiJxQ0cQiu7V0IsKs9eJE1s36PxJq7iGeuee3XBJqdueOUNPVvww12379aKjp+PvS5XdfFSdU\nrcSEULO0fx5qXmRgqNmqkfdTzWfPyvHLs3y/UMIuZ/0j1Nzfbq+KJhbt7LcVLf/aO4V1rMikUPOl\nxTMfLZshOe9sPzbUjLJGJ2aah/7+WqihfewDK2bIvxmz8hqhprd/FNfDgFCzJDNCzRbvB2/NAtbs\n83KoGft6aXuqu8DIvkosEkKI3KOALoQQOUEBXQghcoICuhBC5AQFdCGEyAkK6EIIkRMU0IUQIico\noAshRE6oaGLRkLprSmp28n+H9exvt8eNXRwft54ftn6oGcyYuK0RcVu3H7BzqNnT7isteDBu57vB\ncV7N4kvFs8ywSdyW/zNuy3pmaGtc3Nabq60aata18RVNLLLziv/WWRvGCXO2TdxX5/PrUHPMXy4N\nNbOPztBNf4q3y6GnXRRqruS3oeb59nFbHWfHiUUDeCvU3MEuoWb3P8VxyE6Lt1e7v4cS9jzk+pLl\nA+jNSe2qlVgkhBB5RwFdCCFyggK6EELkBAV0IYTICQroQgiRExTQhRAiJyigCyFETlBAF0KInBBn\nOJSRt610csD6tnJYxz5114WaW34W2zKdbqHGT20fasaeslJsD/uEmj36lW7rvLFxUslavB1qtqBz\nqLn/uT1DzQyWDDXtOSDU9O27RaiZRO9QAxmmvSkj+x5VPGmuw82zwvXHECfOjLTzQs09R1eHmo38\ntFDz/knxDEp8F0s+XezmUHPXZXE9kzLMxMR68f66x5FxYuX9w38U29M+buuO2TuEmods25LlXSk9\nS5VG6EIIkRMU0IUQIicooAshRE5QQBdCiJyggC6EEDlBAV0IIXKCAroQQuQEBXQhhMgJCzxjkZld\nA+wMTHH3DdJl3YHbgFWB94G93P2LIuv7T+tKJxn88/G9QztmrRLnRp3S57hQs7f9I9S866uHmo+t\nZ6hZzd8LNT++4pmS5XWbhlVw7IDhoea0r08ONUu8Gbd16w9+GmqG7BjMwgS899/lQ83u3BVqxtjm\nCzxjUUv4Nl3rijdwS2xD9U73hpqRN+8aapbYeVrcVreRoea+9+J9ccvVHgo1D3+xfahZ7PRQwvXn\nxsluXdrFs5ntfmzclm8da16JJyHj6bo4se7wA0rPWMT61bQ7bmRZZiy6Fmi4dY4HHnL3tYBHgBOa\nUb8QlUK+LdokCxzQ3f1J4LMGi3cFRqSfRwC7LWj9QlQK+bZoq7T0NfSe7j4FwN0nA8u1cP1CVAr5\ntmj16KaoEELkhJZ+2+IUM+vl7lPMbHng41LiN2vumPN52ap1WbZq3RY2RywqfFU7mq9qR5eziSb5\nNjNr5n5uXwUdqspomsgztZOhdkr6ZfLYktrmBnRL/+q5DzgIOBs4ECh5q37tmj2a2bwQCV2qBtKl\nauCc71NO/Xtzq2yWb9OxprntCwFA1fLJHwDr92P4Q8WfklvgSy5mdjPwNLCmmX1gZgcDZwHbmdlb\nwLbpdyHaFPJt0VZZ4BG6u+9bpKj0G9qFaOXIt0VbZYETi5rdsJk/VLdZSc2Pbn82rmfP2aHGb4pP\nRI7e78+h5vwMjx5Ptu6h5lvvGGr6MLlkuW0V/6a6w+K8Gts/7j+7I0Nb37ZMW3wSt/VIz9J+A7Ct\nPbPAiUXNxcwcu7Jo+bmzXg7rONouDTU3EifX7HdjnISVZbt8/0W8XTo8l8EHquO2pi0et/Xpd/Fs\nZmtmmLXKHovb8qcyuNEfM/j2xXFb9nAg2KgaG16exCIhhBCtCAV0IYTICQroQgiRExTQhRAiJyig\nCyFETlBAF0KInKCALoQQOUEBXQghckJLv5yrSWz37ydLlh+7ZzzjzhkXtQ81NxwZJ2Csbu+GmvHe\nK9R0ILZnrK0Rah7zISXLt3siTmBa7ouGr/Sen7fpF2p67xEnQnXfb2aoqdsp7pvvOocSaqiJRfPN\nT7GQ8V8VLbrSxoSrH3tFnPB39WGLhZoZGV6XNKl9vF3WeDquZ/iOsc0nPxy31WOruK0eB04INR9e\nt2yoWWl63Bb949/1SoY+3ODBuCk7vsRMV0C1Q6lxuEboQgiRExTQhRAiJyigCyFETlBAF0KInKCA\nLoQQOUEBXQghcoICuhBC5AQFdCGEyAkVTSzyJ0vPBPLUTzYP69ht2C2h5l72CjVDiWeImWI9Q83h\nfkWo2XbcU6GGF0sXT9tjibCKV3vEzQzsW3zC2Xr81gwzttxUOiEC4Eb2DjUDiGfzyaIpnbK2EOhf\nvOgIuzxcfeSh1aHmYG4ONSM63xpqDown4uLATf4WaobOin3fJr4Uavy42J6x260Yavpd/mHc1toZ\nfHubeDaimbM3CDU/5U9xW0cH9vQD/lW8WCN0IYTICQroQgiRExTQhRAiJyigCyFETlBAF0KInKCA\nLoQQOUEBXQghcoICuhBC5ISKJhaxSemH6J88dbuwCts1nk3E741nE/n1yfEsQhvyZqj5P+Lko8vf\nODrUsEfpZIYeO8TH4u7LZUiaGBsnTdiDcVvtx8TbYdiAjULNwf+LE2EOX++CUFNxbi/e979/OU7S\nsfvj/nzkhC1CzQFXZ/CBg2MfuO7ieB+6YNjhoWbLlYOMOcAejv1t9VUmhRomxMluNi5uq26b+Lcf\n9OioUFPtI0MN0cRpwYxeGqELIUROUEAXQoicoIAuhBA5QQFdCCFyggK6EELkBAV0IYTICQroQgiR\nExTQhRAiJ5h7nMDQ6Ipm1wA7A1PcfYN02SnAUODjVPZHd/9vkfWdHUs/+H/A/XECxl1f7x5qftc5\nTkR51dYPNdvUPRq39VI8a8sDA7cONevxesnyERwY1vEz7g41q3w9IdRc2PnIUHPiyPNDzYDtnw01\nPXxqqBlTt2GomdZhZdw9Q1bN/LSIb29aYr/aMt7n/nzOUaGmm00PNdv7A6Fm9Ulxks4HvZcNNaMY\nHGp2P/DfoebsEcNCzfr+SqjZ6fXaUPNG/z6hZkmfEWr63PlxqBm052OhZrp3K1m+JV24rl2/or7d\nnBH6tcD2jSw/390Hpn+NOrwQrRz5tmiTLHBAd/cngc8aKVqgUZEQrQX5tmirlOMa+q/N7GUzu9rM\nlipD/UJUCvm2aNW09Mu5LgOGu7ub2enA+cAvi6rfqZn7uUcVLFPVwuaIRYXva5/h+8eeKWcTTfPt\nCTVzP3ergqWqymmbyDEzakfxTe0LALzE4iW1LRrQ3f2Tgq9XAf8sucIaNS3ZvFiEWaxqMxar2mzO\n929Pa9k3MjbZt1euadH2xaJLp6pBdKoaBMBGdGHM8EuKapt7ycUouK5oZssXlP0ceK2Z9QtRKeTb\nos2xwCN0M7sZqAKWMbMPgFOAH5nZhkAd8D5wWAvYKMRCRb4t2ioLHNDdfd9GFl/bDFuEaBXIt0Vb\nZYETi5rdsJkfWXdGSc32FidFXOsHh5p3WS3UjD5ny1CTYcIimJXhybYMsyxxZ6C5bXhYxQ/qtgk1\nl3icxLH5yS+FGr6PJZyT4XevnmWWpYcyNFa9wIlFzcXMnA4lfmu/DJXckaGvMgzH9lprRKh5wmPf\nP8yuDDVZunv4/WeGmu12vi/U/IIbQs0M7xRqDn887p+Tf3hCqPm7HxLXQ7zPDr3rxpLl1T1h5Nbt\nypJYJIQQohWhgC6EEDlBAV0IIXKCAroQQuSEVhPQJ9a+V2kTms5HtZW2oMl8WZvhBmdrY0ZtpS1o\nHnW1lbagycysfa7SJjSZN2o/iUWtiLdqp7R4nQrozWFybaUtaDJf1r5caROazje1lbageXhtpS1o\nMt8poJedXAd0IYQQzaOlX87VJFZibjZ1N7rM8z1ZtmZYR196hJrF6BIb0yuW8M28XyeNg96rNtDM\nzlDP0hk0fYPygSuEVazdyO/+jsXnWd6ZdcJ6BvYOJTArg2ZgBs1K8y+a9Cb0XrtgQbeuYTWjR2do\nq4wM3Gju50kfQu8VCwpXzlDBEhk07WNJX5YJNZ/Tcb5lY2lPv4LlK7DifJqGeIa3Cw/M8I7KfsSi\nHo3klizJR/Ms75ShEwdmCA1Zfnv/RvqwIcvQZ57vS/LBfMsGBrGhXxcYWaK8oolFFWlYLDJUNLFI\niDJSzLcrFtCFEEK0LLqGLoQQOUEBXQghckKrCOhmtoOZvWlmb5vZcZW2Jwtm9r6ZjTGzl8zs+Urb\n0xhmdo2ZTTGzVwqWdTezkWb2lpk90JqmUiti7ylmNtHMRqd/O1TSxqbS1nxbfl0eFpZvVzygm1k7\n4FKSWdbXA/Yxs7VLr9UqqAOq3H0jdx9caWOK0Njs9ccDD7n7WsAjQPwquYVHY/YCnO/uA9O//y5s\noxaUNurb8uvysFB8u+IBHRgMvOPu4939e+BWYNcK25QFo3X0X1GKzF6/K1D/ztARwG4L1agSFLEX\nyPA8XOukLfq2/LoMLCzfbg0bbkVgQsH3iemy1o4DD5jZKDMbWmljmkBPd58C4O6TgeUqbE8Wfm1m\nL5vZ1a3tVDqgLfq2/Hrh0qK+3RoCemNHqLbwLOXm7r4xsBPJRskwQ4ZYAC4DVnf3DYHJwPkVtqcp\ntEXfll/3XIupAAABIElEQVQvPFrct1tDQJ8IrFLwfSVgUoVsyUw6CqifDf5uktPrtsAUM+sFcyY+\n/rjC9pTE3T/xuckSVwGDKmlPE2lzvi2/XniUw7dbQ0AfBfQzs1XNbHFgCBDPQVVBzKyTmXVJP3cG\nqmm9s8DPM3s9Sd8elH4+ELh3YRsUMI+96c5Zz89pvf3cGG3Kt+XXZafsvl3Rd7kAuPtsM/sNySsK\n2gHXuPsbFTYrohdwd5ri3QG4yd1LvWKhIhSZvf4s4HYzOwT4ANizchbOSxF7f2RmG5I8ffE+cFjF\nDGwibdC35ddlYmH5tlL/hRAiJ7SGSy5CCCFaAAV0IYTICQroQgiRExTQhRAiJyigCyFETlBAF0KI\nnKCALoQQOUEBXQghcsL/A1cunn39vbPfAAAAAElFTkSuQmCC\n",
       "text/plain": [
-       "<matplotlib.figure.Figure at 0x7f4e8bf51668>"
+       "<matplotlib.figure.Figure at 0x7f83ded346a0>"
       ]
      },
      "metadata": {},

--- a/openmc/mgxs/library.py
+++ b/openmc/mgxs/library.py
@@ -872,8 +872,8 @@ class Library(object):
                                            nuclide=[nuclide])
         # If multiplicity matrix is available, prefer that
         if 'multiplicity matrix' in self.mgxs_types:
-            mult_mgxs = self.get_mgxs(domain, 'multiplicity matrix')
-            xsdata.set_multiplicity_mgxs(mult_mgxs, xs_type=xs_type,
+            mymgxs = self.get_mgxs(domain, 'multiplicity matrix')
+            xsdata.set_multiplicity_mgxs(mymgxs, xs_type=xs_type,
                                          nuclide=[nuclide])
             using_multiplicity = True
         # multiplicity wil fall back to using scatter and nu-scatter

--- a/openmc/mgxs/library.py
+++ b/openmc/mgxs/library.py
@@ -870,9 +870,15 @@ class Library(object):
                 mymgxs = self.get_mgxs(domain, 'nu-fission')
                 xsdata.set_nu_fission_mgxs(mymgxs, xs_type=xs_type,
                                            nuclide=[nuclide])
-        # multiplicity requires scatter and nu-scatter
-        if ((('scatter matrix' in self.mgxs_types) and
-             ('nu-scatter matrix' in self.mgxs_types))):
+        # If multiplicity matrix is available, prefer that
+        if 'multiplicity matrix' in self.mgxs_types:
+            mult_mgxs = self.get_mgxs(domain, 'multiplicity matrix')
+            xsdata.set_multiplicity_mgxs(mult_mgxs, xs_type=xs_type,
+                                         nuclide=[nuclide])
+            using_multiplicity = True
+        # multiplicity wil fall back to using scatter and nu-scatter
+        elif ((('scatter matrix' in self.mgxs_types) and
+               ('nu-scatter matrix' in self.mgxs_types))):
             scatt_mgxs = self.get_mgxs(domain, 'scatter matrix')
             nuscatt_mgxs = self.get_mgxs(domain, 'nu-scatter matrix')
             xsdata.set_multiplicity_mgxs(nuscatt_mgxs, scatt_mgxs,
@@ -1131,9 +1137,10 @@ class Library(object):
             msg = '"nu-scatter matrix" MGXS type is required but not provided.'
             warn(msg)
         else:
-            # Ok, now see the status of scatter
-            if 'scatter matrix' not in self.mgxs_types:
-                # We dont have both nu-scatter and scatter, therefore
+            # Ok, now see the status of scatter and/or multiplicity
+            if ((('scatter matrix' not in self.mgxs_types) and
+                 ('multiplicity matrix' not in self.mgxs_types))):
+                # We dont have data needed for multiplicity matrix, therefore
                 # we need total, and not transport.
                 if 'total' not in self.mgxs_types:
                     error_flag = True

--- a/openmc/mgxs/library.py
+++ b/openmc/mgxs/library.py
@@ -460,11 +460,7 @@ class Library(object):
         ----------
         domain : Material or Cell or Universe or Integral
             The material, cell, or universe object of interest (or its ID)
-        mgxs_type : {'total', 'transport', 'nu-transport', 'absorption',
-                     'capture', 'fission', 'nu-fission', 'kappa-fission',
-                     'scatter', 'nu-scatter', 'scatter matrix',
-                     'nu-scatter matrix', 'multiplicity matrix',
-                     'nu-fission matrix', chi'}
+        mgxs_type : {'total', 'transport', 'nu-transport', 'absorption', 'capture', 'fission', 'nu-fission', 'kappa-fission', 'scatter', 'nu-scatter', 'scatter matrix', 'nu-scatter matrix', 'multiplicity matrix', 'nu-fission matrix', chi'}
             The type of multi-group cross section object to return
 
         Returns

--- a/openmc/mgxs/library.py
+++ b/openmc/mgxs/library.py
@@ -460,7 +460,10 @@ class Library(object):
         ----------
         domain : Material or Cell or Universe or Integral
             The material, cell, or universe object of interest (or its ID)
-        mgxs_type : {'total', 'transport', 'nu-transport', 'absorption', 'capture', 'fission', 'nu-fission', 'kappa-fission', 'scatter', 'nu-scatter', 'scatter matrix', 'nu-scatter matrix', 'chi'}
+        mgxs_type : {'total', 'transport', 'nu-transport', 'absorption',
+                     'capture', 'fission', 'nu-fission', 'kappa-fission',
+                     'scatter', 'nu-scatter', 'scatter matrix',
+                     'nu-scatter matrix', 'nu-fission matrix', chi'}
             The type of multi-group cross section object to return
 
         Returns
@@ -853,13 +856,20 @@ class Library(object):
             mymgxs = self.get_mgxs(domain, 'kappa-fission')
             xsdata.set_kappa_fission_mgxs(mymgxs, xs_type=xs_type,
                                           nuclide=[nuclide])
-        if 'chi' in self.mgxs_types:
-            mymgxs = self.get_mgxs(domain, 'chi')
-            xsdata.set_chi_mgxs(mymgxs, xs_type=xs_type, nuclide=[nuclide])
-        if 'nu-fission' in self.mgxs_types:
-            mymgxs = self.get_mgxs(domain, 'nu-fission')
+        # For chi and nu-fission we can either have only a nu-fission matrix
+        # provided, or vectors of chi and nu-fission provided
+        if 'nu-fission matrix' in self.mgxs_types:
+            mymgxs = self.get_mgxs(domain, 'nu-fission matrix')
             xsdata.set_nu_fission_mgxs(mymgxs, xs_type=xs_type,
                                        nuclide=[nuclide])
+        else:
+            if 'chi' in self.mgxs_types:
+                mymgxs = self.get_mgxs(domain, 'chi')
+                xsdata.set_chi_mgxs(mymgxs, xs_type=xs_type, nuclide=[nuclide])
+            if 'nu-fission' in self.mgxs_types:
+                mymgxs = self.get_mgxs(domain, 'nu-fission')
+                xsdata.set_nu_fission_mgxs(mymgxs, xs_type=xs_type,
+                                           nuclide=[nuclide])
         # multiplicity requires scatter and nu-scatter
         if ((('scatter matrix' in self.mgxs_types) and
              ('nu-scatter matrix' in self.mgxs_types))):

--- a/openmc/mgxs/library.py
+++ b/openmc/mgxs/library.py
@@ -463,7 +463,8 @@ class Library(object):
         mgxs_type : {'total', 'transport', 'nu-transport', 'absorption',
                      'capture', 'fission', 'nu-fission', 'kappa-fission',
                      'scatter', 'nu-scatter', 'scatter matrix',
-                     'nu-scatter matrix', 'nu-fission matrix', chi'}
+                     'nu-scatter matrix', 'multiplicity matrix',
+                     'nu-fission matrix', chi'}
             The type of multi-group cross section object to return
 
         Returns

--- a/openmc/mgxs/library.py
+++ b/openmc/mgxs/library.py
@@ -942,6 +942,7 @@ class Library(object):
         See also
         --------
         Library.dump_to_file()
+        Library.create_mg_mode()
 
         """
 
@@ -994,7 +995,10 @@ class Library(object):
     def create_mg_mode(self, xsdata_names=None, xs_ids=None):
         """Creates an openmc.MGXSLibrary object to contain the MGXS data for the
         Multi-Group mode of OpenMC as well as the associated openmc.Materials
-        and openmc.Geometry objects. This method only creates a macroscopic
+        and openmc.Geometry objects. The created Geometry is the same as that
+        used to generate the MGXS data, with the only differences being
+        modifications to point to newly-created Materials which point to the
+        multi-group data. This method only creates a macroscopic
         MGXS Library even if nuclidic tallies are specified in the Library.
 
         Parameters
@@ -1112,8 +1116,9 @@ class Library(object):
           needed to support tallies the user may wish to request.
         - A nu-scatter matrix is required.
 
+          - Having a multiplicity matrix is preferred.
           - Having both nu-scatter (of any order) and scatter
-            (at least isotropic) matrices is preferred
+            (at least isotropic) matrices is the second choice.
           - If only nu-scatter, need total (not transport), to
             be used in adjusting absorption
             (i.e., reduced_abs = tot - nuscatt)

--- a/openmc/mgxs/mgxs.py
+++ b/openmc/mgxs/mgxs.py
@@ -1774,7 +1774,7 @@ class MatrixMGXS(MGXS):
         return xs
 
     def get_slice(self, nuclides=[], in_groups=[], out_groups=[]):
-        """Build a sliced matrixMGXS object for the specified nuclides and
+        """Build a sliced MatrixMGXS object for the specified nuclides and
         energy groups.
 
         This method constructs a new MGXS to encapsulate a subset of the data
@@ -2862,6 +2862,10 @@ class NuScatterXS(MGXS):
         super(NuScatterXS, self).__init__(domain, domain_type,
                                           groups, by_nuclide, name)
         self._rxn_type = 'nu-scatter'
+
+    @property
+    def estimator(self):
+        return 'analog'
 
 
 class ScatterMatrixXS(MatrixMGXS):

--- a/openmc/mgxs/mgxs.py
+++ b/openmc/mgxs/mgxs.py
@@ -57,7 +57,7 @@ class MGXS(object):
 
     This class can be used for both OpenMC input generation and tally data
     post-processing to compute spatially-homogenized and energy-integrated
-    multi-group cross sections for deterministic neutronics calculations.
+    multi-group cross sections for multi-group neutronics calculations.
 
     NOTE: Users should instantiate the subclasses of this abstract class.
 
@@ -727,9 +727,8 @@ class MGXS(object):
             Return the cross section indexed according to increasing or
             decreasing energy groups (decreasing or increasing energies).
             Defaults to 'increasing'.
-        value : str
-            A string for the type of value to return - 'mean', 'std_dev' or
-            'rel_err' are accepted. Defaults to 'mean'.
+        value : {'mean', 'std_dev', 'rel_err'}
+            A string for the type of value to return. Defaults to 'mean'.
 
         Returns
         -------
@@ -963,8 +962,9 @@ class MGXS(object):
         Returns
         -------
         openmc.mgxs.MGXS
-            A new tally which encapsulates the subset of data requested for the
-            nuclide(s) and/or energy group(s) requested in the parameters.
+            A new MGXS object which encapsulates the subset of data requested
+            for the nuclide(s) and/or energy group(s) requested in the
+            parameters.
 
         """
 
@@ -1536,7 +1536,7 @@ class MatrixMGXS(MGXS):
 
     This class can be used for both OpenMC input generation and tally data
     post-processing to compute spatially-homogenized and energy-integrated
-    multi-group cross sections for deterministic neutronics calculations.
+    multi-group cross sections for multi-group neutronics calculations.
 
     NOTE: Users should instantiate the subclasses of this abstract class.
 
@@ -1624,9 +1624,7 @@ class MatrixMGXS(MGXS):
         energy = openmc.Filter('energy', group_edges)
         energyout = openmc.Filter('energyout', group_edges)
 
-        filters = [[energy], [energy, energyout]]
-
-        return filters
+        return [[energy], [energy, energyout]]
 
     @property
     def estimator(self):
@@ -1636,10 +1634,10 @@ class MatrixMGXS(MGXS):
                subdomains='all', nuclides='all',
                xs_type='macro', order_groups='increasing',
                row_column='inout', value='mean', **kwargs):
-        r"""Returns an array of multi-group cross sections.
+        """Returns an array of multi-group cross sections.
 
-        This method constructs a 2D NumPy array for the requested multiplicity
-        matrix data data for one or more energy groups and subdomains.
+        This method constructs a 2D NumPy array for the requested multi-group
+        matrix data for one or more energy groups and subdomains.
 
         Parameters
         ----------
@@ -1666,9 +1664,8 @@ class MatrixMGXS(MGXS):
             Return the cross section indexed first by incoming group and
             second by outgoing group ('inout'), or vice versa ('outin').
             Defaults to 'inout'.
-        value : str
-            A string for the type of value to return - 'mean', 'std_dev', or
-            'rel_err' are accepted. Defaults to the empty string.
+        value : {'mean', 'std_dev', 'rel_err'}
+            A string for the type of value to return. Defaults to 'mean'.
 
         Returns
         -------
@@ -1777,7 +1774,7 @@ class MatrixMGXS(MGXS):
         return xs
 
     def get_slice(self, nuclides=[], in_groups=[], out_groups=[]):
-        """Build a sliced NuFissionMatrix for the specified nuclides and
+        """Build a sliced matrixMGXS object for the specified nuclides and
         energy groups.
 
         This method constructs a new MGXS to encapsulate a subset of the data
@@ -1799,9 +1796,10 @@ class MatrixMGXS(MGXS):
 
         Returns
         -------
-        openmc.mgxs.MGXS
-            A new tally which encapsulates the subset of data requested for the
-            nuclide(s) and/or energy group(s) requested in the parameters.
+        openmc.mgxs.MatrixMGXS
+            A new MatrixMGXS object which encapsulates the subset of data
+            requested for the nuclide(s) and/or energy group(s) requested in
+            the parameters.
 
         """
 
@@ -1940,7 +1938,7 @@ class TotalXS(MGXS):
 
     This class can be used for both OpenMC input generation and tally data
     post-processing to compute spatially-homogenized and energy-integrated
-    multi-group cross sections for deterministic neutronics calculations.
+    multi-group cross sections for multi-group neutronics calculations.
 
     Parameters
     ----------
@@ -2028,7 +2026,7 @@ class TransportXS(MGXS):
 
     This class can be used for both OpenMC input generation and tally data
     post-processing to compute spatially-homogenized and energy-integrated
-    multi-group cross sections for deterministic neutronics calculations.
+    multi-group cross sections for multi-group neutronics calculations.
 
     Parameters
     ----------
@@ -2142,7 +2140,7 @@ class NuTransportXS(TransportXS):
 
     This class can be used for both OpenMC input generation and tally data
     post-processing to compute spatially-homogenized and energy-integrated
-    multi-group cross sections for deterministic neutronics calculations.
+    multi-group cross sections for multi-group neutronics calculations.
 
     Parameters
     ----------
@@ -2238,7 +2236,7 @@ class AbsorptionXS(MGXS):
 
     This class can be used for both OpenMC input generation and tally data
     post-processing to compute spatially-homogenized and energy-integrated
-    multi-group cross sections for deterministic neutronics calculations.
+    multi-group cross sections for multi-group neutronics calculations.
 
     Parameters
     ----------
@@ -2331,7 +2329,7 @@ class CaptureXS(MGXS):
 
     This class can be used for both OpenMC input generation and tally data
     post-processing to compute spatially-homogenized and energy-integrated
-    multi-group cross sections for deterministic neutronics calculations.
+    multi-group cross sections for multi-group neutronics calculations.
 
     Parameters
     ----------
@@ -2431,7 +2429,7 @@ class FissionXS(MGXS):
 
     This class can be used for both OpenMC input generation and tally data
     post-processing to compute spatially-homogenized and energy-integrated
-    multi-group cross sections for deterministic neutronics calculations.
+    multi-group cross sections for multi-group neutronics calculations.
 
     Parameters
     ----------
@@ -2519,7 +2517,7 @@ class NuFissionXS(MGXS):
 
     This class can be used for both OpenMC input generation and tally data
     post-processing to compute spatially-homogenized and energy-integrated
-    multi-group cross sections for deterministic neutronics calculations.
+    multi-group cross sections for multi-group neutronics calculations.
 
     Parameters
     ----------
@@ -2607,7 +2605,7 @@ class KappaFissionXS(MGXS):
 
     This class can be used for both OpenMC input generation and tally data
     post-processing to compute spatially-homogenized and energy-integrated
-    multi-group cross sections for deterministic neutronics calculations.
+    multi-group cross sections for multi-group neutronics calculations.
 
     Parameters
     ----------
@@ -2695,7 +2693,7 @@ class ScatterXS(MGXS):
 
     This class can be used for both OpenMC input generation and tally data
     post-processing to compute spatially-homogenized and energy-integrated
-    multi-group cross sections for deterministic neutronics calculations.
+    multi-group cross sections for multi-group neutronics calculations.
 
     Parameters
     ----------
@@ -2783,7 +2781,7 @@ class NuScatterXS(MGXS):
 
     This class can be used for both OpenMC input generation and tally data
     post-processing to compute spatially-homogenized and energy-integrated
-    multi-group cross sections for deterministic neutronics calculations.
+    multi-group cross sections for multi-group neutronics calculations.
 
     Parameters
     ----------
@@ -2872,7 +2870,7 @@ class ScatterMatrixXS(MatrixMGXS):
 
     This class can be used for both OpenMC input generation and tally data
     post-processing to compute spatially-homogenized and energy-integrated
-    multi-group cross sections for deterministic neutronics calculations.
+    multi-group cross sections for multi-group neutronics calculations.
 
     Parameters
     ----------
@@ -3116,9 +3114,10 @@ class ScatterMatrixXS(MatrixMGXS):
 
         Returns
         -------
-        openmc.mgxs.MGXS
-            A new tally which encapsulates the subset of data requested for the
-            nuclide(s) and/or energy group(s) requested in the parameters.
+        openmc.mgxs.MatrixMGXS
+            A new MatrixMGXS which encapsulates the subset of data requested
+            for the nuclide(s) and/or energy group(s) requested in the
+            parameters.
 
         """
 
@@ -3200,9 +3199,8 @@ class ScatterMatrixXS(MatrixMGXS):
             Return the cross section indexed first by incoming group and
             second by outgoing group ('inout'), or vice versa ('outin').
             Defaults to 'inout'.
-        value : str
-            A string for the type of value to return - 'mean', 'std_dev', or
-            'rel_err' are accepted. Defaults to the empty string.
+        value : {'mean', 'std_dev', 'rel_err'}
+            A string for the type of value to return. Defaults to 'mean'.
 
         Returns
         -------
@@ -3430,7 +3428,7 @@ class ScatterMatrixXS(MatrixMGXS):
         cv.check_value('xs_type', xs_type, ['macro', 'micro'])
 
         if self.correction != 'P0':
-            rxn_type= '{0} (P{1})'.format(self.rxn_type, moment)
+            rxn_type = '{0} (P{1})'.format(self.rxn_type, moment)
         else:
             rxn_type = self.rxn_type
 
@@ -3449,7 +3447,7 @@ class ScatterMatrixXS(MatrixMGXS):
         template = '{0: <12}Group {1} [{2: <10} - {3: <10}MeV]\n'
 
         # Loop over energy groups ranges
-        for group in range(1, self.num_groups+1):
+        for group in range(1, self.num_groups + 1):
             bounds = self.energy_groups.get_group_bounds(group)
             string += template.format('', group, bounds[0], bounds[1])
 
@@ -3476,8 +3474,8 @@ class ScatterMatrixXS(MatrixMGXS):
                 template = '{0: <12}Group {1} -> Group {2}:\t\t'
 
                 # Loop over incoming/outgoing energy groups ranges
-                for in_group in range(1, self.num_groups+1):
-                    for out_group in range(1, self.num_groups+1):
+                for in_group in range(1, self.num_groups + 1):
+                    for out_group in range(1, self.num_groups + 1):
                         string += template.format('', in_group, out_group)
                         average = \
                             self.get_xs([in_group], [out_group],
@@ -3489,7 +3487,8 @@ class ScatterMatrixXS(MatrixMGXS):
                                         xs_type=xs_type, value='rel_err')
                         average = average.flatten()[0]
                         rel_err = rel_err.flatten()[0] * 100.
-                        string += '{:1.2e} +/- {:1.2e}%'.format(average, rel_err)
+                        string += '{:1.2e} +/- {:1.2e}%'.format(average,
+                                                                rel_err)
                         string += '\n'
                     string += '\n'
                 string += '\n'
@@ -3504,7 +3503,7 @@ class NuScatterMatrixXS(ScatterMatrixXS):
 
     This class can be used for both OpenMC input generation and tally data
     post-processing to compute spatially-homogenized and energy-integrated
-    multi-group cross sections for deterministic neutronics calculations.
+    multi-group cross sections for multi-group neutronics calculations.
 
     Parameters
     ----------
@@ -3597,7 +3596,7 @@ class MultiplicityMatrixXS(MatrixMGXS):
 
     This class can be used for both OpenMC input generation and tally data
     post-processing to compute spatially-homogenized and energy-integrated
-    multi-group cross sections for deterministic neutronics calculations.
+    multi-group cross sections for multi-group neutronics calculations.
 
     Parameters
     ----------
@@ -3691,9 +3690,7 @@ class MultiplicityMatrixXS(MatrixMGXS):
         energy = openmc.Filter('energy', group_edges)
         energyout = openmc.Filter('energyout', group_edges)
 
-        filters = [[energy, energyout], [energy, energyout]]
-
-        return filters
+        return [[energy, energyout], [energy, energyout]]
 
     @property
     def rxn_rate_tally(self):
@@ -3720,7 +3717,7 @@ class NuFissionMatrixXS(MatrixMGXS):
 
     This class can be used for both OpenMC input generation and tally data
     post-processing to compute spatially-homogenized and energy-integrated
-    multi-group cross sections for deterministic neutronics calculations.
+    multi-group cross sections for multi-group neutronics calculations.
 
     Parameters
     ----------
@@ -3800,19 +3797,8 @@ class NuFissionMatrixXS(MatrixMGXS):
                  groups=None, by_nuclide=False, name=''):
         super(NuFissionMatrixXS, self).__init__(domain, domain_type,
                                                 groups, by_nuclide, name)
-        self._rxn_type = 'nu-fission matrix'
-
-    @property
-    def scores(self):
-        scores = ['flux', 'nu-fission']
-        return scores
-
-    @property
-    def rxn_rate_tally(self):
-        if self._rxn_rate_tally is None:
-            self._rxn_rate_tally = self.tallies['nu-fission']
-            self._rxn_rate_tally.sparse = self.sparse
-        return self._rxn_rate_tally
+        self._rxn_type = 'nu-fission'
+        self._hdf5_key = 'nu-fission matrix'
 
 
 class Chi(MGXS):
@@ -3820,7 +3806,7 @@ class Chi(MGXS):
 
     This class can be used for both OpenMC input generation and tally data
     post-processing to compute spatially-homogenized and energy-integrated
-    multi-group cross sections for deterministic neutronics calculations.
+    multi-group cross sections for multi-group neutronics calculations.
 
     Parameters
     ----------
@@ -3966,9 +3952,10 @@ class Chi(MGXS):
 
         Returns
         -------
-        MGXS
-            A new tally which encapsulates the subset of data requested for the
-            nuclide(s) and/or energy group(s) requested in the parameters.
+        openmc.mgxs.MGXS
+            A new MGXS which encapsulates the subset of data requested
+            for the nuclide(s) and/or energy group(s) requested in the
+            parameters.
 
         """
 
@@ -4080,9 +4067,8 @@ class Chi(MGXS):
             Return the cross section indexed according to increasing or
             decreasing energy groups (decreasing or increasing energies).
             Defaults to 'increasing'.
-        value : str
-            A string for the type of value to return - 'mean', 'std_dev', or
-            'rel_err' are accepted. Defaults to 'mean'.
+        value : {'mean', 'std_dev', 'rel_err'}
+            A string for the type of value to return. Defaults to 'mean'.
 
         Returns
         -------

--- a/openmc/mgxs/mgxs.py
+++ b/openmc/mgxs/mgxs.py
@@ -480,7 +480,7 @@ class MGXS(object):
         elif mgxs_type == 'nu-scatter matrix':
             mgxs = NuScatterMatrixXS(domain, domain_type, energy_groups)
         elif mgxs_type == 'multiplicity matrix':
-            mgxs = MultiplicityMatrix(domain, domain_type, energy_groups)
+            mgxs = MultiplicityMatrixXS(domain, domain_type, energy_groups)
         elif mgxs_type == 'nu-fission matrix':
             mgxs = NuFissionMatrixXS(domain, domain_type, energy_groups)
         elif mgxs_type == 'chi':
@@ -1654,9 +1654,10 @@ class MatrixMGXS(MGXS):
             Subdomain IDs of interest. Defaults to 'all'.
         nuclides : Iterable of str or 'all' or 'sum'
             A list of nuclide name strings (e.g., ['U-235', 'U-238']). The
-            special string 'all' will return the cross sections for all nuclides
-            in the spatial domain. The special string 'sum' will return the
-            cross section summed over all nuclides. Defaults to 'all'.
+            special string 'all' will return the cross sections for all
+            nuclides in the spatial domain. The special string 'sum' will
+            return the cross section summed over all nuclides. Defaults to
+            'all'.
         xs_type: {'macro', 'micro'}
             Return the macro or micro cross section in units of cm^-1 or barns.
             Defaults to 'macro'.
@@ -1694,7 +1695,8 @@ class MatrixMGXS(MGXS):
 
         # Construct a collection of the domain filter bins
         if not isinstance(subdomains, basestring):
-            cv.check_iterable_type('subdomains', subdomains, Integral, max_depth=2)
+            cv.check_iterable_type('subdomains', subdomains, Integral,
+                                   max_depth=2)
             for subdomain in subdomains:
                 filters.append(self.domain_type)
                 filter_bins.append((subdomain,))
@@ -1704,14 +1706,16 @@ class MatrixMGXS(MGXS):
             cv.check_iterable_type('groups', in_groups, Integral)
             for group in in_groups:
                 filters.append('energy')
-                filter_bins.append((self.energy_groups.get_group_bounds(group),))
+                filter_bins.append((
+                    self.energy_groups.get_group_bounds(group),))
 
         # Construct list of energy group bounds tuples for all requested groups
         if not isinstance(out_groups, basestring):
             cv.check_iterable_type('groups', out_groups, Integral)
             for group in out_groups:
                 filters.append('energyout')
-                filter_bins.append((self.energy_groups.get_group_bounds(group),))
+                filter_bins.append((
+                    self.energy_groups.get_group_bounds(group),))
 
         # Construct a collection of the nuclides to retrieve from the xs tally
         if self.by_nuclide:
@@ -1840,8 +1844,9 @@ class MatrixMGXS(MGXS):
             The nuclides of the cross-sections to include in the report. This
             may be a list of nuclide name strings (e.g., ['U-235', 'U-238']).
             The special string 'all' will report the cross sections for all
-            nuclides in the spatial domain. The special string 'sum' will report
-            the cross sections summed over all nuclides. Defaults to 'all'.
+            nuclides in the spatial domain. The special string 'sum' will
+            report the cross sections summed over all nuclides. Defaults to
+            'all'.
         xs_type: {'macro', 'micro'}
             Return the macro or micro cross section in units of cm^-1 or barns.
             Defaults to 'macro'.
@@ -1884,7 +1889,7 @@ class MatrixMGXS(MGXS):
         template = '{0: <12}Group {1} [{2: <10} - {3: <10}MeV]\n'
 
         # Loop over energy groups ranges
-        for group in range(1, self.num_groups+1):
+        for group in range(1, self.num_groups + 1):
             bounds = self.energy_groups.get_group_bounds(group)
             string += template.format('', group, bounds[0], bounds[1])
 
@@ -1911,8 +1916,8 @@ class MatrixMGXS(MGXS):
                 template = '{0: <12}Group {1} -> Group {2}:\t\t'
 
                 # Loop over incoming/outgoing energy groups ranges
-                for in_group in range(1, self.num_groups+1):
-                    for out_group in range(1, self.num_groups+1):
+                for in_group in range(1, self.num_groups + 1):
+                    for out_group in range(1, self.num_groups + 1):
                         string += template.format('', in_group, out_group)
                         average = \
                             self.get_xs([in_group], [out_group],
@@ -1924,7 +1929,8 @@ class MatrixMGXS(MGXS):
                                         xs_type=xs_type, value='rel_err')
                         average = average.flatten()[0]
                         rel_err = rel_err.flatten()[0] * 100.
-                        string += '{:1.2e} +/- {:1.2e}%'.format(average, rel_err)
+                        string += '{:1.2e} +/- {:1.2e}%'.format(average,
+                                                                rel_err)
                         string += '\n'
                     string += '\n'
                 string += '\n'
@@ -2864,7 +2870,7 @@ class NuScatterXS(MGXS):
         self._rxn_type = 'nu-scatter'
 
 
-class ScatterMatrixXS(MGXS):
+class ScatterMatrixXS(MatrixMGXS):
     """A scattering matrix multi-group cross section for one or more Legendre
     moments.
 
@@ -2997,10 +3003,6 @@ class ScatterMatrixXS(MGXS):
             filters = [[energy], [energy, energyout]]
 
         return filters
-
-    @property
-    def estimator(self):
-        return 'analog'
 
     @property
     def rxn_rate_tally(self):
@@ -3594,7 +3596,7 @@ class NuScatterMatrixXS(ScatterMatrixXS):
         self._hdf5_key = 'nu-scatter matrix'
 
 
-class MultiplicityMatrix(MatrixMGXS):
+class MultiplicityMatrixXS(MatrixMGXS):
     """The scattering multiplicity matrix.
 
     This class can be used for both OpenMC input generation and tally data
@@ -3677,8 +3679,8 @@ class MultiplicityMatrix(MatrixMGXS):
 
     def __init__(self, domain=None, domain_type=None,
                  groups=None, by_nuclide=False, name=''):
-        super(MultiplicityMatrix, self).__init__(domain, domain_type, groups,
-                                                 by_nuclide, name)
+        super(MultiplicityMatrixXS, self).__init__(domain, domain_type, groups,
+                                                   by_nuclide, name)
         self._rxn_type = 'multiplicity'
 
     @property
@@ -3712,7 +3714,7 @@ class MultiplicityMatrix(MatrixMGXS):
 
             # Compute the multiplicity
             self._xs_tally = self.rxn_rate_tally / scatter
-            super(MultiplicityMatrix, self)._compute_xs()
+            super(MultiplicityMatrixXS, self)._compute_xs()
 
         return self._xs_tally
 

--- a/openmc/mgxs/mgxs.py
+++ b/openmc/mgxs/mgxs.py
@@ -427,11 +427,7 @@ class MGXS(object):
 
         Parameters
         ----------
-        mgxs_type : {'total', 'transport', 'nu-transport', 'absorption',
-                     'capture', 'fission', 'nu-fission', 'kappa-fission',
-                     'scatter', 'nu-scatter', 'scatter matrix',
-                     'nu-scatter matrix', 'multiplicity matrix',
-                     'nu-fission matrix', chi'}
+        mgxs_type : {'total', 'transport', 'nu-transport', 'absorption', 'capture', 'fission', 'nu-fission', 'kappa-fission', 'scatter', 'nu-scatter', 'scatter matrix', 'nu-scatter matrix', 'multiplicity matrix', 'nu-fission matrix', chi'}
             The type of multi-group cross section object to return
         domain : openmc.Material or openmc.Cell or openmc.Universe
             The domain for spatial homogenization
@@ -1810,8 +1806,7 @@ class MatrixMGXS(MGXS):
         """
 
         # Call super class method and null out derived tallies
-        slice_xs = super(NuFissionMatrixXS, self).get_slice(nuclides,
-                                                            in_groups)
+        slice_xs = super(MatrixMGXS, self).get_slice(nuclides, in_groups)
         slice_xs._rxn_rate_tally = None
         slice_xs._xs_tally = None
 

--- a/openmc/mgxs/mgxs.py
+++ b/openmc/mgxs/mgxs.py
@@ -47,8 +47,8 @@ DOMAIN_TYPES = ['cell',
 # Supported domain classes
 # TODO: Implement Mesh domains
 _DOMAINS = [openmc.Cell,
-           openmc.Universe,
-           openmc.Material]
+            openmc.Universe,
+            openmc.Material]
 
 
 class MGXS(object):
@@ -1528,6 +1528,409 @@ class MGXS(object):
         # energy groups such that data is from fast to thermal
         df.sort_values(by=[self.domain_type] + columns, inplace=True)
         return df
+
+
+class MatrixMGXS(MGXS):
+    """An abstract multi-group cross section for some energy group structure
+    within some spatial domain. This class is specifically intended for
+    cross sections which depend on both the incoming and outgoing energy groups
+    and are therefore represented by matrices. Examples of this include the
+    scattering and nu-fission matrices.
+
+    This class can be used for both OpenMC input generation and tally data
+    post-processing to compute spatially-homogenized and energy-integrated
+    multi-group cross sections for deterministic neutronics calculations.
+
+    NOTE: Users should instantiate the subclasses of this abstract class.
+
+    Parameters
+    ----------
+    domain : openmc.Material or openmc.Cell or openmc.Universe
+        The domain for spatial homogenization
+    domain_type : {'material', 'cell', 'distribcell', 'universe'}
+        The domain type for spatial homogenization
+    energy_groups : openmc.mgxs.EnergyGroups
+        The energy group structure for energy condensation
+    by_nuclide : bool
+        If true, computes cross sections for each nuclide in domain
+    name : str, optional
+        Name of the multi-group cross section. Used as a label to identify
+        tallies in OpenMC 'tallies.xml' file.
+
+    Attributes
+    ----------
+    name : str, optional
+        Name of the multi-group cross section
+    rxn_type : str
+        Reaction type (e.g., 'total', 'nu-fission', etc.)
+    by_nuclide : bool
+        If true, computes cross sections for each nuclide in domain
+    domain : Material or Cell or Universe
+        Domain for spatial homogenization
+    domain_type : {'material', 'cell', 'distribcell', 'universe'}
+        Domain type for spatial homogenization
+    energy_groups : openmc.mgxs.EnergyGroups
+        Energy group structure for energy condensation
+    tally_trigger : openmc.Trigger
+        An (optional) tally precision trigger given to each tally used to
+        compute the cross section
+    scores : list of str
+        The scores in each tally used to compute the multi-group cross section
+    filters : list of openmc.Filter
+        The filters in each tally used to compute the multi-group cross section
+    tally_keys : list of str
+        The keys into the tallies dictionary for each tally used to compute
+        the multi-group cross section
+    estimator : {'tracklength', 'analog'}
+        The tally estimator used to compute the multi-group cross section
+    tallies : collections.OrderedDict
+        OpenMC tallies needed to compute the multi-group cross section
+    rxn_rate_tally : openmc.Tally
+        Derived tally for the reaction rate tally used in the numerator to
+        compute the multi-group cross section. This attribute is None
+        unless the multi-group cross section has been computed.
+    xs_tally : openmc.Tally
+        Derived tally for the multi-group cross section. This attribute
+        is None unless the multi-group cross section has been computed.
+    num_subdomains : int
+        The number of subdomains is unity for 'material', 'cell' and 'universe'
+        domain types. When the  This is equal to the number of cell instances
+        for 'distribcell' domain types (it is equal to unity prior to loading
+        tally data from a statepoint file).
+    num_nuclides : int
+        The number of nuclides for which the multi-group cross section is
+        being tracked. This is unity if the by_nuclide attribute is False.
+    nuclides : Iterable of str or 'sum'
+        The optional user-specified nuclides for which to compute cross
+        sections (e.g., 'U-238', 'O-16'). If by_nuclide is True but nuclides
+        are not specified by the user, all nuclides in the spatial domain
+        are included. This attribute is 'sum' if by_nuclide is false.
+    sparse : bool
+        Whether or not the MGXS' tallies use SciPy's LIL sparse matrix format
+        for compressed data storage
+    loaded_sp : bool
+        Whether or not a statepoint file has been loaded with tally data
+    derived : bool
+        Whether or not the MGXS is merged from one or more other MGXS
+    hdf5_key : str
+        The key used to index multi-group cross sections in an HDF5 data store
+
+    """
+
+    # This is an abstract class which cannot be instantiated
+    __metaclass__ = abc.ABCMeta
+
+    @property
+    def filters(self):
+        # Create the non-domain specific Filters for the Tallies
+        group_edges = self.energy_groups.group_edges
+        energy = openmc.Filter('energy', group_edges)
+        energyout = openmc.Filter('energyout', group_edges)
+
+        filters = [[energy], [energy, energyout]]
+
+        return filters
+
+    @property
+    def estimator(self):
+        return 'analog'
+
+    def get_xs(self, in_groups='all', out_groups='all',
+               subdomains='all', nuclides='all',
+               xs_type='macro', order_groups='increasing',
+               row_column='inout', value='mean', **kwargs):
+        r"""Returns an array of multi-group cross sections.
+
+        This method constructs a 2D NumPy array for the requested multiplicity
+        matrix data data for one or more energy groups and subdomains.
+
+        Parameters
+        ----------
+        in_groups : Iterable of Integral or 'all'
+            Incoming energy groups of interest. Defaults to 'all'.
+        out_groups : Iterable of Integral or 'all'
+            Outgoing energy groups of interest. Defaults to 'all'.
+        subdomains : Iterable of Integral or 'all'
+            Subdomain IDs of interest. Defaults to 'all'.
+        nuclides : Iterable of str or 'all' or 'sum'
+            A list of nuclide name strings (e.g., ['U-235', 'U-238']). The
+            special string 'all' will return the cross sections for all nuclides
+            in the spatial domain. The special string 'sum' will return the
+            cross section summed over all nuclides. Defaults to 'all'.
+        xs_type: {'macro', 'micro'}
+            Return the macro or micro cross section in units of cm^-1 or barns.
+            Defaults to 'macro'.
+        order_groups: {'increasing', 'decreasing'}
+            Return the cross section indexed according to increasing or
+            decreasing energy groups (decreasing or increasing energies).
+            Defaults to 'increasing'.
+        row_column: {'inout', 'outin'}
+            Return the cross section indexed first by incoming group and
+            second by outgoing group ('inout'), or vice versa ('outin').
+            Defaults to 'inout'.
+        value : str
+            A string for the type of value to return - 'mean', 'std_dev', or
+            'rel_err' are accepted. Defaults to the empty string.
+
+        Returns
+        -------
+        ndarray
+            A NumPy array of the multi-group cross section indexed in the order
+            each group and subdomain is listed in the parameters.
+
+        Raises
+        ------
+        ValueError
+            When this method is called before the multi-group cross section is
+            computed from tally data.
+
+        """
+
+        cv.check_value('value', value, ['mean', 'std_dev', 'rel_err'])
+        cv.check_value('xs_type', xs_type, ['macro', 'micro'])
+
+        filters = []
+        filter_bins = []
+
+        # Construct a collection of the domain filter bins
+        if not isinstance(subdomains, basestring):
+            cv.check_iterable_type('subdomains', subdomains, Integral, max_depth=2)
+            for subdomain in subdomains:
+                filters.append(self.domain_type)
+                filter_bins.append((subdomain,))
+
+        # Construct list of energy group bounds tuples for all requested groups
+        if not isinstance(in_groups, basestring):
+            cv.check_iterable_type('groups', in_groups, Integral)
+            for group in in_groups:
+                filters.append('energy')
+                filter_bins.append((self.energy_groups.get_group_bounds(group),))
+
+        # Construct list of energy group bounds tuples for all requested groups
+        if not isinstance(out_groups, basestring):
+            cv.check_iterable_type('groups', out_groups, Integral)
+            for group in out_groups:
+                filters.append('energyout')
+                filter_bins.append((self.energy_groups.get_group_bounds(group),))
+
+        # Construct a collection of the nuclides to retrieve from the xs tally
+        if self.by_nuclide:
+            if nuclides == 'all' or nuclides == 'sum' or nuclides == ['sum']:
+                query_nuclides = self.get_all_nuclides()
+            else:
+                query_nuclides = nuclides
+        else:
+            query_nuclides = ['total']
+
+        # Use tally summation if user requested the sum for all nuclides
+        if nuclides == 'sum' or nuclides == ['sum']:
+            xs_tally = self.xs_tally.summation(nuclides=query_nuclides)
+            xs = xs_tally.get_values(filters=filters, filter_bins=filter_bins,
+                                     value=value)
+        else:
+            xs = self.xs_tally.get_values(filters=filters,
+                                          filter_bins=filter_bins,
+                                          nuclides=query_nuclides, value=value)
+
+        xs = np.nan_to_num(xs)
+
+        # Divide by atom number densities for microscopic cross sections
+        if xs_type == 'micro':
+            if self.by_nuclide:
+                densities = self.get_nuclide_densities(nuclides)
+            else:
+                densities = self.get_nuclide_densities('sum')
+            if value == 'mean' or value == 'std_dev':
+                xs /= densities[np.newaxis, :, np.newaxis]
+
+        # Reverse data if user requested increasing energy groups since
+        # tally data is stored in order of increasing energies
+        if order_groups == 'increasing':
+            if in_groups == 'all':
+                num_in_groups = self.num_groups
+            else:
+                num_in_groups = len(in_groups)
+            if out_groups == 'all':
+                num_out_groups = self.num_groups
+            else:
+                num_out_groups = len(out_groups)
+
+            # Reshape tally data array with separate axes for domain and energy
+            num_subdomains = int(xs.shape[0] /
+                                 (num_in_groups * num_out_groups))
+            new_shape = (num_subdomains, num_in_groups, num_out_groups)
+            new_shape += xs.shape[1:]
+            xs = np.reshape(xs, new_shape)
+
+            # Transpose the matrix if requested by user
+            if row_column == 'outin':
+                xs = np.swapaxes(xs, 1, 2)
+
+            # Reverse energies to align with increasing energy groups
+            xs = xs[:, ::-1, ::-1, :]
+
+            # Eliminate trivial dimensions
+            xs = np.squeeze(xs)
+            xs = np.atleast_2d(xs)
+
+        return xs
+
+    def get_slice(self, nuclides=[], in_groups=[], out_groups=[]):
+        """Build a sliced NuFissionMatrix for the specified nuclides and
+        energy groups.
+
+        This method constructs a new MGXS to encapsulate a subset of the data
+        represented by this MGXS. The subset of data to include in the tally
+        slice is determined by the nuclides and energy groups specified in
+        the input parameters.
+
+        Parameters
+        ----------
+        nuclides : list of str
+            A list of nuclide name strings
+            (e.g., ['U-235', 'U-238']; default is [])
+        in_groups : list of int
+            A list of incoming energy group indices starting at 1 for the high
+            energies (e.g., [1, 2, 3]; default is [])
+        out_groups : list of int
+            A list of outgoing energy group indices starting at 1 for the high
+            energies (e.g., [1, 2, 3]; default is [])
+
+        Returns
+        -------
+        openmc.mgxs.MGXS
+            A new tally which encapsulates the subset of data requested for the
+            nuclide(s) and/or energy group(s) requested in the parameters.
+
+        """
+
+        # Call super class method and null out derived tallies
+        slice_xs = super(NuFissionMatrixXS, self).get_slice(nuclides,
+                                                            in_groups)
+        slice_xs._rxn_rate_tally = None
+        slice_xs._xs_tally = None
+
+        # Slice outgoing energy groups if needed
+        if len(out_groups) != 0:
+            filter_bins = []
+            for group in out_groups:
+                group_bounds = self.energy_groups.get_group_bounds(group)
+                filter_bins.append(group_bounds)
+            filter_bins = [tuple(filter_bins)]
+
+            # Slice each of the tallies across energyout groups
+            for tally_type, tally in slice_xs.tallies.items():
+                if tally.contains_filter('energyout'):
+                    tally_slice = tally.get_slice(filters=['energyout'],
+                                                  filter_bins=filter_bins)
+                    slice_xs.tallies[tally_type] = tally_slice
+
+        slice_xs.sparse = self.sparse
+        return slice_xs
+
+    def print_xs(self, subdomains='all', nuclides='all', xs_type='macro'):
+        """Prints a string representation for the multi-group cross section.
+
+        Parameters
+        ----------
+        subdomains : Iterable of Integral or 'all'
+            The subdomain IDs of the cross sections to include in the report.
+            Defaults to 'all'.
+        nuclides : Iterable of str or 'all' or 'sum'
+            The nuclides of the cross-sections to include in the report. This
+            may be a list of nuclide name strings (e.g., ['U-235', 'U-238']).
+            The special string 'all' will report the cross sections for all
+            nuclides in the spatial domain. The special string 'sum' will report
+            the cross sections summed over all nuclides. Defaults to 'all'.
+        xs_type: {'macro', 'micro'}
+            Return the macro or micro cross section in units of cm^-1 or barns.
+            Defaults to 'macro'.
+
+        """
+
+        # Construct a collection of the subdomains to report
+        if not isinstance(subdomains, basestring):
+            cv.check_iterable_type('subdomains', subdomains, Integral)
+        elif self.domain_type == 'distribcell':
+            subdomains = np.arange(self.num_subdomains, dtype=np.int)
+        else:
+            subdomains = [self.domain.id]
+
+        # Construct a collection of the nuclides to report
+        if self.by_nuclide:
+            if nuclides == 'all':
+                nuclides = self.get_all_nuclides()
+            if nuclides == 'sum':
+                nuclides = ['sum']
+            else:
+                cv.check_iterable_type('nuclides', nuclides, basestring)
+        else:
+            nuclides = ['sum']
+
+        cv.check_value('xs_type', xs_type, ['macro', 'micro'])
+
+        # Build header for string with type and domain info
+        string = 'Multi-Group XS\n'
+        string += '{0: <16}=\t{1}\n'.format('\tReaction Type', self.rxn_type)
+        string += '{0: <16}=\t{1}\n'.format('\tDomain Type', self.domain_type)
+        string += '{0: <16}=\t{1}\n'.format('\tDomain ID', self.domain.id)
+
+        # If cross section data has not been computed, only print string header
+        if self.tallies is None:
+            print(string)
+            return
+
+        string += '{0: <16}\n'.format('\tEnergy Groups:')
+        template = '{0: <12}Group {1} [{2: <10} - {3: <10}MeV]\n'
+
+        # Loop over energy groups ranges
+        for group in range(1, self.num_groups+1):
+            bounds = self.energy_groups.get_group_bounds(group)
+            string += template.format('', group, bounds[0], bounds[1])
+
+        # Loop over all subdomains
+        for subdomain in subdomains:
+
+            if self.domain_type == 'distribcell':
+                string += \
+                    '{0: <16}=\t{1}\n'.format('\tSubdomain', subdomain)
+
+            # Loop over all Nuclides
+            for nuclide in nuclides:
+
+                # Build header for nuclide type
+                if xs_type != 'sum':
+                    string += '{0: <16}=\t{1}\n'.format('\tNuclide', nuclide)
+
+                # Build header for cross section type
+                if xs_type == 'macro':
+                    string += '{0: <16}\n'.format('\tCross Sections [cm^-1]:')
+                else:
+                    string += '{0: <16}\n'.format('\tCross Sections [barns]:')
+
+                template = '{0: <12}Group {1} -> Group {2}:\t\t'
+
+                # Loop over incoming/outgoing energy groups ranges
+                for in_group in range(1, self.num_groups+1):
+                    for out_group in range(1, self.num_groups+1):
+                        string += template.format('', in_group, out_group)
+                        average = \
+                            self.get_xs([in_group], [out_group],
+                                        [subdomain], [nuclide],
+                                        xs_type=xs_type, value='mean')
+                        rel_err = \
+                            self.get_xs([in_group], [out_group],
+                                        [subdomain], [nuclide],
+                                        xs_type=xs_type, value='rel_err')
+                        average = average.flatten()[0]
+                        rel_err = rel_err.flatten()[0] * 100.
+                        string += '{:1.2e} +/- {:1.2e}%'.format(average, rel_err)
+                        string += '\n'
+                    string += '\n'
+                string += '\n'
+            string += '\n'
+
+        print(string)
 
 
 class TotalXS(MGXS):
@@ -3191,7 +3594,7 @@ class NuScatterMatrixXS(ScatterMatrixXS):
         self._hdf5_key = 'nu-scatter matrix'
 
 
-class MultiplicityMatrix(MGXS):
+class MultiplicityMatrix(MatrixMGXS):
     """The scattering multiplicity matrix.
 
     This class can be used for both OpenMC input generation and tally data
@@ -3280,23 +3683,19 @@ class MultiplicityMatrix(MGXS):
 
     @property
     def scores(self):
-        return ['nu-scatter', 'scatter']
+        scores = ['nu-scatter', 'scatter']
+        return scores
 
     @property
     def filters(self):
         # Create the non-domain specific Filters for the Tallies
         group_edges = self.energy_groups.group_edges
+        energy = openmc.Filter('energy', group_edges)
         energyout = openmc.Filter('energyout', group_edges)
-        energyin = openmc.Filter('energy', group_edges)
-        return [[energyin, energyout], [energyin, energyout]]
 
-    @property
-    def tally_keys(self):
-        return ['nu-scatter', 'scatter']
+        filters = [[energy, energyout], [energy, energyout]]
 
-    @property
-    def estimator(self):
-        return 'analog'
+        return filters
 
     @property
     def rxn_rate_tally(self):
@@ -3317,306 +3716,8 @@ class MultiplicityMatrix(MGXS):
 
         return self._xs_tally
 
-    def get_slice(self, nuclides=[], in_groups=[], out_groups=[]):
-        """Build a sliced MultiplicityMatrix for the specified nuclides and
-        energy groups.
 
-        This method constructs a new MGXS to encapsulate a subset of the data
-        represented by this MGXS. The subset of data to include in the tally
-        slice is determined by the nuclides and energy groups specified in
-        the input parameters.
-
-        Parameters
-        ----------
-        nuclides : list of str
-            A list of nuclide name strings
-            (e.g., ['U-235', 'U-238']; default is [])
-        in_groups : list of int
-            A list of incoming energy group indices starting at 1 for the high
-            energies (e.g., [1, 2, 3]; default is [])
-        out_groups : list of int
-            A list of outgoing energy group indices starting at 1 for the high
-            energies (e.g., [1, 2, 3]; default is [])
-
-        Returns
-        -------
-        openmc.mgxs.MGXS
-            A new tally which encapsulates the subset of data requested for the
-            nuclide(s) and/or energy group(s) requested in the parameters.
-
-        """
-
-        # Call super class method and null out derived tallies
-        slice_xs = super(MultiplicityMatrix, self).get_slice(nuclides,
-                                                             in_groups)
-        slice_xs._rxn_rate_tally = None
-        slice_xs._xs_tally = None
-
-        # Slice outgoing energy groups if needed
-        if len(out_groups) != 0:
-            filter_bins = []
-            for group in out_groups:
-                group_bounds = self.energy_groups.get_group_bounds(group)
-                filter_bins.append(group_bounds)
-            filter_bins = [tuple(filter_bins)]
-
-            # Slice each of the tallies across energyout groups
-            for tally_type, tally in slice_xs.tallies.items():
-                if tally.contains_filter('energyout'):
-                    tally_slice = tally.get_slice(filters=['energyout'],
-                                                  filter_bins=filter_bins)
-                    slice_xs.tallies[tally_type] = tally_slice
-
-        slice_xs.sparse = self.sparse
-        return slice_xs
-
-    def get_xs(self, in_groups='all', out_groups='all',
-               subdomains='all', nuclides='all',
-               xs_type='macro', order_groups='increasing',
-               row_column='inout', value='mean', **kwargs):
-        r"""Returns an array of multi-group cross sections.
-
-        This method constructs a 2D NumPy array for the requested multiplicity
-        matrix data data for one or more energy groups and subdomains.
-
-        Parameters
-        ----------
-        in_groups : Iterable of Integral or 'all'
-            Incoming energy groups of interest. Defaults to 'all'.
-        out_groups : Iterable of Integral or 'all'
-            Outgoing energy groups of interest. Defaults to 'all'.
-        subdomains : Iterable of Integral or 'all'
-            Subdomain IDs of interest. Defaults to 'all'.
-        nuclides : Iterable of str or 'all' or 'sum'
-            A list of nuclide name strings (e.g., ['U-235', 'U-238']). The
-            special string 'all' will return the cross sections for all nuclides
-            in the spatial domain. The special string 'sum' will return the
-            cross section summed over all nuclides. Defaults to 'all'.
-        xs_type: {'macro', 'micro'}
-            Return the macro or micro cross section in units of cm^-1 or barns.
-            Defaults to 'macro'.
-        order_groups: {'increasing', 'decreasing'}
-            Return the cross section indexed according to increasing or
-            decreasing energy groups (decreasing or increasing energies).
-            Defaults to 'increasing'.
-        row_column: {'inout', 'outin'}
-            Return the cross section indexed first by incoming group and
-            second by outgoing group ('inout'), or vice versa ('outin').
-            Defaults to 'inout'.
-        value : str
-            A string for the type of value to return - 'mean', 'std_dev', or
-            'rel_err' are accepted. Defaults to the empty string.
-
-        Returns
-        -------
-        ndarray
-            A NumPy array of the multi-group cross section indexed in the order
-            each group and subdomain is listed in the parameters.
-
-        Raises
-        ------
-        ValueError
-            When this method is called before the multi-group cross section is
-            computed from tally data.
-
-        """
-
-        cv.check_value('value', value, ['mean', 'std_dev', 'rel_err'])
-        cv.check_value('xs_type', xs_type, ['macro', 'micro'])
-
-        filters = []
-        filter_bins = []
-
-        # Construct a collection of the domain filter bins
-        if not isinstance(subdomains, basestring):
-            cv.check_iterable_type('subdomains', subdomains, Integral, max_depth=2)
-            for subdomain in subdomains:
-                filters.append(self.domain_type)
-                filter_bins.append((subdomain,))
-
-        # Construct list of energy group bounds tuples for all requested groups
-        if not isinstance(in_groups, basestring):
-            cv.check_iterable_type('groups', in_groups, Integral)
-            for group in in_groups:
-                filters.append('energy')
-                filter_bins.append((self.energy_groups.get_group_bounds(group),))
-
-        # Construct list of energy group bounds tuples for all requested groups
-        if not isinstance(out_groups, basestring):
-            cv.check_iterable_type('groups', out_groups, Integral)
-            for group in out_groups:
-                filters.append('energyout')
-                filter_bins.append((self.energy_groups.get_group_bounds(group),))
-
-        # Construct a collection of the nuclides to retrieve from the xs tally
-        if self.by_nuclide:
-            if nuclides == 'all' or nuclides == 'sum' or nuclides == ['sum']:
-                query_nuclides = self.get_all_nuclides()
-            else:
-                query_nuclides = nuclides
-        else:
-            query_nuclides = ['total']
-
-        # Use tally summation if user requested the sum for all nuclides
-        if nuclides == 'sum' or nuclides == ['sum']:
-            xs_tally = self.xs_tally.summation(nuclides=query_nuclides)
-            xs = xs_tally.get_values(filters=filters, filter_bins=filter_bins,
-                                     value=value)
-        else:
-            xs = self.xs_tally.get_values(filters=filters,
-                                          filter_bins=filter_bins,
-                                          nuclides=query_nuclides, value=value)
-
-        xs = np.nan_to_num(xs)
-
-        # Divide by atom number densities for microscopic cross sections
-        if xs_type == 'micro':
-            if self.by_nuclide:
-                densities = self.get_nuclide_densities(nuclides)
-            else:
-                densities = self.get_nuclide_densities('sum')
-            if value == 'mean' or value == 'std_dev':
-                xs /= densities[np.newaxis, :, np.newaxis]
-
-        # Reverse data if user requested increasing energy groups since
-        # tally data is stored in order of increasing energies
-        if order_groups == 'increasing':
-            if in_groups == 'all':
-                num_in_groups = self.num_groups
-            else:
-                num_in_groups = len(in_groups)
-            if out_groups == 'all':
-                num_out_groups = self.num_groups
-            else:
-                num_out_groups = len(out_groups)
-
-            # Reshape tally data array with separate axes for domain and energy
-            num_subdomains = int(xs.shape[0] /
-                                 (num_in_groups * num_out_groups))
-            new_shape = (num_subdomains, num_in_groups, num_out_groups)
-            new_shape += xs.shape[1:]
-            xs = np.reshape(xs, new_shape)
-
-            # Transpose the matrix if requested by user
-            if row_column == 'outin':
-                xs = np.swapaxes(xs, 1, 2)
-
-            # Reverse energies to align with increasing energy groups
-            xs = xs[:, ::-1, ::-1, :]
-
-            # Eliminate trivial dimensions
-            xs = np.squeeze(xs)
-            xs = np.atleast_2d(xs)
-
-        return xs
-
-    def print_xs(self, subdomains='all', nuclides='all',
-                 xs_type='macro'):
-        """Prints a string representation for the multi-group cross section.
-
-        Parameters
-        ----------
-        subdomains : Iterable of Integral or 'all'
-            The subdomain IDs of the cross sections to include in the report.
-            Defaults to 'all'.
-        nuclides : Iterable of str or 'all' or 'sum'
-            The nuclides of the cross-sections to include in the report. This
-            may be a list of nuclide name strings (e.g., ['U-235', 'U-238']).
-            The special string 'all' will report the cross sections for all
-            nuclides in the spatial domain. The special string 'sum' will report
-            the cross sections summed over all nuclides. Defaults to 'all'.
-        xs_type: {'macro', 'micro'}
-            Return the macro or micro cross section in units of cm^-1 or barns.
-            Defaults to 'macro'.
-
-        """
-
-        # Construct a collection of the subdomains to report
-        if not isinstance(subdomains, basestring):
-            cv.check_iterable_type('subdomains', subdomains, Integral)
-        elif self.domain_type == 'distribcell':
-            subdomains = np.arange(self.num_subdomains, dtype=np.int)
-        else:
-            subdomains = [self.domain.id]
-
-        # Construct a collection of the nuclides to report
-        if self.by_nuclide:
-            if nuclides == 'all':
-                nuclides = self.get_all_nuclides()
-            if nuclides == 'sum':
-                nuclides = ['sum']
-            else:
-                cv.check_iterable_type('nuclides', nuclides, basestring)
-        else:
-            nuclides = ['sum']
-
-        cv.check_value('xs_type', xs_type, ['macro', 'micro'])
-
-        # Build header for string with type and domain info
-        string = 'Multi-Group XS\n'
-        string += '{0: <16}=\t{1}\n'.format('\tReaction Type', self.rxn_type)
-        string += '{0: <16}=\t{1}\n'.format('\tDomain Type', self.domain_type)
-        string += '{0: <16}=\t{1}\n'.format('\tDomain ID', self.domain.id)
-
-        # If cross section data has not been computed, only print string header
-        if self.tallies is None:
-            print(string)
-            return
-
-        string += '{0: <16}\n'.format('\tEnergy Groups:')
-        template = '{0: <12}Group {1} [{2: <10} - {3: <10}MeV]\n'
-
-        # Loop over energy groups ranges
-        for group in range(1, self.num_groups+1):
-            bounds = self.energy_groups.get_group_bounds(group)
-            string += template.format('', group, bounds[0], bounds[1])
-
-        # Loop over all subdomains
-        for subdomain in subdomains:
-
-            if self.domain_type == 'distribcell':
-                string += \
-                    '{0: <16}=\t{1}\n'.format('\tSubdomain', subdomain)
-
-            # Loop over all Nuclides
-            for nuclide in nuclides:
-
-                # Build header for nuclide type
-                if xs_type != 'sum':
-                    string += '{0: <16}=\t{1}\n'.format('\tNuclide', nuclide)
-
-                # Build header for cross section type
-                if xs_type == 'macro':
-                    string += '{0: <16}\n'.format('\tCross Sections [cm^-1]:')
-                else:
-                    string += '{0: <16}\n'.format('\tCross Sections [barns]:')
-
-                template = '{0: <12}Group {1} -> Group {2}:\t\t'
-
-                # Loop over incoming/outgoing energy groups ranges
-                for in_group in range(1, self.num_groups+1):
-                    for out_group in range(1, self.num_groups+1):
-                        string += template.format('', in_group, out_group)
-                        average = \
-                            self.get_xs([in_group], [out_group],
-                                        [subdomain], [nuclide],
-                                        xs_type=xs_type, value='mean')
-                        rel_err = \
-                            self.get_xs([in_group], [out_group],
-                                        [subdomain], [nuclide],
-                                        xs_type=xs_type, value='rel_err')
-                        average = average.flatten()[0]
-                        rel_err = rel_err.flatten()[0] * 100.
-                        string += '{:1.2e} +/- {:1.2e}%'.format(average, rel_err)
-                        string += '\n'
-                    string += '\n'
-                string += '\n'
-            string += '\n'
-
-        print(string)
-
-
-class NuFissionMatrixXS(MGXS):
+class NuFissionMatrixXS(MatrixMGXS):
     """A fission production matrix multi-group cross section.
 
     This class can be used for both OpenMC input generation and tally data
@@ -3702,31 +3803,11 @@ class NuFissionMatrixXS(MGXS):
         super(NuFissionMatrixXS, self).__init__(domain, domain_type,
                                                 groups, by_nuclide, name)
         self._rxn_type = 'nu-fission matrix'
-        self._hdf5_key = 'nu-fission matrix'
-
-    def __deepcopy__(self, memo):
-        clone = super(NuFissionMatrixXS, self).__deepcopy__(memo)
-        return clone
 
     @property
     def scores(self):
         scores = ['flux', 'nu-fission']
-
         return scores
-
-    @property
-    def filters(self):
-        group_edges = self.energy_groups.group_edges
-        energy = openmc.Filter('energy', group_edges)
-        energyout = openmc.Filter('energyout', group_edges)
-
-        filters = [[energy], [energy, energyout]]
-
-        return filters
-
-    @property
-    def estimator(self):
-        return 'analog'
 
     @property
     def rxn_rate_tally(self):
@@ -3734,304 +3815,6 @@ class NuFissionMatrixXS(MGXS):
             self._rxn_rate_tally = self.tallies['nu-fission']
             self._rxn_rate_tally.sparse = self.sparse
         return self._rxn_rate_tally
-
-    def get_slice(self, nuclides=[], in_groups=[], out_groups=[]):
-        """Build a sliced NuFissionMatrix for the specified nuclides and
-        energy groups.
-
-        This method constructs a new MGXS to encapsulate a subset of the data
-        represented by this MGXS. The subset of data to include in the tally
-        slice is determined by the nuclides and energy groups specified in
-        the input parameters.
-
-        Parameters
-        ----------
-        nuclides : list of str
-            A list of nuclide name strings
-            (e.g., ['U-235', 'U-238']; default is [])
-        in_groups : list of int
-            A list of incoming energy group indices starting at 1 for the high
-            energies (e.g., [1, 2, 3]; default is [])
-        out_groups : list of int
-            A list of outgoing energy group indices starting at 1 for the high
-            energies (e.g., [1, 2, 3]; default is [])
-
-        Returns
-        -------
-        openmc.mgxs.MGXS
-            A new tally which encapsulates the subset of data requested for the
-            nuclide(s) and/or energy group(s) requested in the parameters.
-
-        """
-
-        # Call super class method and null out derived tallies
-        slice_xs = super(NuFissionMatrixXS, self).get_slice(nuclides,
-                                                            in_groups)
-        slice_xs._rxn_rate_tally = None
-        slice_xs._xs_tally = None
-
-        # Slice outgoing energy groups if needed
-        if len(out_groups) != 0:
-            filter_bins = []
-            for group in out_groups:
-                group_bounds = self.energy_groups.get_group_bounds(group)
-                filter_bins.append(group_bounds)
-            filter_bins = [tuple(filter_bins)]
-
-            # Slice each of the tallies across energyout groups
-            for tally_type, tally in slice_xs.tallies.items():
-                if tally.contains_filter('energyout'):
-                    tally_slice = tally.get_slice(filters=['energyout'],
-                                                  filter_bins=filter_bins)
-                    slice_xs.tallies[tally_type] = tally_slice
-
-        slice_xs.sparse = self.sparse
-        return slice_xs
-
-    def get_xs(self, in_groups='all', out_groups='all',
-               subdomains='all', nuclides='all',
-               xs_type='macro', order_groups='increasing',
-               row_column='inout', value='mean', **kwargs):
-        r"""Returns an array of multi-group cross sections.
-
-        This method constructs a 2D NumPy array for the requested nu-fission
-        matrix data data for one or more energy groups and subdomains.
-
-        Parameters
-        ----------
-        in_groups : Iterable of Integral or 'all'
-            Incoming energy groups of interest. Defaults to 'all'.
-        out_groups : Iterable of Integral or 'all'
-            Outgoing energy groups of interest. Defaults to 'all'.
-        subdomains : Iterable of Integral or 'all'
-            Subdomain IDs of interest. Defaults to 'all'.
-        nuclides : Iterable of str or 'all' or 'sum'
-            A list of nuclide name strings (e.g., ['U-235', 'U-238']). The
-            special string 'all' will return the cross sections for all nuclides
-            in the spatial domain. The special string 'sum' will return the
-            cross section summed over all nuclides. Defaults to 'all'.
-        xs_type: {'macro', 'micro'}
-            Return the macro or micro cross section in units of cm^-1 or barns.
-            Defaults to 'macro'.
-        order_groups: {'increasing', 'decreasing'}
-            Return the cross section indexed according to increasing or
-            decreasing energy groups (decreasing or increasing energies).
-            Defaults to 'increasing'.
-        row_column: {'inout', 'outin'}
-            Return the cross section indexed first by incoming group and
-            second by outgoing group ('inout'), or vice versa ('outin').
-            Defaults to 'inout'.
-        value : str
-            A string for the type of value to return - 'mean', 'std_dev', or
-            'rel_err' are accepted. Defaults to the empty string.
-
-        Returns
-        -------
-        ndarray
-            A NumPy array of the multi-group cross section indexed in the order
-            each group and subdomain is listed in the parameters.
-
-        Raises
-        ------
-        ValueError
-            When this method is called before the multi-group cross section is
-            computed from tally data.
-
-        """
-
-        cv.check_value('value', value, ['mean', 'std_dev', 'rel_err'])
-        cv.check_value('xs_type', xs_type, ['macro', 'micro'])
-
-        filters = []
-        filter_bins = []
-
-        # Construct a collection of the domain filter bins
-        if not isinstance(subdomains, basestring):
-            cv.check_iterable_type('subdomains', subdomains, Integral, max_depth=2)
-            for subdomain in subdomains:
-                filters.append(self.domain_type)
-                filter_bins.append((subdomain,))
-
-        # Construct list of energy group bounds tuples for all requested groups
-        if not isinstance(in_groups, basestring):
-            cv.check_iterable_type('groups', in_groups, Integral)
-            for group in in_groups:
-                filters.append('energy')
-                filter_bins.append((self.energy_groups.get_group_bounds(group),))
-
-        # Construct list of energy group bounds tuples for all requested groups
-        if not isinstance(out_groups, basestring):
-            cv.check_iterable_type('groups', out_groups, Integral)
-            for group in out_groups:
-                filters.append('energyout')
-                filter_bins.append((self.energy_groups.get_group_bounds(group),))
-
-        # Construct a collection of the nuclides to retrieve from the xs tally
-        if self.by_nuclide:
-            if nuclides == 'all' or nuclides == 'sum' or nuclides == ['sum']:
-                query_nuclides = self.get_all_nuclides()
-            else:
-                query_nuclides = nuclides
-        else:
-            query_nuclides = ['total']
-
-        # Use tally summation if user requested the sum for all nuclides
-        if nuclides == 'sum' or nuclides == ['sum']:
-            xs_tally = self.xs_tally.summation(nuclides=query_nuclides)
-            xs = xs_tally.get_values(filters=filters, filter_bins=filter_bins,
-                                     value=value)
-        else:
-            xs = self.xs_tally.get_values(filters=filters,
-                                          filter_bins=filter_bins,
-                                          nuclides=query_nuclides, value=value)
-
-        xs = np.nan_to_num(xs)
-
-        # Divide by atom number densities for microscopic cross sections
-        if xs_type == 'micro':
-            if self.by_nuclide:
-                densities = self.get_nuclide_densities(nuclides)
-            else:
-                densities = self.get_nuclide_densities('sum')
-            if value == 'mean' or value == 'std_dev':
-                xs /= densities[np.newaxis, :, np.newaxis]
-
-        # Reverse data if user requested increasing energy groups since
-        # tally data is stored in order of increasing energies
-        if order_groups == 'increasing':
-            if in_groups == 'all':
-                num_in_groups = self.num_groups
-            else:
-                num_in_groups = len(in_groups)
-            if out_groups == 'all':
-                num_out_groups = self.num_groups
-            else:
-                num_out_groups = len(out_groups)
-
-            # Reshape tally data array with separate axes for domain and energy
-            num_subdomains = int(xs.shape[0] /
-                                 (num_in_groups * num_out_groups))
-            new_shape = (num_subdomains, num_in_groups, num_out_groups)
-            new_shape += xs.shape[1:]
-            xs = np.reshape(xs, new_shape)
-
-            # Transpose the matrix if requested by user
-            if row_column == 'outin':
-                xs = np.swapaxes(xs, 1, 2)
-
-            # Reverse energies to align with increasing energy groups
-            xs = xs[:, ::-1, ::-1, :]
-
-            # Eliminate trivial dimensions
-            xs = np.squeeze(xs)
-            xs = np.atleast_2d(xs)
-
-        return xs
-
-    def print_xs(self, subdomains='all', nuclides='all',
-                 xs_type='macro'):
-        """Prints a string representation for the multi-group cross section.
-
-        Parameters
-        ----------
-        subdomains : Iterable of Integral or 'all'
-            The subdomain IDs of the cross sections to include in the report.
-            Defaults to 'all'.
-        nuclides : Iterable of str or 'all' or 'sum'
-            The nuclides of the cross-sections to include in the report. This
-            may be a list of nuclide name strings (e.g., ['U-235', 'U-238']).
-            The special string 'all' will report the cross sections for all
-            nuclides in the spatial domain. The special string 'sum' will report
-            the cross sections summed over all nuclides. Defaults to 'all'.
-        xs_type: {'macro', 'micro'}
-            Return the macro or micro cross section in units of cm^-1 or barns.
-            Defaults to 'macro'.
-
-        """
-
-        # Construct a collection of the subdomains to report
-        if not isinstance(subdomains, basestring):
-            cv.check_iterable_type('subdomains', subdomains, Integral)
-        elif self.domain_type == 'distribcell':
-            subdomains = np.arange(self.num_subdomains, dtype=np.int)
-        else:
-            subdomains = [self.domain.id]
-
-        # Construct a collection of the nuclides to report
-        if self.by_nuclide:
-            if nuclides == 'all':
-                nuclides = self.get_all_nuclides()
-            if nuclides == 'sum':
-                nuclides = ['sum']
-            else:
-                cv.check_iterable_type('nuclides', nuclides, basestring)
-        else:
-            nuclides = ['sum']
-
-        cv.check_value('xs_type', xs_type, ['macro', 'micro'])
-
-        # Build header for string with type and domain info
-        string = 'Multi-Group XS\n'
-        string += '{0: <16}=\t{1}\n'.format('\tReaction Type', self.rxn_type)
-        string += '{0: <16}=\t{1}\n'.format('\tDomain Type', self.domain_type)
-        string += '{0: <16}=\t{1}\n'.format('\tDomain ID', self.domain.id)
-
-        # If cross section data has not been computed, only print string header
-        if self.tallies is None:
-            print(string)
-            return
-
-        string += '{0: <16}\n'.format('\tEnergy Groups:')
-        template = '{0: <12}Group {1} [{2: <10} - {3: <10}MeV]\n'
-
-        # Loop over energy groups ranges
-        for group in range(1, self.num_groups+1):
-            bounds = self.energy_groups.get_group_bounds(group)
-            string += template.format('', group, bounds[0], bounds[1])
-
-        # Loop over all subdomains
-        for subdomain in subdomains:
-
-            if self.domain_type == 'distribcell':
-                string += \
-                    '{0: <16}=\t{1}\n'.format('\tSubdomain', subdomain)
-
-            # Loop over all Nuclides
-            for nuclide in nuclides:
-
-                # Build header for nuclide type
-                if xs_type != 'sum':
-                    string += '{0: <16}=\t{1}\n'.format('\tNuclide', nuclide)
-
-                # Build header for cross section type
-                if xs_type == 'macro':
-                    string += '{0: <16}\n'.format('\tCross Sections [cm^-1]:')
-                else:
-                    string += '{0: <16}\n'.format('\tCross Sections [barns]:')
-
-                template = '{0: <12}Group {1} -> Group {2}:\t\t'
-
-                # Loop over incoming/outgoing energy groups ranges
-                for in_group in range(1, self.num_groups+1):
-                    for out_group in range(1, self.num_groups+1):
-                        string += template.format('', in_group, out_group)
-                        average = \
-                            self.get_xs([in_group], [out_group],
-                                        [subdomain], [nuclide],
-                                        xs_type=xs_type, value='mean')
-                        rel_err = \
-                            self.get_xs([in_group], [out_group],
-                                        [subdomain], [nuclide],
-                                        xs_type=xs_type, value='rel_err')
-                        average = average.flatten()[0]
-                        rel_err = rel_err.flatten()[0] * 100.
-                        string += '{:1.2e} +/- {:1.2e}%'.format(average, rel_err)
-                        string += '\n'
-                    string += '\n'
-                string += '\n'
-            string += '\n'
-
-        print(string)
 
 
 class Chi(MGXS):

--- a/openmc/mgxs/mgxs.py
+++ b/openmc/mgxs/mgxs.py
@@ -430,7 +430,8 @@ class MGXS(object):
         mgxs_type : {'total', 'transport', 'nu-transport', 'absorption',
                      'capture', 'fission', 'nu-fission', 'kappa-fission',
                      'scatter', 'nu-scatter', 'scatter matrix',
-                     'nu-scatter matrix', 'nu-fission matrix', 'chi'}
+                     'nu-scatter matrix', 'multiplicity matrix',
+                     'nu-fission matrix', chi'}
             The type of multi-group cross section object to return
         domain : openmc.Material or openmc.Cell or openmc.Universe
             The domain for spatial homogenization

--- a/openmc/mgxs/mgxs.py
+++ b/openmc/mgxs/mgxs.py
@@ -32,6 +32,7 @@ MGXS_TYPES = ['total',
               'nu-scatter',
               'scatter matrix',
               'nu-scatter matrix',
+              'multiplicity matrix',
               'nu-fission matrix',
               'chi']
 
@@ -478,6 +479,8 @@ class MGXS(object):
             mgxs = ScatterMatrixXS(domain, domain_type, energy_groups)
         elif mgxs_type == 'nu-scatter matrix':
             mgxs = NuScatterMatrixXS(domain, domain_type, energy_groups)
+        elif mgxs_type == 'multiplicity matrix':
+            mgxs = MultiplicityMatrix(domain, domain_type, energy_groups)
         elif mgxs_type == 'nu-fission matrix':
             mgxs = NuFissionMatrixXS(domain, domain_type, energy_groups)
         elif mgxs_type == 'chi':
@@ -3188,6 +3191,431 @@ class NuScatterMatrixXS(ScatterMatrixXS):
         self._hdf5_key = 'nu-scatter matrix'
 
 
+class MultiplicityMatrix(MGXS):
+    """The scattering multiplicity matrix.
+
+    This class can be used for both OpenMC input generation and tally data
+    post-processing to compute spatially-homogenized and energy-integrated
+    multi-group cross sections for deterministic neutronics calculations.
+
+    Parameters
+    ----------
+    domain : openmc.Material or openmc.Cell or openmc.Universe
+        The domain for spatial homogenization
+    domain_type : {'material', 'cell', 'distribcell', 'universe'}
+        The domain type for spatial homogenization
+    energy_groups : openmc.mgxs.EnergyGroups
+        The energy group structure for energy condensation
+    by_nuclide : bool
+        If true, computes cross sections for each nuclide in domain
+    name : str, optional
+        Name of the multi-group cross section. Used as a label to identify
+        tallies in OpenMC 'tallies.xml' file.
+
+    Attributes
+    ----------
+    name : str, optional
+        Name of the multi-group cross section
+    rxn_type : str
+        Reaction type (e.g., 'total', 'nu-fission', etc.)
+    by_nuclide : bool
+        If true, computes cross sections for each nuclide in domain
+    domain : Material or Cell or Universe
+        Domain for spatial homogenization
+    domain_type : {'material', 'cell', 'distribcell', 'universe'}
+        Domain type for spatial homogenization
+    energy_groups : openmc.mgxs.EnergyGroups
+        Energy group structure for energy condensation
+    tally_trigger : openmc.Trigger
+        An (optional) tally precision trigger given to each tally used to
+        compute the cross section
+    scores : list of str
+        The scores in each tally used to compute the multi-group cross section
+    filters : list of openmc.Filter
+        The filters in each tally used to compute the multi-group cross section
+    tally_keys : list of str
+        The keys into the tallies dictionary for each tally used to compute
+        the multi-group cross section
+    estimator : {'tracklength', 'analog'}
+        The tally estimator used to compute the multi-group cross section
+    tallies : collections.OrderedDict
+        OpenMC tallies needed to compute the multi-group cross section
+    rxn_rate_tally : openmc.Tally
+        Derived tally for the reaction rate tally used in the numerator to
+        compute the multi-group cross section. This attribute is None
+        unless the multi-group cross section has been computed.
+    xs_tally : openmc.Tally
+        Derived tally for the multi-group cross section. This attribute
+        is None unless the multi-group cross section has been computed.
+    num_subdomains : int
+        The number of subdomains is unity for 'material', 'cell' and 'universe'
+        domain types. When the  This is equal to the number of cell instances
+        for 'distribcell' domain types (it is equal to unity prior to loading
+        tally data from a statepoint file).
+    num_nuclides : int
+        The number of nuclides for which the multi-group cross section is
+        being tracked. This is unity if the by_nuclide attribute is False.
+    nuclides : Iterable of str or 'sum'
+        The optional user-specified nuclides for which to compute cross
+        sections (e.g., 'U-238', 'O-16'). If by_nuclide is True but nuclides
+        are not specified by the user, all nuclides in the spatial domain
+        are included. This attribute is 'sum' if by_nuclide is false.
+    sparse : bool
+        Whether or not the MGXS' tallies use SciPy's LIL sparse matrix format
+        for compressed data storage
+    loaded_sp : bool
+        Whether or not a statepoint file has been loaded with tally data
+    derived : bool
+        Whether or not the MGXS is merged from one or more other MGXS
+    hdf5_key : str
+        The key used to index multi-group cross sections in an HDF5 data store
+
+    """
+
+    def __init__(self, domain=None, domain_type=None,
+                 groups=None, by_nuclide=False, name=''):
+        super(MultiplicityMatrix, self).__init__(domain, domain_type, groups,
+                                                 by_nuclide, name)
+        self._rxn_type = 'multiplicity'
+
+    @property
+    def scores(self):
+        return ['nu-scatter', 'scatter']
+
+    @property
+    def filters(self):
+        # Create the non-domain specific Filters for the Tallies
+        group_edges = self.energy_groups.group_edges
+        energyout = openmc.Filter('energyout', group_edges)
+        energyin = openmc.Filter('energy', group_edges)
+        return [[energyin, energyout], [energyin, energyout]]
+
+    @property
+    def tally_keys(self):
+        return ['nu-scatter', 'scatter']
+
+    @property
+    def estimator(self):
+        return 'analog'
+
+    @property
+    def rxn_rate_tally(self):
+        if self._rxn_rate_tally is None:
+            self._rxn_rate_tally = self.tallies['nu-scatter']
+            self._rxn_rate_tally.sparse = self.sparse
+        return self._rxn_rate_tally
+
+    @property
+    def xs_tally(self):
+
+        if self._xs_tally is None:
+            scatter = self.tallies['scatter']
+
+            # Compute the multiplicity
+            self._xs_tally = self.rxn_rate_tally / scatter
+            super(MultiplicityMatrix, self)._compute_xs()
+
+        return self._xs_tally
+
+    def get_slice(self, nuclides=[], in_groups=[], out_groups=[]):
+        """Build a sliced MultiplicityMatrix for the specified nuclides and
+        energy groups.
+
+        This method constructs a new MGXS to encapsulate a subset of the data
+        represented by this MGXS. The subset of data to include in the tally
+        slice is determined by the nuclides and energy groups specified in
+        the input parameters.
+
+        Parameters
+        ----------
+        nuclides : list of str
+            A list of nuclide name strings
+            (e.g., ['U-235', 'U-238']; default is [])
+        in_groups : list of int
+            A list of incoming energy group indices starting at 1 for the high
+            energies (e.g., [1, 2, 3]; default is [])
+        out_groups : list of int
+            A list of outgoing energy group indices starting at 1 for the high
+            energies (e.g., [1, 2, 3]; default is [])
+
+        Returns
+        -------
+        openmc.mgxs.MGXS
+            A new tally which encapsulates the subset of data requested for the
+            nuclide(s) and/or energy group(s) requested in the parameters.
+
+        """
+
+        # Call super class method and null out derived tallies
+        slice_xs = super(MultiplicityMatrix, self).get_slice(nuclides,
+                                                             in_groups)
+        slice_xs._rxn_rate_tally = None
+        slice_xs._xs_tally = None
+
+        # Slice outgoing energy groups if needed
+        if len(out_groups) != 0:
+            filter_bins = []
+            for group in out_groups:
+                group_bounds = self.energy_groups.get_group_bounds(group)
+                filter_bins.append(group_bounds)
+            filter_bins = [tuple(filter_bins)]
+
+            # Slice each of the tallies across energyout groups
+            for tally_type, tally in slice_xs.tallies.items():
+                if tally.contains_filter('energyout'):
+                    tally_slice = tally.get_slice(filters=['energyout'],
+                                                  filter_bins=filter_bins)
+                    slice_xs.tallies[tally_type] = tally_slice
+
+        slice_xs.sparse = self.sparse
+        return slice_xs
+
+    def get_xs(self, in_groups='all', out_groups='all',
+               subdomains='all', nuclides='all',
+               xs_type='macro', order_groups='increasing',
+               row_column='inout', value='mean', **kwargs):
+        r"""Returns an array of multi-group cross sections.
+
+        This method constructs a 2D NumPy array for the requested multiplicity
+        matrix data data for one or more energy groups and subdomains.
+
+        Parameters
+        ----------
+        in_groups : Iterable of Integral or 'all'
+            Incoming energy groups of interest. Defaults to 'all'.
+        out_groups : Iterable of Integral or 'all'
+            Outgoing energy groups of interest. Defaults to 'all'.
+        subdomains : Iterable of Integral or 'all'
+            Subdomain IDs of interest. Defaults to 'all'.
+        nuclides : Iterable of str or 'all' or 'sum'
+            A list of nuclide name strings (e.g., ['U-235', 'U-238']). The
+            special string 'all' will return the cross sections for all nuclides
+            in the spatial domain. The special string 'sum' will return the
+            cross section summed over all nuclides. Defaults to 'all'.
+        xs_type: {'macro', 'micro'}
+            Return the macro or micro cross section in units of cm^-1 or barns.
+            Defaults to 'macro'.
+        order_groups: {'increasing', 'decreasing'}
+            Return the cross section indexed according to increasing or
+            decreasing energy groups (decreasing or increasing energies).
+            Defaults to 'increasing'.
+        row_column: {'inout', 'outin'}
+            Return the cross section indexed first by incoming group and
+            second by outgoing group ('inout'), or vice versa ('outin').
+            Defaults to 'inout'.
+        value : str
+            A string for the type of value to return - 'mean', 'std_dev', or
+            'rel_err' are accepted. Defaults to the empty string.
+
+        Returns
+        -------
+        ndarray
+            A NumPy array of the multi-group cross section indexed in the order
+            each group and subdomain is listed in the parameters.
+
+        Raises
+        ------
+        ValueError
+            When this method is called before the multi-group cross section is
+            computed from tally data.
+
+        """
+
+        cv.check_value('value', value, ['mean', 'std_dev', 'rel_err'])
+        cv.check_value('xs_type', xs_type, ['macro', 'micro'])
+
+        filters = []
+        filter_bins = []
+
+        # Construct a collection of the domain filter bins
+        if not isinstance(subdomains, basestring):
+            cv.check_iterable_type('subdomains', subdomains, Integral, max_depth=2)
+            for subdomain in subdomains:
+                filters.append(self.domain_type)
+                filter_bins.append((subdomain,))
+
+        # Construct list of energy group bounds tuples for all requested groups
+        if not isinstance(in_groups, basestring):
+            cv.check_iterable_type('groups', in_groups, Integral)
+            for group in in_groups:
+                filters.append('energy')
+                filter_bins.append((self.energy_groups.get_group_bounds(group),))
+
+        # Construct list of energy group bounds tuples for all requested groups
+        if not isinstance(out_groups, basestring):
+            cv.check_iterable_type('groups', out_groups, Integral)
+            for group in out_groups:
+                filters.append('energyout')
+                filter_bins.append((self.energy_groups.get_group_bounds(group),))
+
+        # Construct a collection of the nuclides to retrieve from the xs tally
+        if self.by_nuclide:
+            if nuclides == 'all' or nuclides == 'sum' or nuclides == ['sum']:
+                query_nuclides = self.get_all_nuclides()
+            else:
+                query_nuclides = nuclides
+        else:
+            query_nuclides = ['total']
+
+        # Use tally summation if user requested the sum for all nuclides
+        if nuclides == 'sum' or nuclides == ['sum']:
+            xs_tally = self.xs_tally.summation(nuclides=query_nuclides)
+            xs = xs_tally.get_values(filters=filters, filter_bins=filter_bins,
+                                     value=value)
+        else:
+            xs = self.xs_tally.get_values(filters=filters,
+                                          filter_bins=filter_bins,
+                                          nuclides=query_nuclides, value=value)
+
+        xs = np.nan_to_num(xs)
+
+        # Divide by atom number densities for microscopic cross sections
+        if xs_type == 'micro':
+            if self.by_nuclide:
+                densities = self.get_nuclide_densities(nuclides)
+            else:
+                densities = self.get_nuclide_densities('sum')
+            if value == 'mean' or value == 'std_dev':
+                xs /= densities[np.newaxis, :, np.newaxis]
+
+        # Reverse data if user requested increasing energy groups since
+        # tally data is stored in order of increasing energies
+        if order_groups == 'increasing':
+            if in_groups == 'all':
+                num_in_groups = self.num_groups
+            else:
+                num_in_groups = len(in_groups)
+            if out_groups == 'all':
+                num_out_groups = self.num_groups
+            else:
+                num_out_groups = len(out_groups)
+
+            # Reshape tally data array with separate axes for domain and energy
+            num_subdomains = int(xs.shape[0] /
+                                 (num_in_groups * num_out_groups))
+            new_shape = (num_subdomains, num_in_groups, num_out_groups)
+            new_shape += xs.shape[1:]
+            xs = np.reshape(xs, new_shape)
+
+            # Transpose the matrix if requested by user
+            if row_column == 'outin':
+                xs = np.swapaxes(xs, 1, 2)
+
+            # Reverse energies to align with increasing energy groups
+            xs = xs[:, ::-1, ::-1, :]
+
+            # Eliminate trivial dimensions
+            xs = np.squeeze(xs)
+            xs = np.atleast_2d(xs)
+
+        return xs
+
+    def print_xs(self, subdomains='all', nuclides='all',
+                 xs_type='macro'):
+        """Prints a string representation for the multi-group cross section.
+
+        Parameters
+        ----------
+        subdomains : Iterable of Integral or 'all'
+            The subdomain IDs of the cross sections to include in the report.
+            Defaults to 'all'.
+        nuclides : Iterable of str or 'all' or 'sum'
+            The nuclides of the cross-sections to include in the report. This
+            may be a list of nuclide name strings (e.g., ['U-235', 'U-238']).
+            The special string 'all' will report the cross sections for all
+            nuclides in the spatial domain. The special string 'sum' will report
+            the cross sections summed over all nuclides. Defaults to 'all'.
+        xs_type: {'macro', 'micro'}
+            Return the macro or micro cross section in units of cm^-1 or barns.
+            Defaults to 'macro'.
+
+        """
+
+        # Construct a collection of the subdomains to report
+        if not isinstance(subdomains, basestring):
+            cv.check_iterable_type('subdomains', subdomains, Integral)
+        elif self.domain_type == 'distribcell':
+            subdomains = np.arange(self.num_subdomains, dtype=np.int)
+        else:
+            subdomains = [self.domain.id]
+
+        # Construct a collection of the nuclides to report
+        if self.by_nuclide:
+            if nuclides == 'all':
+                nuclides = self.get_all_nuclides()
+            if nuclides == 'sum':
+                nuclides = ['sum']
+            else:
+                cv.check_iterable_type('nuclides', nuclides, basestring)
+        else:
+            nuclides = ['sum']
+
+        cv.check_value('xs_type', xs_type, ['macro', 'micro'])
+
+        # Build header for string with type and domain info
+        string = 'Multi-Group XS\n'
+        string += '{0: <16}=\t{1}\n'.format('\tReaction Type', self.rxn_type)
+        string += '{0: <16}=\t{1}\n'.format('\tDomain Type', self.domain_type)
+        string += '{0: <16}=\t{1}\n'.format('\tDomain ID', self.domain.id)
+
+        # If cross section data has not been computed, only print string header
+        if self.tallies is None:
+            print(string)
+            return
+
+        string += '{0: <16}\n'.format('\tEnergy Groups:')
+        template = '{0: <12}Group {1} [{2: <10} - {3: <10}MeV]\n'
+
+        # Loop over energy groups ranges
+        for group in range(1, self.num_groups+1):
+            bounds = self.energy_groups.get_group_bounds(group)
+            string += template.format('', group, bounds[0], bounds[1])
+
+        # Loop over all subdomains
+        for subdomain in subdomains:
+
+            if self.domain_type == 'distribcell':
+                string += \
+                    '{0: <16}=\t{1}\n'.format('\tSubdomain', subdomain)
+
+            # Loop over all Nuclides
+            for nuclide in nuclides:
+
+                # Build header for nuclide type
+                if xs_type != 'sum':
+                    string += '{0: <16}=\t{1}\n'.format('\tNuclide', nuclide)
+
+                # Build header for cross section type
+                if xs_type == 'macro':
+                    string += '{0: <16}\n'.format('\tCross Sections [cm^-1]:')
+                else:
+                    string += '{0: <16}\n'.format('\tCross Sections [barns]:')
+
+                template = '{0: <12}Group {1} -> Group {2}:\t\t'
+
+                # Loop over incoming/outgoing energy groups ranges
+                for in_group in range(1, self.num_groups+1):
+                    for out_group in range(1, self.num_groups+1):
+                        string += template.format('', in_group, out_group)
+                        average = \
+                            self.get_xs([in_group], [out_group],
+                                        [subdomain], [nuclide],
+                                        xs_type=xs_type, value='mean')
+                        rel_err = \
+                            self.get_xs([in_group], [out_group],
+                                        [subdomain], [nuclide],
+                                        xs_type=xs_type, value='rel_err')
+                        average = average.flatten()[0]
+                        rel_err = rel_err.flatten()[0] * 100.
+                        string += '{:1.2e} +/- {:1.2e}%'.format(average, rel_err)
+                        string += '\n'
+                    string += '\n'
+                string += '\n'
+            string += '\n'
+
+        print(string)
+
+
 class NuFissionMatrixXS(MGXS):
     """A fission production matrix multi-group cross section.
 
@@ -3366,12 +3794,8 @@ class NuFissionMatrixXS(MGXS):
                row_column='inout', value='mean', **kwargs):
         r"""Returns an array of multi-group cross sections.
 
-        This method constructs a 2D NumPy array for the requested scattering
+        This method constructs a 2D NumPy array for the requested nu-fission
         matrix data data for one or more energy groups and subdomains.
-
-        NOTE: The scattering moments are not multiplied by the :math:`(2l+1)/2`
-        prefactor in the expansion of the scattering source into Legendre
-        moments in the neutron transport equation.
 
         Parameters
         ----------
@@ -3491,7 +3915,7 @@ class NuFissionMatrixXS(MGXS):
             new_shape += xs.shape[1:]
             xs = np.reshape(xs, new_shape)
 
-            # Transpose the scattering matrix if requested by user
+            # Transpose the matrix if requested by user
             if row_column == 'outin':
                 xs = np.swapaxes(xs, 1, 2)
 

--- a/openmc/mgxs_library.py
+++ b/openmc/mgxs_library.py
@@ -906,7 +906,7 @@ class XSdata(object):
     def set_multiplicity_mgxs(self, nuscatter, scatter=None, nuclide='total',
                               xs_type='macro'):
         """This method allows for either the direct use of only an
-        openmc.mgxs.MultiplicityMatrix OR an openmc.mgxs.NuScatterMatrixXS and
+        openmc.mgxs.MultiplicityMatrixXS OR an openmc.mgxs.NuScatterMatrixXS and
         openmc.mgxs.ScatterMatrixXS to be used to set the scattering
         multiplicity for this XSdata object. Multiplicity,
         in OpenMC parlance, is a factor used to account for the production
@@ -917,7 +917,7 @@ class XSdata(object):
         Parameters
         ----------
         nuscatter: {openmc.mgxs.NuScatterMatrixXS,
-                    openmc.mgxs.MultiplicityMatrix}
+                    openmc.mgxs.MultiplicityMatrixXS}
             MGXS Object containing the matrix cross section for the domain
             of interest.
         scatter: openmc.mgxs.ScatterMatrixXS
@@ -938,15 +938,15 @@ class XSdata(object):
         """
 
         check_type('nuscatter', nuscatter, (openmc.mgxs.NuScatterMatrixXS,
-                                            openmc.mgxs.MultiplicityMatrix))
+                                            openmc.mgxs.MultiplicityMatrixXS))
         check_value('energy_groups', nuscatter.energy_groups,
                     [self.energy_groups])
         check_value('domain_type', nuscatter.domain_type,
                     ['universe', 'cell', 'material'])
         if scatter is not None:
             check_type('scatter', scatter, openmc.mgxs.ScatterMatrixXS)
-            if isinstance(nuscatter, openmc.mgxs.MultiplicityMatrix):
-                msg = 'Either an MultiplicityMatrix object must be passed ' \
+            if isinstance(nuscatter, openmc.mgxs.MultiplicityMatrixXS):
+                msg = 'Either an MultiplicityMatrixXS object must be passed ' \
                       'for "nuscatter" or the "scatter" argument must be ' \
                       'provided.'
                 raise ValueError(msg)
@@ -958,7 +958,7 @@ class XSdata(object):
         if self.representation is 'isotropic':
             nuscatt = nuscatter.get_xs(nuclides=nuclide,
                                        xs_type=xs_type, moment=0)
-            if isinstance(nuscatter, openmc.mgxs.MultiplicityMatrix):
+            if isinstance(nuscatter, openmc.mgxs.MultiplicityMatrixXS):
                 self._multiplicity = nuscatt
             else:
                 scatt = scatter.get_xs(nuclides=nuclide,

--- a/openmc/mgxs_library.py
+++ b/openmc/mgxs_library.py
@@ -525,7 +525,7 @@ class XSdata(object):
     def chi(self, chi):
         if self.use_chi is not None:
             if not self.use_chi:
-                msg = 'Providing chi when nu_fission already provided as a' \
+                msg = 'Providing "chi" when "nu-fission" already provided as a' \
                       'matrix'
                 raise ValueError(msg)
 
@@ -753,7 +753,7 @@ class XSdata(object):
             msg = 'Angular-Dependent MGXS have not yet been implemented'
             raise ValueError(msg)
 
-        if type(nu_fission) is openmc.mgxs.NuFissionMatrixXS:
+        if isinstance(nu_fission, openmc.mgxs.NuFissionMatrixXS):
             self.use_chi = False
         else:
             self.use_chi = True


### PR DESCRIPTION
This mild-mannered PR addresses the bottom two checkboxes in #597: giving the Python API's Library class the ability to generate scattering multiplicity matrices and nu-fission matrices (the latter replacing the combination of nu-fission and chi vectors).
In doing this, I also added in a MatrixMGXS type which becomes the base for all energyin x energyout matrix MGXS types.  This is now the parent of *ScatterMatrixXS, NuFissionMatrixXS, and MultiplicityMatrixXS.

The incorporation of these changes would give us the ability to automagically generate all the isotropically-weighted and Legendre-expanded data types one would need for OpenMC's multi-group mode [adding in angle-dependent MGXS and/or tabular-mu scattering data is a tougher nut to crack].