### PR TITLE
Throw ImportError if user has h5py 2.6.0

### DIFF
--- a/openmc/particle_restart.py
+++ b/openmc/particle_restart.py
@@ -37,6 +37,11 @@ class Particle(object):
 
     def __init__(self, filename):
         import h5py
+        if h5py.__version__ == '2.6.0':
+            raise ImportError("h5py 2.6.0 has a known bug which makes it "
+                              "incompatible with OpenMC's HDF5 files. "
+                              "Please switch to a different version.")
+
         self._f = h5py.File(filename, 'r')
 
         # Ensure filetype and revision are correct

--- a/openmc/statepoint.py
+++ b/openmc/statepoint.py
@@ -106,6 +106,11 @@ class StatePoint(object):
 
     def __init__(self, filename, autolink=True):
         import h5py
+        if h5py.__version__ == '2.6.0':
+            raise ImportError("h5py 2.6.0 has a known bug which makes it "
+                              "incompatible with OpenMC's HDF5 files. "
+                              "Please switch to a different version.")
+
         self._f = h5py.File(filename, 'r')
 
         # Ensure filetype and revision are correct

--- a/openmc/summary.py
+++ b/openmc/summary.py
@@ -26,6 +26,10 @@ class Summary(object):
         # Python API so we'll only try to import h5py if the user actually inits
         # a Summary object.
         import h5py
+        if h5py.__version__ == '2.6.0':
+            raise ImportError("h5py 2.6.0 has a known bug which makes it "
+                              "incompatible with OpenMC's HDF5 files. "
+                              "Please switch to a different version.")
 
         openmc.reset_auto_ids()
 

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -314,6 +314,10 @@ class Tally(object):
 
         if not self._results_read:
             import h5py
+            if h5py.__version__ == '2.6.0':
+                raise ImportError("h5py 2.6.0 has a known bug which makes it "
+                                  "incompatible with OpenMC's HDF5 files. "
+                                  "Please switch to a different version.")
 
             # Open the HDF5 statepoint file
             f = h5py.File(self._sp_filename, 'r')


### PR DESCRIPTION
h5py has a bug in version 2.6.0 that OpenMC does not like one bit. This PR prevents a user from using our Python API if they have h5py 2.6.