### PR TITLE
Fixed the placement of a right parenthesis in xsdata path

### DIFF
--- a/scripts/openmc-ace-to-hdf5
+++ b/scripts/openmc-ace-to-hdf5
@@ -108,7 +108,7 @@ elif args.xsdata is not None:
         for line in xsdata:
             words = line.split()
             if len(words) >= 9:
-                path = os.path.join(os.path.dirname(args.xsdata, words[8]))
+                path = os.path.join(os.path.dirname(args.xsdata), words[8])
                 if path not in ace_libraries:
                     ace_libraries.append(path)
 


### PR DESCRIPTION
Fixed the placement of a right parenthesis in xsdata path

This bug cause the --xsdata flag (for Serpent XS) not to work.