### PR TITLE
Improve 0K substitution warning messages

### DIFF
--- a/src/input_xml.F90
+++ b/src/input_xml.F90
@@ -5765,7 +5765,7 @@ contains
           file_id = file_open(libraries(i_library) % path, 'r')
           group_id = open_group(file_id, name)
           call nuclides(i_nuclide) % from_hdf5(group_id, nuc_temps(i_nuclide), &
-               temperature_method, temperature_tolerance)
+               temperature_method, temperature_tolerance, master)
           call close_group(group_id)
           call file_close(file_id)
 
@@ -5999,7 +5999,7 @@ contains
         group_id = open_group(file_id, name)
         method = TEMPERATURE_NEAREST
         call resonant_nuc % from_hdf5(group_id, temperature, &
-             method, 1000.0_8)
+             method, 1000.0_8, master)
         call close_group(group_id)
         call file_close(file_id)
 

--- a/src/nuclide_header.F90
+++ b/src/nuclide_header.F90
@@ -194,8 +194,6 @@ module nuclide_header
     integer,          intent(inout) :: method
     real(8),          intent(in)    :: tolerance
     logical,          intent(in)    :: master     ! if this is the master proc
-                                                  !  (can't use global cuz
-                                                  !  circular dependance)
 
     integer :: i
     integer :: storage_type

--- a/src/nuclide_header.F90
+++ b/src/nuclide_header.F90
@@ -186,12 +186,16 @@ module nuclide_header
 
   end subroutine nuclide_clear
 
-  subroutine nuclide_from_hdf5(this, group_id, temperature, method, tolerance)
-    class(Nuclide),  intent(inout) :: this
-    integer(HID_T),  intent(in)    :: group_id
+  subroutine nuclide_from_hdf5(this, group_id, temperature, method, tolerance, &
+                               master)
+    class(Nuclide),   intent(inout) :: this
+    integer(HID_T),   intent(in)    :: group_id
     type(VectorReal), intent(in)   :: temperature ! list of desired temperatures
-    integer,         intent(inout) :: method
-    real(8),         intent(in)    :: tolerance
+    integer,          intent(inout) :: method
+    real(8),          intent(in)    :: tolerance
+    logical,          intent(in)    :: master     ! if this is the master proc
+                                                  !  (can't use global cuz
+                                                  !  circular dependance)
 
     integer :: i
     integer :: storage_type
@@ -265,15 +269,17 @@ module nuclide_header
             call temps_to_read % push_back(nint(temp_actual))
 
             ! Write warning for resonance scattering data if 0K is not available
-            if (abs(temp_actual - temp_desired) > 0 .and. temp_desired == 0) then
+            if (abs(temp_actual - temp_desired) > 0 .and. temp_desired == 0 &
+                 .and. master) then
               call warning(trim(this % name) // " does not contain 0K data &
                    &needed for resonance scattering options selected. Using &
-                   &data at " // trim(to_str(nint(temp_actual))) // " K instead.")
+                   &data at " // trim(to_str(temp_actual)) &
+                   // " K instead.")
             end if
           end if
         else
-          call fatal_error("Nuclear data library does not contain cross sections &
-               &for " // trim(this % name) // " at or near " // &
+          call fatal_error("Nuclear data library does not contain cross &
+               &sections for " // trim(this % name) // " at or near " // &
                trim(to_str(nint(temp_desired))) // " K.")
         end if
       end do


### PR DESCRIPTION
Currently, if you use resonance scattering with the MCNP 0.1K data in a big MPI run, your output will be spammed with messages like
```
 WARNING: U238 does not contain 0K data needed for resonance scattering options
          selected. Using data at 0 K instead.
 WARNING: U238 does not contain 0K data needed for resonance scattering options
          selected. Using data at 0 K instead.
 WARNING:  WARNING: U238 does not contain 0K data needed for resonance scattering options
          selected. Using data at 0 K instead.
U238 does not contain 0K data needed for resonance scattering options
          selected. Using data at 0 K instead.
```

This PR makes two improvements:  Only the master process will give the warning, and it will not round the actual temperature value to an integer.  The new output looks like:
```
 WARNING: U238 does not contain 0K data needed for resonance scattering options
          selected. Using data at 0.100001 K instead.
```