### PR TITLE
A few fixes to ensure smooth MCNP6 ACE library conversion

### DIFF
--- a/openmc/data/ace.py
+++ b/openmc/data/ace.py
@@ -282,7 +282,7 @@ class Library(object):
 
         lines = [ace_file.readline() for i in range(13)]
 
-        while len(lines) != 0 and lines[0] != '':
+        while len(lines) != 0 and lines[0].strip() != '':
             # Read name of table, atomic mass ratio, and temperature. If first
             # line is empty, we are at end of file
 

--- a/openmc/data/function.py
+++ b/openmc/data/function.py
@@ -97,7 +97,7 @@ class Tabulated1D(object):
 
             if self.interpolation[k] == 1:
                 # Histogram
-                y[contined] = yi
+                y[contained] = yi
 
             elif self.interpolation[k] == 2:
                 # Linear-linear

--- a/openmc/data/neutron.py
+++ b/openmc/data/neutron.py
@@ -178,7 +178,7 @@ class IncidentNeutron(object):
     @temperature.setter
     def temperature(self, temperature):
         cv.check_type('temperature', temperature, Real)
-        cv.check_greater_than('temperature', temperature, 0.0)
+        cv.check_greater_than('temperature', temperature, 0.0, True)
         self._temperature = temperature
 
     @energy.setter
@@ -448,6 +448,10 @@ class IncidentNeutron(object):
                 # Create summed reaction with appropriate cross section
                 rx = Reaction(mt)
                 mts = data.get_reaction_components(mt)
+                if len(mts) == 0:
+                    warn('Photon production is present for MT={} but no '
+                         'reaction components exist.'.format(mt))
+                    continue
                 rx.xs = Sum([data.reactions[mt_i].xs for mt_i in mts])
 
                 # Determine summed cross section

--- a/openmc/data/thermal.py
+++ b/openmc/data/thermal.py
@@ -16,7 +16,7 @@ from openmc.stats import Discrete, Tabular
 
 _THERMAL_NAMES = {'al': 'c_Al27', 'al27': 'c_Al27',
                   'be': 'c_Be',
-                  'bebeo': 'c_Be_in_BeO', 'be-o': 'c_Be_in_BeO',
+                  'bebeo': 'c_Be_in_BeO', 'be-o': 'c_Be_in_BeO', 'be/o': 'c_Be_in_BeO',
                   'benz': 'c_Benzine',
                   'cah': 'c_Ca_in_CaH2',
                   'dd2o': 'c_D_in_D2O', 'hwtr': 'c_D_in_D2O',
@@ -25,18 +25,18 @@ _THERMAL_NAMES = {'al': 'c_Al27', 'al27': 'c_Al27',
                   'hca': 'c_H_in_CaH2',
                   'hch2': 'c_H_in_CH2', 'poly': 'c_H_in_CH2',
                   'hh2o': 'c_H_in_H2O', 'lwtr': 'c_H_in_H2O',
-                  'hzrh': 'c_H_in_ZrH', 'h-zr': 'c_H_in_ZrH',
+                  'hzrh': 'c_H_in_ZrH', 'h-zr': 'c_H_in_ZrH', 'h/zr': 'c_H_in_ZrH',
                   'lch4': 'c_liquid_CH4', 'lmeth': 'c_liquid_CH4',
                   'mg': 'c_Mg24',
-                  'obeo': 'c_O_in_BeO', 'o-be': 'c_O_in_BeO',
+                  'obeo': 'c_O_in_BeO', 'o-be': 'c_O_in_BeO', 'o/be': 'c_O_in_BeO',
                   'orthod': 'c_ortho_D', 'dortho': 'c_ortho_D',
                   'orthoh': 'c_ortho_H', 'hortho': 'c_ortho_H',
-                  'ouo2': 'c_O_in_UO2', 'o2-u': 'c_O_in_UO2',
+                  'ouo2': 'c_O_in_UO2', 'o2-u': 'c_O_in_UO2', 'o2/u': 'c_O_in_UO2',
                   'parad': 'c_para_D', 'dpara': 'c_para_D',
                   'parah': 'c_para_H', 'hpara': 'c_para_H',
                   'sch4': 'c_solid_CH4', 'smeth': 'c_solid_CH4',
-                  'uuo2': 'c_U_in_UO2', 'u-o2': 'c_U_in_UO2',
-                  'zrzrh': 'c_Zr_in_ZrH', 'zr-h': 'c_Zr_in_ZrH'}
+                  'uuo2': 'c_U_in_UO2', 'u-o2': 'c_U_in_UO2', 'u/o2': 'c_U_in_UO2',
+                  'zrzrh': 'c_Zr_in_ZrH', 'zr-h': 'c_Zr_in_ZrH', 'zr/h': 'c_Zr_in_ZrH'}
 
 
 class CoherentElastic(object):

--- a/openmc/data/thermal.py
+++ b/openmc/data/thermal.py
@@ -16,6 +16,7 @@ from openmc.stats import Discrete, Tabular
 
 _THERMAL_NAMES = {'al': 'c_Al27', 'al27': 'c_Al27',
                   'be': 'c_Be',
+                  'beo': 'c_BeO',
                   'bebeo': 'c_Be_in_BeO', 'be-o': 'c_Be_in_BeO', 'be/o': 'c_Be_in_BeO',
                   'benz': 'c_Benzine',
                   'cah': 'c_Ca_in_CaH2',

--- a/scripts/openmc-ace-to-hdf5
+++ b/scripts/openmc-ace-to-hdf5
@@ -75,8 +75,15 @@ elif args.xsdir is not None:
     else:
         raise IOError("Could not find 'directory' section in MCNP xsdir file")
 
+    # Handle continuation lines indicated by '+' at end of line
+    lines = lines[index + 1:]
+    continue_lines = [i for i, line in enumerate(lines)
+                      if line.strip().endswith('+')]
+    for i in reversed(continue_lines):
+        lines[i] += lines[i].strip()[:-1] + lines.pop(i + 1)
+
     # Create list of ACE libraries
-    for line in lines[index + 1:]:
+    for line in lines:
         words = line.split()
         if len(words) < 3:
             continue
@@ -111,12 +118,12 @@ for filename in ace_libraries:
             # Continuous-energy neutron data
             neutron = openmc.data.IncidentNeutron.from_ace(
                 table, args.metastable)
-            print(neutron.name)
+            print('Converting {} (ACE) to {} (HDF5)'.format(table.name, neutron.name))
 
             # Determine filename
             outfile = os.path.join(args.destination,
                                    neutron.name.replace('.', '_') + '.h5')
-            neutron.export_to_hdf5(outfile)
+            neutron.export_to_hdf5(outfile, 'w')
 
             # Register with library
             library.register_file(outfile)
@@ -124,12 +131,12 @@ for filename in ace_libraries:
         elif table.name.endswith('t'):
             # Thermal scattering data
             thermal = openmc.data.ThermalScattering.from_ace(table)
-            print(thermal.name)
+            print('Converting {} (ACE) to {} (HDF5)'.format(table.name, thermal.name))
 
             # Determine filename
             outfile = os.path.join(args.destination,
                                    thermal.name.replace('.', '_') + '.h5')
-            thermal.export_to_hdf5(outfile)
+            thermal.export_to_hdf5(outfile, 'w')
 
             # Register with library
             library.register_file(outfile, 'thermal')

--- a/scripts/openmc-ace-to-hdf5
+++ b/scripts/openmc-ace-to-hdf5
@@ -64,7 +64,9 @@ if args.xml is not None:
         directory = os.path.dirname(args.xml)
 
     for ace_table in root.findall('ace_table'):
-        ace_libraries.append(os.path.join(directory, ace_table.attrib['path']))
+        path = os.path.join(directory, ace_table.attrib['path'])
+        if path not in ace_libraries:
+            ace_libraries.append(path)
 
 elif args.xsdir is not None:
     # Find 'directory' section
@@ -116,8 +118,12 @@ for filename in ace_libraries:
     for table in lib.tables:
         if table.name.endswith('c'):
             # Continuous-energy neutron data
-            neutron = openmc.data.IncidentNeutron.from_ace(
-                table, args.metastable)
+            try:
+                neutron = openmc.data.IncidentNeutron.from_ace(
+                    table, args.metastable)
+            except Exception as e:
+                print('Failed to convert {}: {}'.format(table.name, e))
+                continue
             print('Converting {} (ACE) to {} (HDF5)'.format(table.name, neutron.name))
 
             # Determine filename


### PR DESCRIPTION
This pull request makes a few changes that I found to be necessary in order to convert MCNP6 cross section libraries.

- Add a few names to our `_THERMAL_NAMES` dictionary so that none are unrecognized.
- Handle continuation lines in xsdir files
- When writing HDF5 files, open it in 'w' mode (overwrite, rather than append which is default). I found this to be necessary for a few of the thermal tables because in the MCNP6 data, they actually have some tables repeated with different names, e.g. h-zr.20t and h/zr.20t appear in the same file with exactly the same data.