### PR TITLE
Update MGXS Library documentation to reflect reality regarding Legendre sampling

### DIFF
--- a/docs/source/usersguide/mgxs_library.rst
+++ b/docs/source/usersguide/mgxs_library.rst
@@ -172,7 +172,7 @@ attributes/sub-elements required to describe the meta-data:
     during the scattering process.  Specifically, the options are to either
     convert the Legendre expansion to a tabular representation or leave it as
     a set of Legendre coefficients.  Converting to a tabular representation will
-    cost memory but is likely to decrease runtime compared to leaving as a
+    cost memory but can allow for a decrease in runtime compared to leaving as a
     set of Legendre coefficients.  This element has the following
     attributes/sub-elements:
 
@@ -181,7 +181,7 @@ attributes/sub-elements required to describe the meta-data:
       tabular format should be performed or not.  A value of "true" means
       the conversion should be performed, "false" means it should not.
 
-      *Default*: "true"
+      *Default*: "false"
 
     :num_points:
       If the conversion is to take place the number of tabular points is


### PR DESCRIPTION
The documentation eroneously states that the default value of the `<enable>` attribute of `<tabular_legendre>` in the MGXS Library is `True`, when its actually `False`.  This fixes the documentation.  I chose to keep it this way since the Tabular representation is slower than I think it should be right now so I'd rather ensure normal use is with the Legendre's for now.