### PR TITLE
Fix bug relating to microscopic Legendre scattering moments

### DIFF
--- a/openmc/mgxs/mgxs.py
+++ b/openmc/mgxs/mgxs.py
@@ -1517,6 +1517,7 @@ class MGXS(object):
                 densities = self.get_nuclide_densities(nuclides)
             else:
                 densities = self.get_nuclide_densities('sum')
+            densities = np.repeat(densities, len(self.rxn_rate_tally.scores))
             tile_factor = df.shape[0] / len(densities)
             df['mean'] /= np.tile(densities, tile_factor)
             df['std. dev.'] /= np.tile(densities, tile_factor)


### PR DESCRIPTION
When openmc.mgxs is used to calculate microscopic scattering matrix Legendre moments for individual nuclides that are displayed using `get_pandas_dataframe(xs_type='micro')`, nuclide densities are not divided out in the correct order. This stems from the following lines in `MGXS.get_pandas_dataframe`:
```python
        if xs_type == 'micro':
            if self.by_nuclide:
                densities = self.get_nuclide_densities(nuclides)
            else:
                densities = self.get_nuclide_densities('sum')
            tile_factor = df.shape[0] / len(densities)
            df['mean'] /= np.tile(densities, tile_factor)
            df['std. dev.'] /= np.tile(densities, tile_factor)
```
The problem is that each nuclide has multiple scores associated with it. So, for example if you have a material with U-235 and U-238 and you're calculating up to order 2 moments, nuclide densities will be divided as follows because of the use of `np.tile`:

U-235 P0 / N_235
U-235 P1 / N_238
U-235 P2 / N_235
U-238 P0 / N_238
U-238 P1 / N_235
U-238 P2 / N_238

My fix is to simply apply `np.repeat` to the densities based on the length of the reaction rate tally scores. I should also note that `get_xs` and `print_xs` work just fine in this situation.

Thanks to Chang-ho Lee at ANL for the bug report.