### PR TITLE
OpenCG Lattice Names

### DIFF
--- a/openmc/data/thermal.py
+++ b/openmc/data/thermal.py
@@ -59,8 +59,6 @@ def get_thermal_name(name):
             # OK, we give up. Just use the ACE name.
             return 'c_' + name
 
-    return name
-
 
 class CoherentElastic(object):
     r"""Coherent elastic scattering data from a crystalline material

--- a/openmc/data/thermal.py
+++ b/openmc/data/thermal.py
@@ -43,7 +43,9 @@ _THERMAL_NAMES = {'al': 'c_Al27', 'al27': 'c_Al27',
 def get_thermal_name(name):
     """Get proper S(a,b) table name, e.g. 'HH2O' -> 'c_H_in_H2O'"""
 
-    if name.lower() in _THERMAL_NAMES:
+    if name in _THERMAL_NAMES.values():
+        return name
+    elif name.lower() in _THERMAL_NAMES:
         return _THERMAL_NAMES[name.lower()]
     else:
         # Make an educated guess?? This actually works well for
@@ -52,7 +54,7 @@ def get_thermal_name(name):
         matches = get_close_matches(
             name.lower(), _THERMAL_NAMES.keys(), cutoff=0.5)
         if len(matches) > 0:
-            return _THERMAL_NAMES[matches[0]] + '.' + xs
+            return _THERMAL_NAMES[matches[0]]
         else:
             # OK, we give up. Just use the ACE name.
             return 'c_' + name

--- a/openmc/data/thermal.py
+++ b/openmc/data/thermal.py
@@ -40,6 +40,26 @@ _THERMAL_NAMES = {'al': 'c_Al27', 'al27': 'c_Al27',
                   'zrzrh': 'c_Zr_in_ZrH', 'zr-h': 'c_Zr_in_ZrH', 'zr/h': 'c_Zr_in_ZrH'}
 
 
+def get_thermal_name(name):
+    """Get proper S(a,b) table name, e.g. 'HH2O' -> 'c_H_in_H2O'"""
+
+    if name.lower() in _THERMAL_NAMES:
+        return _THERMAL_NAMES[name.lower()]
+    else:
+        # Make an educated guess?? This actually works well for
+        # JEFF-3.2 which stupidly uses names like lw00.32t,
+        # lw01.32t, etc. for different temperatures
+        matches = get_close_matches(
+            name.lower(), _THERMAL_NAMES.keys(), cutoff=0.5)
+        if len(matches) > 0:
+            return _THERMAL_NAMES[matches[0]] + '.' + xs
+        else:
+            # OK, we give up. Just use the ACE name.
+            return 'c_' + name
+
+    return name
+
+
 class CoherentElastic(object):
     r"""Coherent elastic scattering data from a crystalline material
 

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -6,6 +6,7 @@ from xml.etree import ElementTree as ET
 import sys
 
 import openmc
+import openmc.data
 import openmc.checkvalue as cv
 from openmc.clean_xml import sort_xml_elements, clean_xml_indentation
 
@@ -484,7 +485,7 @@ class Material(object):
                   'non-string cross-section identifier "{1}"'.format(self._id, xs)
             raise ValueError(msg)
 
-        self._sab.append((name, xs))
+        self._sab.append((openmc.data.get_thermal_name(name), xs))
 
     def make_isotropic_in_lab(self):
         for nuclide, percent, percent_type in self._nuclides:

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -485,7 +485,13 @@ class Material(object):
                   'non-string cross-section identifier "{1}"'.format(self._id, xs)
             raise ValueError(msg)
 
-        self._sab.append((openmc.data.get_thermal_name(name), xs))
+        new_name = openmc.data.get_thermal_name(name)
+        if new_name != name:
+            msg = 'OpenMC S(a,b) tables follow the GND naming convention. ' \
+                  'Table "{}" is being renamed as "{}".'.format(name, new_name)
+            warnings.warn(msg)
+
+        self._sab.append((new_name, xs))
 
     def make_isotropic_in_lab(self):
         for nuclide, percent, percent_type in self._nuclides:

--- a/openmc/nuclide.py
+++ b/openmc/nuclide.py
@@ -101,7 +101,7 @@ class Nuclide(object):
         check_type('name', name, basestring)
 
         if '-' in name:
-            new_name = name.strip('-', '')
+            new_name = name.replace('-', '')
             msg = 'OpenMC nuclide names follow the GND standard. Nuclide ' \
                   '"{}" is being transformed to "{}".'.format(name, new_name)
             warnings.warn(msg, DeprecationWarning)

--- a/openmc/nuclide.py
+++ b/openmc/nuclide.py
@@ -102,6 +102,10 @@ class Nuclide(object):
 
         if '-' in name:
             new_name = name.replace('-', '')
+            new_name = new_name.replace('Nat', '0')
+            if new_name.endswith('m'):
+                new_name = new_name[:-1] + '_m1'
+
             msg = 'OpenMC nuclides follow the GND naming convention. Nuclide ' \
                   '"{}" is being renamed as "{}".'.format(name, new_name)
             warnings.warn(msg, DeprecationWarning)

--- a/openmc/nuclide.py
+++ b/openmc/nuclide.py
@@ -1,5 +1,6 @@
 from numbers import Integral
 import sys
+import warnings
 
 from openmc.checkvalue import check_type
 
@@ -98,7 +99,14 @@ class Nuclide(object):
     @name.setter
     def name(self, name):
         check_type('name', name, basestring)
-        self._name = name
+
+        if '-' in name:
+            new_name = name.strip('-', '')
+            msg = 'OpenMC nuclide names follow the GND standard. Nuclide ' \
+                  '"{}" is being transformed to "{}".'.format(name, new_name)
+            warnings.warn(msg, DeprecationWarning)
+
+        self._name = name.replace('-', '')
 
     @xs.setter
     def xs(self, xs):

--- a/openmc/nuclide.py
+++ b/openmc/nuclide.py
@@ -102,8 +102,8 @@ class Nuclide(object):
 
         if '-' in name:
             new_name = name.replace('-', '')
-            msg = 'OpenMC nuclide names follow the GND standard. Nuclide ' \
-                  '"{}" is being transformed to "{}".'.format(name, new_name)
+            msg = 'OpenMC nuclides follow the GND naming convention. Nuclide ' \
+                  '"{}" is being renamed as "{}".'.format(name, new_name)
             warnings.warn(msg, DeprecationWarning)
 
         self._name = name.replace('-', '')

--- a/openmc/nuclide.py
+++ b/openmc/nuclide.py
@@ -108,7 +108,7 @@ class Nuclide(object):
 
             msg = 'OpenMC nuclides follow the GND naming convention. Nuclide ' \
                   '"{}" is being renamed as "{}".'.format(name, new_name)
-            warnings.warn(msg, DeprecationWarning)
+            warnings.warn(msg)
 
         self._name = name.replace('-', '')
 

--- a/openmc/nuclide.py
+++ b/openmc/nuclide.py
@@ -99,18 +99,17 @@ class Nuclide(object):
     @name.setter
     def name(self, name):
         check_type('name', name, basestring)
+        self._name = name
 
         if '-' in name:
-            new_name = name.replace('-', '')
-            new_name = new_name.replace('Nat', '0')
-            if new_name.endswith('m'):
-                new_name = new_name[:-1] + '_m1'
+            self._name = name.replace('-', '')
+            self._name = self._name.replace('Nat', '0')
+            if self._name.endswith('m'):
+                self._name = self._name[:-1] + '_m1'
 
             msg = 'OpenMC nuclides follow the GND naming convention. Nuclide ' \
-                  '"{}" is being renamed as "{}".'.format(name, new_name)
+                  '"{}" is being renamed as "{}".'.format(name, self._name)
             warnings.warn(msg)
-
-        self._name = name.replace('-', '')
 
     @xs.setter
     def xs(self, xs):

--- a/openmc/opencg_compatible.py
+++ b/openmc/opencg_compatible.py
@@ -911,6 +911,7 @@ def get_openmc_lattice(opencg_lattice):
     if lattice_id in OPENMC_LATTICES:
         return OPENMC_LATTICES[lattice_id]
 
+    name = opencg_lattice.name
     dimension = opencg_lattice.dimension
     width = opencg_lattice.width
     offset = opencg_lattice.offset
@@ -941,7 +942,7 @@ def get_openmc_lattice(opencg_lattice):
                  ((np.array(width, dtype=np.float64) *
                    np.array(dimension, dtype=np.float64))) / -2.0
 
-    openmc_lattice = openmc.RectLattice(lattice_id=lattice_id)
+    openmc_lattice = openmc.RectLattice(lattice_id=lattice_id, name=name)
     openmc_lattice.pitch = width
     openmc_lattice.universes = universe_array
     openmc_lattice.lower_left = lower_left

--- a/scripts/openmc-update-inputs
+++ b/scripts/openmc-update-inputs
@@ -253,23 +253,6 @@ def update_geometry(geometry_root):
 
     return was_updated
 
-def get_thermal_name(name):
-    """Get proper S(a,b) table name, e.g. 'HH2O' -> 'c_H_in_H2O'"""
-    if name.lower() in _THERMAL_NAMES:
-        return _THERMAL_NAMES[name.lower()]
-    else:
-        # Make an educated guess?? This actually works well for
-        # JEFF-3.2 which stupidly uses names like lw00.32t,
-        # lw01.32t, etc. for different temperatures
-        matches = get_close_matches(
-            name.lower(), _THERMAL_NAMES.keys(), cutoff=0.5)
-        if len(matches) > 0:
-            return _THERMAL_NAMES[matches[0]] + '.' + xs
-        else:
-            # OK, we give up. Just use the ACE name.
-            return 'c_' + name
-    return name
-
 def update_materials(root):
     """Update the given XML materials tree. Return True if changes were made."""
     was_updated = False
@@ -298,13 +281,13 @@ def update_materials(root):
         for sab in material.findall('sab'):
             if 'name' in sab.attrib:
                 sabname = sab.attrib['name']
-                sab.set('name', get_thermal_name(sabname))
+                sab.set('name', openmc.data.get_thermal_name(sabname))
                 was_updated = True
 
             elif sab.find('name') is not None:
                 name_elem = sab.find('name')
                 sabname = name_elem.text
-                name_elem.text = get_thermal(sabname)
+                name_elem.text = openmc.data.get_thermal_name(sabname)
                 was_updated = True
 
     return was_updated


### PR DESCRIPTION
This short PR fixes two things:

*  The OpenMC-OpenCG compatibility module now tracks OpenCG `Lattice` names
* The Python API removes hyphens in nuclide names for backwards compatibility