### PR TITLE
When expanding natural elements, make sure order is consistent

### DIFF
--- a/openmc/element.py
+++ b/openmc/element.py
@@ -126,7 +126,7 @@ class Element(object):
         """
 
         isotopes = []
-        for isotope, abundance in natural_abundance.items():
+        for isotope, abundance in sorted(natural_abundance.items()):
             if isotope.startswith(self.name + '-'):
                 nuc = openmc.Nuclide(isotope, self.xs)
                 isotopes.append((nuc, abundance))


### PR DESCRIPTION
This pull request guarantees that the order of isotopes you get when you expand a natural element is always the same. While this might not seem to matter at first glance, it is important if you use an `Element` in your model and then try to get microscopic multi-group cross sections because the order of nuclides in the tallies and the order of nuclide densities that are retrieved when dividing macros by densities to get micros may be different. Put simply, the micros will almost always be wrong (unless you get lucky and the order was the same).

Thanks to Chang-ho Lee at ANL for pointing out this issue.