### PR TITLE
Fix mesh filter max iterator check

### DIFF
--- a/src/tally_filter.F90
+++ b/src/tally_filter.F90
@@ -295,8 +295,12 @@ contains
           search_iter = 0
           do while (any(ijk0(:m % n_dimension) < 1) &
                .or. any(ijk0(:m % n_dimension) > m % dimension))
-            if (search_iter == MAX_SEARCH_ITER) call fatal_error("Failed to &
-                 &find a mesh intersection on a tally mesh filter.")
+            if (search_iter == MAX_SEARCH_ITER) then
+              call warning("Failed to find a mesh intersection on a tally mesh &
+                   &filter.")
+              next_bin = NO_BIN_FOUND
+              return
+            end if
 
             do j = 1, m % n_dimension
               if (abs(uvw(j)) < FP_PRECISION) then
@@ -315,6 +319,8 @@ contains
             else
               ijk0(j) = ijk0(j) - 1
             end if
+
+            search_iter = search_iter + 1
           end do
           distance = d(j)
           xyz0 = xyz0 + distance * uvw


### PR DESCRIPTION
Found a bug from #678.  There was a check for an infinite loop that never actually incremented it's loop count.  I've fixed that and I've changed the call from `fatal_error` to `warning`.  @wbinventor found some cases on really big runs where this loop would cycle infinitely.  There is likely some finite precision error related to the particle's position behind this error.