### PR TITLE
[HOTFIX] Improved Exact Paramter for StatePoint.get_tally(...)

### DIFF
--- a/openmc/mgxs/mgxs.py
+++ b/openmc/mgxs/mgxs.py
@@ -693,7 +693,7 @@ class MGXS(object):
         for tally_type, tally in self.tallies.items():
             sp_tally = statepoint.get_tally(
                 tally.scores, tally.filters, tally.nuclides,
-                estimator=tally.estimator, exact=True)
+                estimator=tally.estimator, exact_filters=True)
             sp_tally = sp_tally.get_slice(
                 tally.scores, filters, filter_bins, tally.nuclides)
             sp_tally.sparse = self.sparse

--- a/openmc/statepoint.py
+++ b/openmc/statepoint.py
@@ -504,16 +504,6 @@ class StatePoint(object):
         This routine searches the list of Tallies and returns the first Tally
         found which satisfies all of the input parameters.
 
-        If the "exactness" parameter is 0 (default), the input parameters
-        do not need to match the complete Tally specification and may only
-        represent a subset of the Tally's properties. If the "exactness"
-        parameter is 1 then the length of the scores, filters, nuclides
-        parameters must precisely match those of any matching Tally, but the
-        filter bins may represent a subset of those in any matching Tally
-        (useful if tallies are merged in the input). If the "exactness"
-        parameter is 2 then the values of the scores, nuclides and filters
-        parameters must precisely match those of any matching Tally.
-
         NOTE: If any of the "exact" parameters are False (default), the input
         parameters do not need to match the complete Tally specification and
         may only represent a subset of the Tally's properties. If an "exact"

--- a/openmc/statepoint.py
+++ b/openmc/statepoint.py
@@ -497,8 +497,8 @@ class StatePoint(object):
                 self.tallies[tally_id].sparse = self.sparse
 
     def get_tally(self, scores=[], filters=[], nuclides=[],
-                  name=None, id=None, estimator=None, exact_nuclides=False,
-                  exact_filters=False, exact_scores=False):
+                  name=None, id=None, estimator=None, exact_filters=False,
+                  exact_nuclides=False, exact_scores=False):
         """Finds and returns a Tally object with certain properties.
 
         This routine searches the list of Tallies and returns the first Tally

--- a/openmc/statepoint.py
+++ b/openmc/statepoint.py
@@ -497,17 +497,28 @@ class StatePoint(object):
                 self.tallies[tally_id].sparse = self.sparse
 
     def get_tally(self, scores=[], filters=[], nuclides=[],
-                  name=None, id=None, estimator=None, exact=False):
+                  name=None, id=None, estimator=None, exact_nuclides=False,
+                  exact_filters=False, exact_scores=False):
         """Finds and returns a Tally object with certain properties.
 
         This routine searches the list of Tallies and returns the first Tally
         found which satisfies all of the input parameters.
 
-        NOTE: If the "exact" parameter is False (default), the input parameters
+        If the "exactness" parameter is 0 (default), the input parameters
         do not need to match the complete Tally specification and may only
-        represent a subset of the Tally's properties. If the "exact" parameter
-        is True then the scores, filters, nuclides and estimator parameters
-        must precisely match those of any matching Tally.
+        represent a subset of the Tally's properties. If the "exactness"
+        parameter is 1 then the length of the scores, filters, nuclides
+        parameters must precisely match those of any matching Tally, but the
+        filter bins may represent a subset of those in any matching Tally
+        (useful if tallies are merged in the input). If the "exactness"
+        parameter is 2 then the values of the scores, nuclides and filters
+        parameters must precisely match those of any matching Tally.
+
+        NOTE: If any of the "exact" parameters are False (default), the input
+        parameters do not need to match the complete Tally specification and
+        may only represent a subset of the Tally's properties. If an "exact"
+        parameter is True then number of scores, filters, or nuclides in the
+        parameters must precisely match those of any matching Tally.
 
         Parameters
         ----------
@@ -523,9 +534,18 @@ class StatePoint(object):
             The id specified for the Tally (default is None).
         estimator: str, optional
             The type of estimator ('tracklength', 'analog'; default is None).
-        exact : bool
-            Whether to strictly enforce the match between the parameters and
-            the returned tally
+        exact_filters : bool
+            If True, the number of filters in the parameters must be identical
+            to those in the matching Tally. If False (default), the filters in
+            the parameters may be a subset of those in the matching Tally.
+        exact_nuclides : bool
+            If True, the number of nuclides in the parameters must be identical
+            to those in the matching Tally. If False (default), the nuclides in
+            the parameters may be a subset of those in the matching Tally.
+        exact_scores : bool
+            If True, the number of scores in the parameters must be identical
+            to those in the matching Tally. If False (default), the scores
+            in the parameters may be a subset of those in the matching Tally.
 
         Returns
         -------
@@ -554,17 +574,16 @@ class StatePoint(object):
                 continue
 
             # Determine if Tally has queried estimator
-            if (estimator or exact) and estimator != test_tally.estimator:
+            if estimator and estimator != test_tally.estimator:
                 continue
 
             # The number of filters, nuclides and scores must exactly match
-            if exact:
-                if len(scores) != test_tally.num_scores:
-                    continue
-                if len(nuclides) != test_tally.num_nuclides:
-                    continue
-                if len(filters) != test_tally.num_filters:
-                    continue
+            if exact_scores and len(scores) != test_tally.num_scores:
+                continue
+            if exact_nuclides and len(nuclides) != test_tally.num_nuclides:
+                continue
+            if exact_filters and len(filters) != test_tally.num_filters:
+                continue
 
             # Determine if Tally has the queried score(s)
             if scores:

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -762,8 +762,6 @@ class Tally(object):
 
                 # If filters are the second mergeable filters encountered
                 elif filter1.can_merge(filter2) and merge_filters:
-                    merge_filters = True
-                    mergeable_filter = True
                     return False
 
             # If no mergeable filter was found, the tallies are not mergeable

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -762,6 +762,8 @@ class Tally(object):
 
                 # If filters are the second mergeable filters encountered
                 elif filter1.can_merge(filter2) and merge_filters:
+                    merge_filters = True
+                    mergeable_filter = True
                     return False
 
             # If no mergeable filter was found, the tallies are not mergeable


### PR DESCRIPTION
This PR fixes #663 by using finer granularity for the `exact` parameter introduced for `StatePoint.get_tally(...)` in #660. In the case of MGXS, the following rules must be adhered to when loading tallies from a statepoint (whether or not the tallies were merged in the input):

* number of scores need not match (*i.e.*, scores may have been merged)
* number of nuclides need not match (*i.e.*, nuclides may have been merged)
* number of filters must match
* filters may be subsets of one another (*i.e.*, "cell" or "material" filter bins may have been merged)

This PR simply introduces `exact_filters`, `exact_nuclides` and `exact_scores` parameters in place of the single `exact` parameter. In order to meet the rules above, the `MGXS.load_from_statatepoint(...)` method simply sets `exact_filters` to `True`. 

