### PR TITLE
Fix for #655: tally merging not thoroughly merging all tallies which can be merged.

### DIFF
--- a/docs/source/pythonapi/examples/mgxs-part-iv.ipynb
+++ b/docs/source/pythonapi/examples/mgxs-part-iv.ipynb
@@ -433,7 +433,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPoAAAD6AgMAAAD1grKuAAAABGdBTUEAALGPC/xhBQAAACBjSFJN\nAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAADFBMVEX////pgJFyEhJNv8RV\nUZDeAAAAAWJLR0QAiAUdSAAAAAd0SU1FB+AFGBM0Bsv0CskAAAWFSURBVGje7Zs7cttADIZ9CSvX\ncrP0iCxUqbBc8Ag6xR6BhV2EvYvwFD4CCx1ABT1jMdgndpegRQnOrCbjpPlGESISC4A/gd27e8H5\n83CX3b4+iKJrRHkS4vkghMPBonRYWGwtfgD2YN+dRDUOoh6lACw0Noi9w2fESuEoAR/uVuMolX03\n9oXGT7F3eFL2iEfhUX1f4cPdL/ishs+68ai+udE4xPhexbjX2FfjGNoPj/DPNX4Tsd+EODr8FvsV\ndf1Hd9P2VvCi4+s/aXvrf+upAD+1/9GV1mkOH5X9vV6THtfvACslcaUCbESL61drBPtdI8SrFMWr\nELsXCkuFDYW75gbiP7d9Cf7bAYI/aCwUShrBvh30+lWQkzVgZ/HD4OixNCgcQpJ3BxU/Ln91elKo\nM5VEE38QtJ+Yv6cQ9xjKNYayyl8TypP8DfJnQ2H/b/N3ye9P83cT33SQv/sQh9gV7zZ/0dNj5HQa\nC5vVzv9+/WFN2w8KVaZ2BwL1+pv4g0x1QRfjq0dB4Q3kT277oP6VNL6gKxNU9a8zK+WLbi/Wwpdi\nhbboKqyxFOulHMj6v4W/AXbmUeAxrv9J/CqEBXaRKsXaodD4nsYvkT/G6H1D4SR/iPy1Roj9JsQ5\ne18/7EUHv1+Fvx/Xj5V9Ugb5K8TW4TZEEdcvoz/up0VTe9qsVIppKVX6a7D6y9ZvwEKjrtQxPtv6\nfXII9vCxKOGaIeAIfEF8IvAG8ie3vRK9rRQl+PPpSctbhfpTUCpviH+kxsZgpT91+snoX1l49KK3\niUQvICRy5aUw6l8leoVwoo3Uv1rKreF/UFLY6d9QP4L9Wf2r7EP9GOSfcsjZ56f60kz+XmVPXv+R\nuP49ff0T/53Rv6n/7m2lvXT9Wqd/VUz8hvh5M/ED6ILmt4mfHYZSaePnTWpsf/SvqV9O6dLYYClL\nEetnoH/LBLFoBvrX189uTv8++kot5vTvQD4/9jP690g9P/4z/bvo/XVG/xYoZZx+8fr3MxAtsf7t\nUOkG2JqsTtCIpgCt/qX1226KqZS7gfzJbe+c9jLrtIZ8lXD+s4umlW6AKIVrlML2/cXjgPFjlJqI\nRC+Fj0bVJe+vSh56pSdR6YkQ1ygF10Wqf0FeLta/iKn9Mv1L24ti2e+7W4n1b3T/W+L+t9H9T/Sv\nVboUmqJJon1/hZq8LnzRDlDrX1u0xRT1+6vEpomMmyYkqi95vIH8yW1PN+122KkLcNLKi/WTF01z\n/cNASrWE/l3ev6T17zX909z9X27/euK/Rf3zWP+Waf9eEv37KkWJ+rfDl6ZglNDa+cEBhwYDvkoN\nP/rX69814NaI3imq0l7OYDy/qSdDGwr7r+Y3VbzoKZr6XX2lfxfOb87qXzr+b1j/Xlp/nP6dn98M\ncdH7cn7zjPObKsYWS3Eb9w8n85smHtqQuPuZ30T2dlIT6F9xFl+n8xslegL9a4c2KRr9W4rp/GYq\numiM9Nec/j2v/yj9u1h//hv9e93vc++f63/u+rPjL3f+5Lbn1j9m/eXWf+7zh/v8+2b9e/Hzn6s/\nuPqHrb8g71n6L3f+5Lbnvn8w33+4718/+5d47//c/gO7/5E7/nPbc/tv3P4fs//I7X9y+6/fqH+v\n6j9z+9/c/ju3/8+eP+TOn9z23PkXc/7Gnf9x5483q38Xzn+582fu/Js9fy8kb/6fO39y23P3n3S8\n/S/c/Tfc/T83uX/pgv1XE/9duP+Lu/+Mvf8td/znti8kb/8ld/9nx9t/Sjw/Ltr/yt1/+337f6/b\nf0zoB3nJ/ucVc/81d/83e/957vzJbc89/8A8f8E9/5HE78XnT/4H/cs5f8Q9/8Q9f8U+/5U7f3Lb\nc88fdrzzjyvm+cuf/Uu887/c88fs88954/8vO4SjPC+2QRIAAAAldEVYdGRhdGU6Y3JlYXRlADIw\nMTYtMDUtMjRUMTk6NTI6MDYtMDQ6MDBj3IIkAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE2LTA1LTI0\nVDE5OjUyOjA2LTA0OjAwEoE6mAAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPoAAAD6AgMAAAD1grKuAAAABGdBTUEAALGPC/xhBQAAACBjSFJN\nAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAADFBMVEX////pgJFyEhJNv8RV\nUZDeAAAAAWJLR0QAiAUdSAAAAAd0SU1FB+AFHg4UNdA1IIIAAAWFSURBVGje7Zs7cttADIZ9CSvX\ncrP0iCxUqbBc8Ag6xR6BhV2EvYvwFD4CCx1ABT1jMdgndpegRQnOrCbjpPlGESISC4A/gd27e8H5\n83CX3b4+iKJrRHkS4vkghMPBonRYWGwtfgD2YN+dRDUOoh6lACw0Noi9w2fESuEoAR/uVuMolX03\n9oXGT7F3eFL2iEfhUX1f4cPdL/ishs+68ai+udE4xPhexbjX2FfjGNoPj/DPNX4Tsd+EODr8FvsV\ndf1Hd9P2VvCi4+s/aXvrf+upAD+1/9GV1mkOH5X9vV6THtfvACslcaUCbESL61drBPtdI8SrFMWr\nELsXCkuFDYW75gbiP7d9Cf7bAYI/aCwUShrBvh30+lWQkzVgZ/HD4OixNCgcQpJ3BxU/Ln91elKo\nM5VEE38QtJ+Yv6cQ9xjKNYayyl8TypP8DfJnQ2H/b/N3ye9P83cT33SQv/sQh9gV7zZ/0dNj5HQa\nC5vVzv9+/WFN2w8KVaZ2BwL1+pv4g0x1QRfjq0dB4Q3kT277oP6VNL6gKxNU9a8zK+WLbi/Wwpdi\nhbboKqyxFOulHMj6v4W/AXbmUeAxrv9J/CqEBXaRKsXaodD4nsYvkT/G6H1D4SR/iPy1Roj9JsQ5\ne18/7EUHv1+Fvx/Xj5V9Ugb5K8TW4TZEEdcvoz/up0VTe9qsVIppKVX6a7D6y9ZvwEKjrtQxPtv6\nfXII9vCxKOGaIeAIfEF8IvAG8ie3vRK9rRQl+PPpSctbhfpTUCpviH+kxsZgpT91+snoX1l49KK3\niUQvICRy5aUw6l8leoVwoo3Uv1rKreF/UFLY6d9QP4L9Wf2r7EP9GOSfcsjZ56f60kz+XmVPXv+R\nuP49ff0T/53Rv6n/7m2lvXT9Wqd/VUz8hvh5M/ED6ILmt4mfHYZSaePnTWpsf/SvqV9O6dLYYClL\nEetnoH/LBLFoBvrX189uTv8++kot5vTvQD4/9jP690g9P/4z/bvo/XVG/xYoZZx+8fr3MxAtsf7t\nUOkG2JqsTtCIpgCt/qX1226KqZS7gfzJbe+c9jLrtIZ8lXD+s4umlW6AKIVrlML2/cXjgPFjlJqI\nRC+Fj0bVJe+vSh56pSdR6YkQ1ygF10Wqf0FeLta/iKn9Mv1L24ti2e+7W4n1b3T/W+L+t9H9T/Sv\nVboUmqJJon1/hZq8LnzRDlDrX1u0xRT1+6vEpomMmyYkqi95vIH8yW1PN+122KkLcNLKi/WTF01z\n/cNASrWE/l3ev6T17zX909z9X27/euK/Rf3zWP+Waf9eEv37KkWJ+rfDl6ZglNDa+cEBhwYDvkoN\nP/rX69814NaI3imq0l7OYDy/qSdDGwr7r+Y3VbzoKZr6XX2lfxfOb87qXzr+b1j/Xlp/nP6dn98M\ncdH7cn7zjPObKsYWS3Eb9w8n85smHtqQuPuZ30T2dlIT6F9xFl+n8xslegL9a4c2KRr9W4rp/GYq\numiM9Nec/j2v/yj9u1h//hv9e93vc++f63/u+rPjL3f+5Lbn1j9m/eXWf+7zh/v8+2b9e/Hzn6s/\nuPqHrb8g71n6L3f+5Lbnvn8w33+4718/+5d47//c/gO7/5E7/nPbc/tv3P4fs//I7X9y+6/fqH+v\n6j9z+9/c/ju3/8+eP+TOn9z23PkXc/7Gnf9x5483q38Xzn+582fu/Js9fy8kb/6fO39y23P3n3S8\n/S/c/Tfc/T83uX/pgv1XE/9duP+Lu/+Mvf8td/znti8kb/8ld/9nx9t/Sjw/Ltr/yt1/+337f6/b\nf0zoB3nJ/ucVc/81d/83e/957vzJbc89/8A8f8E9/5HE78XnT/4H/cs5f8Q9/8Q9f8U+/5U7f3Lb\nc88fdrzzjyvm+cuf/Uu887/c88fs88954/8vO4SjPC+2QRIAAAAldEVYdGRhdGU6Y3JlYXRlADIw\nMTYtMDUtMzBUMTQ6MjA6NTMtMDQ6MDBAcYHjAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE2LTA1LTMw\nVDE0OjIwOjUzLTA0OjAwMSw5XwAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<IPython.core.display.Image object>"
       ]
@@ -723,8 +723,8 @@
       "      Copyright:      2011-2016 Massachusetts Institute of Technology\n",
       "      License:        http://openmc.readthedocs.io/en/latest/license.html\n",
       "      Version:        0.7.1\n",
-      "      Git SHA1:       b7cc8a3a1460a9662fd3e8d11a6c0cf5902946c2\n",
-      "      Date/Time:      2016-05-24 19:52:06\n",
+      "      Git SHA1:       d20322f22d4850bd640b4accf34e2551550d17fb\n",
+      "      Date/Time:      2016-05-30 14:20:53\n",
       "      OpenMP Threads: 4\n",
       "\n",
       " ===========================================================================\n",
@@ -811,20 +811,20 @@
       "\n",
       " =======================>     TIMING STATISTICS     <=======================\n",
       "\n",
-      " Total time for initialization     =  1.4330E+00 seconds\n",
-      "   Reading cross sections          =  1.1310E+00 seconds\n",
-      " Total time in simulation          =  1.8040E+01 seconds\n",
-      "   Time in transport only          =  1.7983E+01 seconds\n",
-      "   Time in inactive batches        =  2.0740E+00 seconds\n",
-      "   Time in active batches          =  1.5966E+01 seconds\n",
-      "   Time synchronizing fission bank =  8.0000E-03 seconds\n",
-      "     Sampling source sites         =  5.0000E-03 seconds\n",
-      "     SEND/RECV source sites        =  3.0000E-03 seconds\n",
+      " Total time for initialization     =  1.4260E+00 seconds\n",
+      "   Reading cross sections          =  1.1340E+00 seconds\n",
+      " Total time in simulation          =  1.6739E+01 seconds\n",
+      "   Time in transport only          =  1.6650E+01 seconds\n",
+      "   Time in inactive batches        =  2.1540E+00 seconds\n",
+      "   Time in active batches          =  1.4585E+01 seconds\n",
+      "   Time synchronizing fission bank =  1.0000E-02 seconds\n",
+      "     Sampling source sites         =  9.0000E-03 seconds\n",
+      "     SEND/RECV source sites        =  1.0000E-03 seconds\n",
       "   Time accumulating tallies       =  0.0000E+00 seconds\n",
       " Total time for finalization       =  0.0000E+00 seconds\n",
-      " Total time elapsed                =  1.9482E+01 seconds\n",
-      " Calculation Rate (inactive)       =  24108.0 neutrons/second\n",
-      " Calculation Rate (active)         =  12526.6 neutrons/second\n",
+      " Total time elapsed                =  1.8174E+01 seconds\n",
+      " Calculation Rate (inactive)       =  23212.6 neutrons/second\n",
+      " Calculation Rate (active)         =  13712.7 neutrons/second\n",
       "\n",
       " ============================>     RESULTS     <============================\n",
       "\n",
@@ -967,11 +967,11 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/nelsonag/git/openmc/openmc/tallies.py:1988: RuntimeWarning: invalid value encountered in true_divide\n",
+      "/home/nelsonag/git/openmc/openmc/tallies.py:1986: RuntimeWarning: invalid value encountered in true_divide\n",
       "  self_rel_err = data['self']['std. dev.'] / data['self']['mean']\n",
-      "/home/nelsonag/git/openmc/openmc/tallies.py:1989: RuntimeWarning: invalid value encountered in true_divide\n",
+      "/home/nelsonag/git/openmc/openmc/tallies.py:1987: RuntimeWarning: invalid value encountered in true_divide\n",
       "  other_rel_err = data['other']['std. dev.'] / data['other']['mean']\n",
-      "/home/nelsonag/git/openmc/openmc/tallies.py:1990: RuntimeWarning: invalid value encountered in true_divide\n",
+      "/home/nelsonag/git/openmc/openmc/tallies.py:1988: RuntimeWarning: invalid value encountered in true_divide\n",
       "  new_tally._mean = data['self']['mean'] / data['other']['mean']\n"
      ]
     }
@@ -1099,8 +1099,8 @@
       "      Copyright:      2011-2016 Massachusetts Institute of Technology\n",
       "      License:        http://openmc.readthedocs.io/en/latest/license.html\n",
       "      Version:        0.7.1\n",
-      "      Git SHA1:       b7cc8a3a1460a9662fd3e8d11a6c0cf5902946c2\n",
-      "      Date/Time:      2016-05-24 19:52:26\n",
+      "      Git SHA1:       d20322f22d4850bd640b4accf34e2551550d17fb\n",
+      "      Date/Time:      2016-05-30 14:21:12\n",
       "      OpenMP Threads: 4\n",
       "\n",
       " ===========================================================================\n",
@@ -1184,20 +1184,20 @@
       "\n",
       " =======================>     TIMING STATISTICS     <=======================\n",
       "\n",
-      " Total time for initialization     =  3.6000E-02 seconds\n",
-      "   Reading cross sections          =  7.0000E-03 seconds\n",
-      " Total time in simulation          =  1.4412E+01 seconds\n",
-      "   Time in transport only          =  1.4376E+01 seconds\n",
-      "   Time in inactive batches        =  1.2750E+00 seconds\n",
-      "   Time in active batches          =  1.3137E+01 seconds\n",
-      "   Time synchronizing fission bank =  1.0000E-02 seconds\n",
-      "     Sampling source sites         =  7.0000E-03 seconds\n",
-      "     SEND/RECV source sites        =  3.0000E-03 seconds\n",
+      " Total time for initialization     =  2.8000E-02 seconds\n",
+      "   Reading cross sections          =  4.0000E-03 seconds\n",
+      " Total time in simulation          =  1.2816E+01 seconds\n",
+      "   Time in transport only          =  1.2770E+01 seconds\n",
+      "   Time in inactive batches        =  1.3130E+00 seconds\n",
+      "   Time in active batches          =  1.1503E+01 seconds\n",
+      "   Time synchronizing fission bank =  9.0000E-03 seconds\n",
+      "     Sampling source sites         =  3.0000E-03 seconds\n",
+      "     SEND/RECV source sites        =  6.0000E-03 seconds\n",
       "   Time accumulating tallies       =  0.0000E+00 seconds\n",
       " Total time for finalization       =  0.0000E+00 seconds\n",
-      " Total time elapsed                =  1.4458E+01 seconds\n",
-      " Calculation Rate (inactive)       =  39215.7 neutrons/second\n",
-      " Calculation Rate (active)         =  15224.2 neutrons/second\n",
+      " Total time elapsed                =  1.2854E+01 seconds\n",
+      " Calculation Rate (inactive)       =  38080.7 neutrons/second\n",
+      " Calculation Rate (active)         =  17386.8 neutrons/second\n",
       "\n",
       " ============================>     RESULTS     <============================\n",
       "\n",
@@ -1384,7 +1384,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.text.Text at 0x7f83decbba20>"
+       "<matplotlib.text.Text at 0x7fd36d5d20b8>"
       ]
      },
      "execution_count": 40,
@@ -1395,7 +1395,7 @@
      "data": {
       "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXQAAADDCAYAAACS2+oqAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJztnXeYFeX1xz8HUJSmoIJiA8WOokSwm43RtUSjiQ1LbAnq\nzySYaGzR6IrGHns0tih2YzcxidjWXlAUS2woIoiggoqKorDn98fMwmXZe88su5e7O3w/z7PP3jvv\nd9733HfOnHmnnHnN3RFCCNH2aVdpA4QQQrQMCuhCCJETFNCFECInKKALIUROUEAXQoicoIAuhBA5\nodUFdDN7zcy2rrQdizJm9m8z+0Uz1r/czE5sSZsWRcyszsxWK1Ge231FPriAuHv4B+wLjAK+BD4E\n7ge2yLJuUO+1wPDm1lPJv/Q3zASmp39fAi9V2q4Mdp8CfFdg83TgD5W2qwk2TwOeBDZtwvqPAocs\nBDvfB74FejRY/jJQB6ySsZ7ZwGoFftakfQVYDDgZeDPdxhPSfXe7Sm/LRranfLAF/sIRupkdBZwP\nnA70BFYBLgN+Gq27CHG2u3dL/7q6+0Yt3YCZtW/pOoFbC2zu5u7nlaGNluZWd+8GLAvUArdX1pxG\ncWAcsE/9AjPrDyyRlmXFmmnHncAuwP5Ad6AvcBGwU6ONlcfHIuSDLUlwNOlGcuT8eQnN4sCFJCP3\nicAFwGJp2Q9JRgVHAVNSzUFp2VCSI923JEe7e9Pl44BtCo6GtwEjUs2rwMCCtutIRzDp93lGMWkb\n7wCfAvcAK6TLV03XbdfYkRNYnWRDfQ58DNxS4vcXHTkVtHMAMD6t648F5QYcD4wFPgFuBZZusO4h\n6bq16fIDSEaAnwAn1fcX0Av4GuheUP8P0jbbFxlpXB+NIkr1Rbqtp6RlLwPrNmU7FGzDw4C3ganA\npcHo6PqC7+uQjGKXSb8vDfwztXNq+rl3WnY6MAuYkfrSxenytYGRqf4NYM+C+ncCXk/1E4CjMo7C\nxgF/BJ4vWHYucEJq7yqNjdaAA4EnGvo3GfaVRmzYNvWHFTLYeiwwBviG5DLsOqltn5Hsc7s05hsl\nbP4t8G66Hc7Juj3lg833wWiEvhnQMe2AYpwEDAY2AAakn08qKF8e6Ar0Bn4F/NXMlnL3q4CbSDZ4\nN3fftUj9uwA3A0ulnfPXgrKiox0z2wY4A9gDWAH4gCRghusCpwEPuPvSwErAJSW0WdgCWINkJzvZ\nzNZKlx9JcqazFUn/fEZy9lPI1iQbfHszW4fk9+9D8puWStfD3aeQ7AR7Fay7H4nzz26G7Y32hZlV\nA1sC/dKyvUkcch4ybAeAn5AcfDYE9krrLomZLU4STKaS9BskwejvwMokZ5IzSP3F3U8CngB+k/rb\nMDPrRLIj3Ugy2toHuCztZ4CrgaGejMb6A49EdhXwLNDVzNYys3Yk2+VG4lH3fH7ZhH2lkB8Dz7n7\nRxm0Q4AdSYJRO+A+4L/AcsAw4CYzW6MJNu8GDEz/djWzQzLYUAr5YEYfjAL6MsCn7l5XQrMvcKq7\nT3X3qcCpQOHNjO+A09x9trv/B/gKWKuReorxpLs/4Mnh6gaSA0c9pXaOfYFr3H2Mu39PMjrazMxW\nydDm98CqZraiu3/n7k8H+mPMbJqZfZb+v7agzIGatJ5XSEZCA9KyQ4ET3f2j1MbhwB5pAKhf9xR3\n/8bdZ5I45H3u/oy7zyK5PlrI9aR9n9axD0mfFWPvBnYv34S++J7kQL2umZm7v5UeVBqSZTuc6e5f\nuvsEkoPShpHNJDvKL4E96v3T3ae5+93uPtPdvwbOJDkgFmNnYJy7X+8JL5NcptgjLf8OWM/Murr7\nF2l5U7iBZIffjuQ69qQmrt8clgUm138xs+7pdv7czL5poL3I3SelPrYp0Nndz3b3We7+KPAvCi4f\nZeCstL8mkpy9l1pXPtiCPhgF9KnAsgUBpjF6kxzx6hmfLptTR4MDwgygS9BuIZMLPs8AlgjsKbRr\nfP2XtHOnAitmWPcYkr553sxeNbODAczsBDP70symm1nhSPpcd+/h7t3T/wc3qK/QyQp//6rA3akj\nTwP+R+KkvQr0Exv8pgkFv+kb5h2R3AusY2Z9gGrgc3d/ocTvvK2B3ZMb0TTaF+mOfinJ6GOymf3N\nzBrbrlm2Q7H+KWozyf2c14CN6wvMbEkzu8LM3jezz4HHgKXNrNiBf1Vg0/r+N7PPSHb++v7fnWTk\nNt7MHjWzTUvY1Rg3pvUdRHKwLRupX9b75kokfbxCfbm7f+bu3UlGoYs3WL2oj6WMJ9t+01h9DeNB\nQ+SDLeiDUWB8huS63W4lNB+mRhUamHUk0pQbRI0xA+hU8L3w6D6p0C4z60xyxjGR5NoixdZ194/d\n/VB3XxE4nOQUaDV3P9Pn3rw5opm2Q3Ig3DF15Hqn7tzgNLmwjz4iOeWs/01Lpr+p3u6ZwD9IboLt\nT+nReSaK9UVadqm7bwysR3LWdUwjVZTaDs2xa1pqT42Z1Tv/0SSXtgalp+D1I6P6namhv00guTdR\n2P/d3P03aRsvuvtuJJce7iXp26bY+AHJNeodgbsakXxNcf+dr7qgra4FvjkReBgYZGaNBdOGwaWw\n7kkklwsKWYVkP89qc+H6q9DMMxP5YHYfLBnQ3X06yU2Av5rZrunRp4OZ7WhmZ6WyW4GTzGxZM1sW\n+BPZA8kUkps+TaHQGV8C9jWzdma2A8lN2HpuBg42sw3MrCPJNbRn3X2Cu39K4qD7p+seQnLjJWnA\nbA8zqz96f05y02RBr0OXuix0BXBG/amfmS1nZoVPDzVc9w5gFzPb1MwWI7m81ZAbSEaEu5CMEJtF\nsb4ws43NbLCZdSC5mfYtjfdR0e3QXNvc/S2Sa73HpYu6prZMN7MeQE2DVRr627+ANc1s/9SvF0t/\n19rp533NrJsn9yC+JLmh1VQOIblx2fAyByQ38X6e7lf9SE7fi9GkfcXdHyS5dHBPup0WS7fVZpQ+\nODwHfG1mx6Z9UkVyWeCWJth8jJktbWYrk9wnani9uknIB7P7YHjpwt0vIHlK5SSSO7cfAEcw90bp\n6cALQP314ReAP5eqsuDzNSTXh6aZ2V2NlEfr/47kpuJnJNfp7i6w+xGSg8tdJMG7L8nNn3qGktzd\n/5TkTvVTBWWDgOfMbHr6O4e5+3iKc2x6qjs9Pe39uIi9Db9fRHLUHWlmXwBPk9xUbnRdd/8fyRME\nt5GMOr4g2SYzCzRPkzj86HSEuCAUtlusL7oBV5E8izuOpB/ne+Qsw3Yo1T9ZOA8Ymg4mLiQZPX5K\n0pf/bqC9CNjTzKaa2YXu/hXJpakhJP05CTiLuZckfgGMS0+dDyW5yZyFOb/B3ce5++jGykie0Pie\n5LLitcx/AG7uvvJzkoBxI8k+8h7JfrJ9kTZIrzH/lOTpik9JLmn8wt3fyWgzJD79IjCa5EGGvwd2\nNoZ8MKFJPmjuzb3qISpFeur4Ocld/vEFyx8GbnL3BdmRhFhgzKyOxB/fq7QtiyKtLvVflMbMdk5P\ndzsDfwFeaRDMBwEbkYzihRCLEArobY9dSU7LJpJc959z6mhm15E803pkeidfiIWNTvkriC65CCFE\nTtAIXQghckKHclSaPkJ4IckB4xp3P7sRjU4NRFlx9+a+3Go+5NuiNVDMt1v8koslWZxvk7xLYhLJ\na3eHuPubDXTOcQVtP1kDW9bMW9mIDA1ekEGTJWn51QyaFxr01T01sFvNvMsOjnMVLqg7PdT8/u2/\nlSy/eM2hYR3DHrlq/oUjauDAmjlfV/rxO/NrGvDynDcVFOdqfhVqvqNjqLnCD5tv2fSai+lWM2zO\n9w+fL/VakZRNrcUDepN8+/iC5OgnamCrmjlf+57xv7Ctce+uGxs0OcPPezjev7v84ZP5ls3887l0\nPHFujs7/dbo8rOfcYQ3fRDE/Ay55NtT099dCzU1HNOJvo2pgUM2cr49ftvH8mgZs/ZdSidQpx8R9\nuHXdyFDz+AM7zLvgxhrYv2beZTuWrqO6GkaOLO7b5bjkMhh4x93Hp8+03kpyI0+Ito58W7RqyhHQ\nV2Ted0FMpGnvgRCitSLfFq2aclxDb+xUoPFzlidr5n7uuHQZTCkza1dV2oKmM6Cq0hY0mY5Vm8Si\nF2thdG25Tcnu20/UzP3cBn27/VabV9qEptO7qtIWNI0NqjIKa9M/GDu2tLIcAX0iyQt56lmJYi/n\naXjNvK3RFgP6hlWVtqDJZAroP6hK/uq5prHX3DSb7L5dcM28LdJh6y0qbULTWbGq0hY0jcwBvSr9\ng3794L33ivt2OS65jAL6mdmqlrwAfgjJC/OFaOvIt0WrpsVH6O4+28x+Q5KxWP9o1xst3Y4QCxv5\ntmjtlOU5dHf/L02blUiINoF8W7RmKpb6b2ZOn6DtbWPb7LQZocYv7RRqZg+JJzxfYvnPQ03XpaeH\nmk06PBdq1gkGfhd9fGRYx5E9Lwo1VfZoqHmHNUPNmHlmBmycZ9gs1HxO91CzQoZpMl9pt1lZEouy\nkCQWlZq1MfZZ7LNYs1v8gM1md8bToJ5EnBfxk5PjerocN//z7A2p7hw/r33X9fFbik854PhQ04f3\nQ83hX8TP18/8TeyT/CiWXHRwnDtyZPuVSpZXV6/OyJEHLNTn0IUQQlQABXQhhMgJCuhCCJETFNCF\nECInKKALIUROUEAXQoicoIAuhBA5QQFdCCFyQlkyRTNzblA+M67isJ6lJ4IA6HXGH0KNdY1zUGYe\n2zXUVPF0qOntjb/PqZDzOLFk+Vo9Dwjr6E88UcBmPjrUPMtGoeb358fb4a6jg7f3A+dwbKjZ2f4V\nal4JFWXmlyXKrolXf3x2/Jr1frwbano9Fye62SazQ83sp+PEu5073R5q7iBOGhp1QJyk9iXdQs02\nPBlqNlmqb6j58IY4geuWDLPoXMWhoYZNBpUuXxsYWXzf1whdCCFyggK6EELkBAV0IYTICQroQgiR\nExTQhRAiJyigCyFETlBAF0KInFDZ59D7BOVd4iou/eyYUNNudqnJBlKujI9tH9Ej1CxvF4Sa3f3O\nUOOPlJ7A4vkfx5NX7O53hBoGx88Xb7JUXA0Pxn38s6vjPv7rr44INXeyewaD/pJBUz6GXnlx0bKr\nZg4L1+/EN6FmeTJMgtEr7vNhnBNq9n5ow1Bzhp0Qai71/4SaXtYn1Nzue4aabT6MfXutiaGEtTcZ\nF7f1VtxW+8/j5/3ZMMiHWb10sUboQgiRExTQhRAiJyigCyFETlBAF0KInKCALoQQOUEBXQghcoIC\nuhBC5AQFdCGEyAnm7pVp2MxH1a1bUjPowxfCeuq+6RRqBq3+WKh54fEfhhqfEUpgQAbNIxk0QY7G\nERPjxJm3vV+o2aZdPJHCiY+GEuqeiicIefGPpbc3QHebFmqu5LBQc67V4O6xUWXAzHyduuK+O3Zq\nvF1GLBtPYJLl540Ps/fg+OfjJDU6x5Kj1vtzqDn/8dITtwAM3zpOFjx5XDQ7DvBsLBmxf6w5sDqD\nG10Sx9Hr+u0dak7jTyXLt6Iz17frW9S3NUIXQoicoIAuhBA5QQFdCCFyggK6EELkBAV0IYTICQro\nQgiRExTQhRAiJyigCyFETijLjEVm9j7wBVAHfO/ugxvTDbFbS9Yzunc8SwoWz5QzmPNDzTc/iJMH\nluiSYcaRF+Nj5C37xck8++x/d8nyr/yqsI4HP94t1Fhd3H9+T/ybnjpho1CzJXGiGI/FbW3yw+fi\nespEVt9+o33x2a3s7XgqriHL3BMb80ncV/5VhqSYwbEP2MtxW3957qS4ra3jtk7O8Ltu7BPPWrV/\n39tDzYHfZhjTxpOQQb/4d43n+FAzbs3SyXdrbFl6/XJNQVcHVLl7hjmyhGhTyLdFq6Vcl1ysjHUL\nUUnk26LVUi7HdOABMxtlZkPL1IYQlUC+LVot5brksrm7Tzaz5YAHzewNd3+yTG0JsTCRb4tWS1kC\nurtPTv9/YmZ3A4OB+Zx+Ws1lcz4vWTWIJasGlcMcsQjwWu1UXq+N39TYXLL6Nn5hwZdNwTYtu20i\np8yohW9qARj7Umlpiwd0M+sEtHP3r8ysM1ANnNqYtkfNES3dvFhE6V+1DP2rlpnz/fZTx7Z4G03x\nbex3Ld6+WETpVJX8Af02gvfGDC8qLccIvRdwt5l5Wv9N7j6yDO0IsbCRb4tWTYsHdHcfB2R4gFyI\ntoV8W7R2Kjpj0dW+T0nNMkwN6/mP7xhqetqUULOv3xJqXvCNQ80v3roz1HjHUMKYfqUTQmrr4gcs\nOvq3oebwY26IjamOfWT57caFmsnPrRa31TFuq93bcRIHQ9pVdMaiPWdfV7T89svj2YhmT2gfao48\n88xQM5kVQs1t4w4KNU/3jY9jHYgT7wa/+WqomdU79oG1ur0eat67qH+osfXjtrx3KOHttVYONWs/\nMT6u6JnSLlvdF0YOMc1YJIQQeUcBXQghcoICuhBC5AQFdCGEyAkK6EIIkRMU0IUQIicooAshRE5Q\nQBdCiJxQ0cQiu7V0IsKs9eJE1s36PxJq7iGeuee3XBJqdueOUNPVvww12379aKjp+PvS5XdfFSdU\nrcSEULO0fx5qXmRgqNmqkfdTzWfPyvHLs3y/UMIuZ/0j1Nzfbq+KJhbt7LcVLf/aO4V1rMikUPOl\nxTMfLZshOe9sPzbUjLJGJ2aah/7+WqihfewDK2bIvxmz8hqhprd/FNfDgFCzJDNCzRbvB2/NAtbs\n83KoGft6aXuqu8DIvkosEkKI3KOALoQQOUEBXQghcoICuhBC5AQFdCGEyAkK6EIIkRMU0IUQIico\noAshRE6oaGLRkLprSmp28n+H9exvt8eNXRwft54ftn6oGcyYuK0RcVu3H7BzqNnT7isteDBu57vB\ncV7N4kvFs8ywSdyW/zNuy3pmaGtc3Nabq60aata18RVNLLLziv/WWRvGCXO2TdxX5/PrUHPMXy4N\nNbOPztBNf4q3y6GnXRRqruS3oeb59nFbHWfHiUUDeCvU3MEuoWb3P8VxyE6Lt1e7v4cS9jzk+pLl\nA+jNSe2qlVgkhBB5RwFdCCFyggK6EELkBAV0IYTICQroQgiRExTQhRAiJyigCyFETlBAF0KInBBn\nOJSRt610csD6tnJYxz5114WaW34W2zKdbqHGT20fasaeslJsD/uEmj36lW7rvLFxUslavB1qtqBz\nqLn/uT1DzQyWDDXtOSDU9O27RaiZRO9QAxmmvSkj+x5VPGmuw82zwvXHECfOjLTzQs09R1eHmo38\ntFDz/knxDEp8F0s+XezmUHPXZXE9kzLMxMR68f66x5FxYuX9w38U29M+buuO2TuEmods25LlXSk9\nS5VG6EIIkRMU0IUQIicooAshRE5QQBdCiJyggC6EEDlBAV0IIXKCAroQQuQEBXQhhMgJCzxjkZld\nA+wMTHH3DdJl3YHbgFWB94G93P2LIuv7T+tKJxn88/G9QztmrRLnRp3S57hQs7f9I9S866uHmo+t\nZ6hZzd8LNT++4pmS5XWbhlVw7IDhoea0r08ONUu8Gbd16w9+GmqG7BjMwgS899/lQ83u3BVqxtjm\nCzxjUUv4Nl3rijdwS2xD9U73hpqRN+8aapbYeVrcVreRoea+9+J9ccvVHgo1D3+xfahZ7PRQwvXn\nxsluXdrFs5ntfmzclm8da16JJyHj6bo4se7wA0rPWMT61bQ7bmRZZiy6Fmi4dY4HHnL3tYBHgBOa\nUb8QlUK+LdokCxzQ3f1J4LMGi3cFRqSfRwC7LWj9QlQK+bZoq7T0NfSe7j4FwN0nA8u1cP1CVAr5\ntmj16KaoEELkhJZ+2+IUM+vl7lPMbHng41LiN2vumPN52ap1WbZq3RY2RywqfFU7mq9qR5eziSb5\nNjNr5n5uXwUdqspomsgztZOhdkr6ZfLYktrmBnRL/+q5DzgIOBs4ECh5q37tmj2a2bwQCV2qBtKl\nauCc71NO/Xtzq2yWb9OxprntCwFA1fLJHwDr92P4Q8WfklvgSy5mdjPwNLCmmX1gZgcDZwHbmdlb\nwLbpdyHaFPJt0VZZ4BG6u+9bpKj0G9qFaOXIt0VbZYETi5rdsJk/VLdZSc2Pbn82rmfP2aHGb4pP\nRI7e78+h5vwMjx5Ptu6h5lvvGGr6MLlkuW0V/6a6w+K8Gts/7j+7I0Nb37ZMW3wSt/VIz9J+A7Ct\nPbPAiUXNxcwcu7Jo+bmzXg7rONouDTU3EifX7HdjnISVZbt8/0W8XTo8l8EHquO2pi0et/Xpd/Fs\nZmtmmLXKHovb8qcyuNEfM/j2xXFb9nAg2KgaG16exCIhhBCtCAV0IYTICQroQgiRExTQhRAiJyig\nCyFETlBAF0KInKCALoQQOUEBXQghckJLv5yrSWz37ydLlh+7ZzzjzhkXtQ81NxwZJ2Csbu+GmvHe\nK9R0ILZnrK0Rah7zISXLt3siTmBa7ouGr/Sen7fpF2p67xEnQnXfb2aoqdsp7pvvOocSaqiJRfPN\nT7GQ8V8VLbrSxoSrH3tFnPB39WGLhZoZGV6XNKl9vF3WeDquZ/iOsc0nPxy31WOruK0eB04INR9e\nt2yoWWl63Bb949/1SoY+3ODBuCk7vsRMV0C1Q6lxuEboQgiRExTQhRAiJyigCyFETlBAF0KInKCA\nLoQQOUEBXQghcoICuhBC5AQFdCGEyAkVTSzyJ0vPBPLUTzYP69ht2C2h5l72CjVDiWeImWI9Q83h\nfkWo2XbcU6GGF0sXT9tjibCKV3vEzQzsW3zC2Xr81gwzttxUOiEC4Eb2DjUDiGfzyaIpnbK2EOhf\nvOgIuzxcfeSh1aHmYG4ONSM63xpqDown4uLATf4WaobOin3fJr4Uavy42J6x260Yavpd/mHc1toZ\nfHubeDaimbM3CDU/5U9xW0cH9vQD/lW8WCN0IYTICQroQgiRExTQhRAiJyigCyFETlBAF0KInKCA\nLoQQOUEBXQghcoICuhBC5ISKJhaxSemH6J88dbuwCts1nk3E741nE/n1yfEsQhvyZqj5P+Lko8vf\nODrUsEfpZIYeO8TH4u7LZUiaGBsnTdiDcVvtx8TbYdiAjULNwf+LE2EOX++CUFNxbi/e979/OU7S\nsfvj/nzkhC1CzQFXZ/CBg2MfuO7ieB+6YNjhoWbLlYOMOcAejv1t9VUmhRomxMluNi5uq26b+Lcf\n9OioUFPtI0MN0cRpwYxeGqELIUROUEAXQoicoIAuhBA5QQFdCCFyggK6EELkBAV0IYTICQroQgiR\nExTQhRAiJ5h7nMDQ6Ipm1wA7A1PcfYN02SnAUODjVPZHd/9vkfWdHUs/+H/A/XECxl1f7x5qftc5\nTkR51dYPNdvUPRq39VI8a8sDA7cONevxesnyERwY1vEz7g41q3w9IdRc2PnIUHPiyPNDzYDtnw01\nPXxqqBlTt2GomdZhZdw9Q1bN/LSIb29aYr/aMt7n/nzOUaGmm00PNdv7A6Fm9Ulxks4HvZcNNaMY\nHGp2P/DfoebsEcNCzfr+SqjZ6fXaUPNG/z6hZkmfEWr63PlxqBm052OhZrp3K1m+JV24rl2/or7d\nnBH6tcD2jSw/390Hpn+NOrwQrRz5tmiTLHBAd/cngc8aKVqgUZEQrQX5tmirlOMa+q/N7GUzu9rM\nlipD/UJUCvm2aNW09Mu5LgOGu7ub2enA+cAvi6rfqZn7uUcVLFPVwuaIRYXva5/h+8eeKWcTTfPt\nCTVzP3ergqWqymmbyDEzakfxTe0LALzE4iW1LRrQ3f2Tgq9XAf8sucIaNS3ZvFiEWaxqMxar2mzO\n929Pa9k3MjbZt1euadH2xaJLp6pBdKoaBMBGdGHM8EuKapt7ycUouK5oZssXlP0ceK2Z9QtRKeTb\nos2xwCN0M7sZqAKWMbMPgFOAH5nZhkAd8D5wWAvYKMRCRb4t2ioLHNDdfd9GFl/bDFuEaBXIt0Vb\nZYETi5rdsJkfWXdGSc32FidFXOsHh5p3WS3UjD5ny1CTYcIimJXhybYMsyxxZ6C5bXhYxQ/qtgk1\nl3icxLH5yS+FGr6PJZyT4XevnmWWpYcyNFa9wIlFzcXMnA4lfmu/DJXckaGvMgzH9lprRKh5wmPf\nP8yuDDVZunv4/WeGmu12vi/U/IIbQs0M7xRqDn887p+Tf3hCqPm7HxLXQ7zPDr3rxpLl1T1h5Nbt\nypJYJIQQohWhgC6EEDlBAV0IIXKCAroQQuSEVhPQJ9a+V2kTms5HtZW2oMl8WZvhBmdrY0ZtpS1o\nHnW1lbagycysfa7SJjSZN2o/iUWtiLdqp7R4nQrozWFybaUtaDJf1r5caROazje1lbageXhtpS1o\nMt8poJedXAd0IYQQzaOlX87VJFZibjZ1N7rM8z1ZtmZYR196hJrF6BIb0yuW8M28XyeNg96rNtDM\nzlDP0hk0fYPygSuEVazdyO/+jsXnWd6ZdcJ6BvYOJTArg2ZgBs1K8y+a9Cb0XrtgQbeuYTWjR2do\nq4wM3Gju50kfQu8VCwpXzlDBEhk07WNJX5YJNZ/Tcb5lY2lPv4LlK7DifJqGeIa3Cw/M8I7KfsSi\nHo3klizJR/Ms75ShEwdmCA1Zfnv/RvqwIcvQZ57vS/LBfMsGBrGhXxcYWaK8oolFFWlYLDJUNLFI\niDJSzLcrFtCFEEK0LLqGLoQQOUEBXQghckKrCOhmtoOZvWlmb5vZcZW2Jwtm9r6ZjTGzl8zs+Urb\n0xhmdo2ZTTGzVwqWdTezkWb2lpk90JqmUiti7ylmNtHMRqd/O1TSxqbS1nxbfl0eFpZvVzygm1k7\n4FKSWdbXA/Yxs7VLr9UqqAOq3H0jdx9caWOK0Njs9ccDD7n7WsAjQPwquYVHY/YCnO/uA9O//y5s\noxaUNurb8uvysFB8u+IBHRgMvOPu4939e+BWYNcK25QFo3X0X1GKzF6/K1D/ztARwG4L1agSFLEX\nyPA8XOukLfq2/LoMLCzfbg0bbkVgQsH3iemy1o4DD5jZKDMbWmljmkBPd58C4O6TgeUqbE8Wfm1m\nL5vZ1a3tVDqgLfq2/Hrh0qK+3RoCemNHqLbwLOXm7r4xsBPJRskwQ4ZYAC4DVnf3DYHJwPkVtqcp\ntEXfll/3XIupAAABIElEQVQvPFrct1tDQJ8IrFLwfSVgUoVsyUw6CqifDf5uktPrtsAUM+sFcyY+\n/rjC9pTE3T/xuckSVwGDKmlPE2lzvi2/XniUw7dbQ0AfBfQzs1XNbHFgCBDPQVVBzKyTmXVJP3cG\nqmm9s8DPM3s9Sd8elH4+ELh3YRsUMI+96c5Zz89pvf3cGG3Kt+XXZafsvl3Rd7kAuPtsM/sNySsK\n2gHXuPsbFTYrohdwd5ri3QG4yd1LvWKhIhSZvf4s4HYzOwT4ANizchbOSxF7f2RmG5I8ffE+cFjF\nDGwibdC35ddlYmH5tlL/hRAiJ7SGSy5CCCFaAAV0IYTICQroQgiRExTQhRAiJyigCyFETlBAF0KI\nnKCALoQQOUEBXQghcsL/A1cunn39vbPfAAAAAElFTkSuQmCC\n",
       "text/plain": [
-       "<matplotlib.figure.Figure at 0x7f83ded346a0>"
+       "<matplotlib.figure.Figure at 0x7fd36d659630>"
       ]
      },
      "metadata": {},

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -827,9 +827,7 @@ class Tally(object):
 
         # Search for each of this tally's scores in the other tally
         for score in self.scores:
-            if score not in other.scores:
-                all_scores_match = False
-            else:
+            if score in other.scores:
                 no_scores_match = False
 
         # Search for each of the other tally's scores in this tally
@@ -3471,7 +3469,8 @@ class Tallies(cv.CheckedList):
 
         """
         if not isinstance(tally, Tally):
-            msg = 'Unable to add a non-Tally "{0}" to the Tallies instance'.format(tally)
+            msg = 'Unable to add a non-Tally "{0}" to the ' \
+                  'Tallies instance'.format(tally)
             raise TypeError(msg)
 
         if merge:
@@ -3482,13 +3481,13 @@ class Tallies(cv.CheckedList):
 
                 # If a mergeable tally is found
                 if tally2.can_merge(tally):
-                    # Replace tally 2 with the merged tally
+                    # Replace tally2 with the merged tally
                     merged_tally = tally2.merge(tally)
                     self[i] = merged_tally
                     merged = True
                     break
 
-            # If not mergeable tally was found, simply add this tally
+            # If no mergeable tally was found, simply add this tally
             if not merged:
                 super(Tallies, self).append(tally)
 


### PR DESCRIPTION
I first noticed this problem when creating the `mgxs-part-iv` notebook.  In that case, the tallies were not being merged thoroughly, resulting in many more tallies being present than actually needed.  

The problem was that `tallies._can_merge_scores()` only thought a score was merge-able if either no scores conflicted or if all scores were the same.  However, there is nothing wrong with having only one of many scores overlap.  I fixed this.

I also updated the `mgxs-part-iv` notebook and found that the runtimes didn't change drastically, indicating to me that the mesh tally is dominating the total tally penalty.  Therefore the other mgxs example notebooks don't require similar updating.