### PR TITLE
fixed issue with expanded elements into their naturally-occurring isotopes

### DIFF
--- a/openmc/element.py
+++ b/openmc/element.py
@@ -127,7 +127,7 @@ class Element(object):
 
         isotopes = []
         for isotope, abundance in natural_abundance.items():
-            if isotope.startswith(self.name):
+            if isotope.startswith(self.name + '-'):
                 nuc = openmc.Nuclide(isotope, self.xs)
                 isotopes.append((nuc, abundance))
         return isotopes


### PR DESCRIPTION
This PR fixes an issue in `element.py` where elements represented by a single letter (e.g. O, C, B, U etc) will expand to include isotopes of all elements that start with that letter (e.g. O would expand to include O *and* Os isotopes).