### PR TITLE
Fix bug in plotting meshlines

### DIFF
--- a/src/plot.F90
+++ b/src/plot.F90
@@ -239,10 +239,10 @@ contains
     xyz_ll_plot = pl % origin
     xyz_ur_plot = pl % origin
 
-    xyz_ll_plot(outer) = pl % origin(1) - pl % width(1) / TWO
-    xyz_ll_plot(inner) = pl % origin(2) - pl % width(2) / TWO
-    xyz_ur_plot(outer) = pl % origin(1) + pl % width(1) / TWO
-    xyz_ur_plot(inner) = pl % origin(2) + pl % width(2) / TWO
+    xyz_ll_plot(outer) = pl % origin(outer) - pl % width(1) / TWO
+    xyz_ll_plot(inner) = pl % origin(inner) - pl % width(2) / TWO
+    xyz_ur_plot(outer) = pl % origin(outer) + pl % width(1) / TWO
+    xyz_ur_plot(inner) = pl % origin(inner) + pl % width(2) / TWO
 
     width = xyz_ur_plot - xyz_ll_plot
 


### PR DESCRIPTION
This PR fixes a little bug in plotting mesh lines. In `draw_mesh_lines()`, the starting point of the figure is improperly initialized, resulting in wrong mesh lines especially for non-xy-plane plotting.

Here is a simple example (by modifying `tests/test_plot`).
``` xml
<entropy>                                                                                                                                                                      
      <dimension>5 4 3</dimension>                                                                                                                                                 
      <lower_left>-10 -10 2.5</lower_left>                                                                                                                                         
      <upper_right>10 10 22.5</upper_right>                                                                                                                                        
</entropy> 
```
``` xml
 <plot id="1" basis="xz">                                                                                                                                                       
       <origin>0. 0. 12.5</origin>                                                                                                                                                  
       <width>25 25</width>                                                                                                                                                         
       <pixels>200 200</pixels>                                                                                                                                                     
       <col_spec id="1" rgb="255 0 0" /> <!-- Red -->                                                                                                                               
       <meshlines meshtype="entropy" linewidth="1" color="0 255 0"/>                                                                                                                
 </plot>
```

wrong mesh lines
![1_plot_error](https://cloud.githubusercontent.com/assets/3030455/18819162/a995ab42-8358-11e6-92a3-2bda8b503bbd.png)

correct plot
![1_plot_correct](https://cloud.githubusercontent.com/assets/3030455/18819163/b08a0790-8358-11e6-8d52-9fc912cadb8d.png)


