### PR TITLE
fix cython fatal error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import glob
+import numpy as np
 try:
     from setuptools import setup
     have_setuptools = True
@@ -57,7 +58,8 @@ if have_setuptools:
 # If Cython is present, add resonance reconstruction capability
 if have_cython:
     kwargs.update({
-        'ext_modules': cythonize('openmc/data/reconstruct.pyx')
+        'ext_modules': cythonize('openmc/data/reconstruct.pyx'),
+        'include_dirs': [np.get_include()]
     })
 
 setup(**kwargs)


### PR DESCRIPTION
Error occurs when I install openmc in a clustter:

> (develop)$ python setup.py install --user
Compiling openmc/data/reconstruct.pyx because it changed.
[1/1] Cythonizing openmc/data/reconstruct.pyx
running install
running bdist_egg
running egg_info
writing dependency_links to openmc.egg-info/dependency_links.txt
writing requirements to openmc.egg-info/requires.txt
writing top-level names to openmc.egg-info/top_level.txt
writing openmc.egg-info/PKG-INFO
reading manifest file 'openmc.egg-info/SOURCES.txt'
writing manifest file 'openmc.egg-info/SOURCES.txt'
installing library code to build/bdist.linux-x86_64/egg
running install_lib
running build_py
running build_ext
building 'openmc.data.reconstruct' extension
gcc -pthread -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes
-fPIC -I/home/qingming/anaconda3/include/python3.5m -c openmc/data/reconstruct.c
-o build/temp.linux-x86_64-3.5/openmc/data/reconstruct.o
openmc/data/reconstruct.c:284:31: fatal error: numpy/arrayobject.h: No such file
or directory
compilation terminated.
error: command 'gcc' failed with exit status 1

I don't know the reason exactly, but when I follow the advice it works.
http://stackoverflow.com/questions/14657375/cython-fatal-error-numpy-arrayobject-h-no-such-file-or-directory