### PR TITLE
Add attributes 'level' and ‘meshlines’ to openmc.plot

### DIFF
--- a/docs/source/usersguide/input.rst
+++ b/docs/source/usersguide/input.rst
@@ -2105,8 +2105,8 @@ attributes or sub-elements.  These are not used in "voxel" plots:
     *Default*: None
 
   :meshlines:
-    The ``meshlines`` sub-element allows for plotting the boundaries of
-    a tally mesh on top of a plot. Only one ``meshlines`` element is allowed per
+    The ``meshlines`` sub-element allows for plotting the boundaries of a
+    regular mesh on top of a plot. Only one ``meshlines`` element is allowed per
     ``plot`` element, and it must contain as attributes or sub-elements a mesh
     type and a linewidth.  Optionally, a color may be specified for the overlay:
 


### PR DESCRIPTION
Two elements "level" and "meshlines" are not implemented in Python API. This PR fixes this.

The "[meshlines]" feature is added to openmc though PR #306 but Python API has not been updated.

``` python
# Instantiate a Plot
plot = openmc.Plot(plot_id=1)
plot.origin = [0, 0, 0]
plot.width = [21.5, 21.5]
plot.pixels = [250, 250]
plot.level = 0
plot.meshlines = {
  'type': 'tally',
  'id': 3,
  'linewidth': 2,
  'color': (122, 122, 0)
}

# Instantiate a Plots collection and export to "plots.xml"
plot_file = openmc.Plots([plot])
plot_file.export_to_xml()
```
will generate plots.xml file 
``` xml
<plots>
    <plot basis="xy" color="cell" filename="plot" id="1" type="slice">
        <origin>0 0 0</origin>
        <width>21.5 21.5</width>
        <pixels>250 250</pixels>
        <background>0 0 0</background>
        <level>0</level>
        <meshlines color="122 122 0" id="3" linewidth="2" meshtype="tally" />
    </plot>
</plots>
```