### PR TITLE
Optimization to Speedup OpenCG Conversion

### DIFF
--- a/openmc/opencg_compatible.py
+++ b/openmc/opencg_compatible.py
@@ -997,7 +997,7 @@ def get_opencg_geometry(openmc_geometry):
     return opencg_geometry
 
 
-def get_openmc_geometry(opencg_geometry, compatible=True):
+def get_openmc_geometry(opencg_geometry, compatible=False):
     """Return an OpenMC geometry corresponding to an OpenCG geometry.
 
     Parameters
@@ -1007,7 +1007,7 @@ def get_openmc_geometry(opencg_geometry, compatible=True):
     compatible : bool
         Whether the OpenCG geometry is compatible with OpenMOC's geometric
         primitives. This should be set to False if the OpenCG geometry
-        uses SquarePrism surfaces. True by default as an optimization.
+        uses SquarePrism surfaces. False by default.
 
     Returns
     -------

--- a/openmc/opencg_compatible.py
+++ b/openmc/opencg_compatible.py
@@ -997,13 +997,17 @@ def get_opencg_geometry(openmc_geometry):
     return opencg_geometry
 
 
-def get_openmc_geometry(opencg_geometry):
+def get_openmc_geometry(opencg_geometry, compatible=True):
     """Return an OpenMC geometry corresponding to an OpenCG geometry.
 
     Parameters
     ----------
     opencg_geometry : opencg.Geometry
         OpenCG geometry
+    compatible : bool
+        Whether the OpenCG geometry is compatible with OpenMOC's geometric
+        primitives. This should be set to False if the OpenCG geometry
+        uses SquarePrism surfaces. True by default as an optimization.
 
     Returns
     -------
@@ -1019,9 +1023,6 @@ def get_openmc_geometry(opencg_geometry):
     opencg_geometry.assign_auto_ids()
     opencg_geometry = copy.deepcopy(opencg_geometry)
 
-    # Update Cell bounding boxes in Geometry
-    opencg_geometry.update_bounding_boxes()
-
     # Clear dictionaries and auto-generated ID
     OPENMC_SURFACES.clear()
     OPENCG_SURFACES.clear()
@@ -1033,12 +1034,13 @@ def get_openmc_geometry(opencg_geometry):
     OPENCG_LATTICES.clear()
 
     # Make the entire geometry "compatible" before assigning auto IDs
-    universes = opencg_geometry.get_all_universes()
-    for universe in universes.values():
-        if not isinstance(universe, opencg.Lattice):
-            make_opencg_cells_compatible(universe)
+    if not compatible:
+        universes = opencg_geometry.get_all_universes()
+        for universe in universes.values():
+            if not isinstance(universe, opencg.Lattice):
+                make_opencg_cells_compatible(universe)
 
-    opencg_geometry.assign_auto_ids()
+        opencg_geometry.assign_auto_ids()
 
     opencg_root_universe = opencg_geometry.root_universe
     openmc_root_universe = get_openmc_universe(opencg_root_universe)


### PR DESCRIPTION
This short PR adds a `compatible` param to the `openmc.opencg_compatible.get_openmoc_geometry(...)` method to speedup the conversion of very large geometries. In particular, I ran into some bottlenecks when modelling the full core BEAVRS geometry with where some or all of the fuel pins are treated with unique cells/material primitives. Part of the bottleneck is looping over all of the primitives to check for compatibility - i.e., checking to see if any of OpenCG's `SquarePrism` surfaces are in the `Geometry` since they must be converted to a series of OpenMC's `Plane` surfaces. This is a pretty minor PR which is not likely to affect anyone save for me (and perhaps my successor), so it is up to you @paulromano whether to merge or ignore this change.