### PR TITLE
Specify the default source energy distribution in docs

### DIFF
--- a/docs/source/usersguide/input.rst
+++ b/docs/source/usersguide/input.rst
@@ -528,7 +528,8 @@ attributes/sub-elements:
     sub-elements/attributes are those of a univariate probability distribution
     (see the description in :ref:`univariate`).
 
-    *Default*: Watt spectrum with :math:`a` = 0.988 MeV and :math:`b` = 2.249 MeV
+    *Default*: Watt spectrum with :math:`a` = 0.988 MeV and :math:`b` =
+    2.249 MeV :sup:`-1`
 
   :write_initial:
     An element specifying whether to write out the initial source bank used at

--- a/docs/source/usersguide/input.rst
+++ b/docs/source/usersguide/input.rst
@@ -528,6 +528,8 @@ attributes/sub-elements:
     sub-elements/attributes are those of a univariate probability distribution
     (see the description in :ref:`univariate`).
 
+    *Default*: Watt spectrum with :math:`a` = 0.988 MeV and :math:`b` = 2.249 MeV
+
   :write_initial:
     An element specifying whether to write out the initial source bank used at
     the beginning of the first batch. The output file is named


### PR DESCRIPTION
Just filling a small gap in our docs.