### PR TITLE
[HOTFIX] MGXS Pandas DataFrames with Nuclides

### DIFF
--- a/openmc/mgxs/mgxs.py
+++ b/openmc/mgxs/mgxs.py
@@ -1484,7 +1484,7 @@ class MGXS(object):
 
             # Use tally summation to sum across all nuclides
             query_nuclides = [nuclides]
-            xs_tally = self.xs_tally.summation(nuclides=query_nuclides)
+            xs_tally = self.xs_tally.summation(nuclides=self.get_nuclides())
             df = xs_tally.get_pandas_dataframe(
                 distribcell_paths=distribcell_paths)
 

--- a/openmc/mgxs/mgxs.py
+++ b/openmc/mgxs/mgxs.py
@@ -1496,12 +1496,14 @@ class MGXS(object):
 
         # If the user requested a specific set of nuclides
         elif self.by_nuclide and nuclides != 'all':
+            query_nuclides = nuclides
             xs_tally = self.xs_tally.get_slice(nuclides=nuclides)
             df = xs_tally.get_pandas_dataframe(
                 distribcell_paths=distribcell_paths)
 
         # If the user requested all nuclides, keep nuclide column in dataframe
         else:
+            query_nuclides = self.get_nuclides()
             df = self.xs_tally.get_pandas_dataframe(
                 distribcell_paths=distribcell_paths)
 
@@ -1513,7 +1515,7 @@ class MGXS(object):
 
         # Override energy groups bounds with indices
         all_groups = np.arange(self.num_groups, 0, -1, dtype=np.int)
-        all_groups = np.repeat(all_groups, self.num_nuclides)
+        all_groups = np.repeat(all_groups, len(query_nuclides)) 
         if 'energy low [MeV]' in df and 'energyout low [MeV]' in df:
             df.rename(columns={'energy low [MeV]': 'group in'},
                       inplace=True)

--- a/openmc/mgxs/mgxs.py
+++ b/openmc/mgxs/mgxs.py
@@ -1490,9 +1490,9 @@ class MGXS(object):
 
             # Remove nuclide column since it is homogeneous and redundant
             if self.domain_type == 'mesh':
-                df.drop('nuclide', axis=1, level=0, inplace=True)
+                df.drop('sum(nuclide)', axis=1, level=0, inplace=True)
             else:
-                df.drop('nuclide', axis=1, inplace=True)
+                df.drop('sum(nuclide)', axis=1, inplace=True)
 
         # If the user requested a specific set of nuclides
         elif self.by_nuclide and nuclides != 'all':

--- a/openmc/mgxs/mgxs.py
+++ b/openmc/mgxs/mgxs.py
@@ -337,7 +337,7 @@ class MGXS(object):
         if self.by_nuclide:
             return self.get_nuclides()
         else:
-            return 'sum'
+            return ['sum']
 
     @property
     def loaded_sp(self):
@@ -1483,7 +1483,7 @@ class MGXS(object):
         if self.by_nuclide and nuclides == 'sum':
 
             # Use tally summation to sum across all nuclides
-            query_nuclides = self.get_nuclides()
+            query_nuclides = [nuclides]
             xs_tally = self.xs_tally.summation(nuclides=query_nuclides)
             df = xs_tally.get_pandas_dataframe(
                 distribcell_paths=distribcell_paths)
@@ -1503,7 +1503,7 @@ class MGXS(object):
 
         # If the user requested all nuclides, keep nuclide column in dataframe
         else:
-            query_nuclides = self.get_nuclides()
+            query_nuclides = self.nuclides
             df = self.xs_tally.get_pandas_dataframe(
                 distribcell_paths=distribcell_paths)
 


### PR DESCRIPTION
This short PR fixes a bug that must have been introduced recently to the `MGXS.get_pandas_dataframe(...)` method. In particular, the column of energy groups (in/out) is incorrectly inserted into the DataFrame. Leave it up to me to find these obscure bugs in `openmc.mgxs` after a bit of late night head scratching!