### PR TITLE
Additions to openmc.data.Function1D and openmc.data.DataLibrary

### DIFF
--- a/openmc/data/function.py
+++ b/openmc/data/function.py
@@ -427,9 +427,9 @@ class Combination(EqualityMixin):
         self.operations = operations
 
     def __call__(self, x):
-        ans = np.zeros_like(x)
-        for op, func in zip(self.operations, self.functions):
-            ans = op(ans, func(x))
+        ans = self.functions[0](x)
+        for i, operation in enumerate(self.operations):
+            ans = operation(ans, self.functions[i + 1](x))
         return ans
 
     @property
@@ -448,7 +448,7 @@ class Combination(EqualityMixin):
     @operations.setter
     def operations(self, operations):
         cv.check_type('operations', operations, Iterable, np.ufunc)
-        length = len(self.functions)
+        length = len(self.functions) - 1
         cv.check_length('operations', operations, length, length_max=length)
         self._operations = operations
 

--- a/openmc/data/function.py
+++ b/openmc/data/function.py
@@ -407,7 +407,7 @@ class Combination(EqualityMixin):
     Parameters
     ----------
     functions : Iterable of Callable
-        Functions which are to be added together
+        Functions to combine according to operations
     operations : Iterable of numpy.ufunc
         Operations to perform between functions; note that the standard order
         of operations will not be followed, but can be simulated by
@@ -418,9 +418,12 @@ class Combination(EqualityMixin):
     Attributes
     ----------
     functions : Iterable of Callable
-        Functions which are to be added together
+        Functions to combine according to operations
     operations : Iterable of numpy.ufunc
-        Operations to perform between functions
+        Operations to perform between functions; note that the standard order
+        of operations will not be followed, but can be simulated by
+        combinations of Combination objects. The operations parameter must have
+        a length one less than the number of functions.
 
     """
 

--- a/openmc/data/function.py
+++ b/openmc/data/function.py
@@ -410,7 +410,9 @@ class Combination(EqualityMixin):
         Functions which are to be added together
     operations : Iterable of numpy.ufunc
         Operations to perform between functions; note that the standard order
-        of operations (i.e., PEMDAS) will not be followed.
+        of operations will not be followed, but can be simulated by
+        combinations of Combination objects. The operations parameter must have
+        a length one less than the number of functions.
 
 
     Attributes

--- a/openmc/data/function.py
+++ b/openmc/data/function.py
@@ -428,8 +428,8 @@ class Combination(EqualityMixin):
 
     def __call__(self, x):
         ans = np.zeros_like(x)
-        for i, operation in enumerate(self.operations):
-            ans = operation(ans, self.functions[i](x))
+        for op, func in zip(self.operations, self.functions):
+            ans = op(ans, func(x))
         return ans
 
     @property
@@ -488,7 +488,7 @@ class Sum(EqualityMixin):
         self._functions = functions
 
 
-class Piecewise(EqualityMixin):
+class Regions1D(EqualityMixin):
     """Piecewise composition of multiple functions.
 
     This class allows you to create a callable object which is composed
@@ -499,9 +499,9 @@ class Piecewise(EqualityMixin):
     functions : Iterable of Callable
         Functions which are to be combined in a piecewise fashion
     breakpoints : Iterable of float
-        The breakpoints between each function. The functions
-        in the functions attribute must be provided in order of
-        increasing intervals.
+        The values of the dependent variable that define the domain of
+        each function. The *i*th and *(i+1)*th values are the limits of the
+        domain of the *i*th function. Values must be monotonically increasing.
 
     Attributes
     ----------

--- a/openmc/data/function.py
+++ b/openmc/data/function.py
@@ -397,6 +397,62 @@ class Polynomial(np.polynomial.Polynomial, Function1D):
         return cls(dataset.value)
 
 
+class Combination(EqualityMixin):
+    """Combination of multiple functions with a user-defined operator
+
+    This class allows you to create a callable object which represents the
+    combination of other callable objects by way of a series of user-defined
+    operators connecting each of the callable objects.
+
+    Parameters
+    ----------
+    functions : Iterable of Callable
+        Functions which are to be added together
+    operations : Iterable of numpy.ufunc
+        Operations to perform between functions; note that the standard order
+        of operations (i.e., PEMDAS) will not be followed.
+
+
+    Attributes
+    ----------
+    functions : Iterable of Callable
+        Functions which are to be added together
+    operations : Iterable of numpy.ufunc
+        Operations to perform between functions
+
+    """
+
+    def __init__(self, functions, operations):
+        self.functions = functions
+        self.operations = operations
+
+    def __call__(self, x):
+        ans = np.zeros_like(x)
+        for i, operation in enumerate(self.operations):
+            ans = operation(ans, self.functions[i](x))
+        return ans
+
+    @property
+    def functions(self):
+        return self._functions
+
+    @functions.setter
+    def functions(self, functions):
+        cv.check_type('functions', functions, Iterable, Callable)
+        self._functions = functions
+
+    @property
+    def operations(self):
+        return self._operations
+
+    @operations.setter
+    def operations(self, operations):
+        cv.check_type('operations', operations, Iterable, np.ufunc)
+        length = len(self.functions)
+        cv.check_length('operations', operations, length, length_max=length)
+        self._operations = operations
+
+
 class Sum(EqualityMixin):
     """Sum of multiple functions.
 
@@ -430,6 +486,63 @@ class Sum(EqualityMixin):
     def functions(self, functions):
         cv.check_type('functions', functions, Iterable, Callable)
         self._functions = functions
+
+
+class Piecewise(EqualityMixin):
+    """Piecewise composition of multiple functions.
+
+    This class allows you to create a callable object which is composed
+    of multiple other callable objects, each applying to a specific interval
+
+    Parameters
+    ----------
+    functions : Iterable of Callable
+        Functions which are to be combined in a piecewise fashion
+    breakpoints : Iterable of float
+        The breakpoints between each function. The functions
+        in the functions attribute must be provided in order of
+        increasing intervals.
+
+    Attributes
+    ----------
+    functions : Iterable of Callable
+        Functions which are to be combined in a piecewise fashion
+    breakpoints : Iterable of float
+        The breakpoints between each function
+
+    """
+
+    def __init__(self, functions, breakpoints):
+        self.functions = functions
+        self.breakpoints = breakpoints
+
+    def __call__(self, x):
+        i = np.searchsorted(self.breakpoints, x)
+        if isinstance(x, Iterable):
+            ans = np.empty_like(x)
+            for j in range(len(i)):
+                ans[j] = self.functions[i[j]](x[j])
+            return ans
+        else:
+            return self.functions[i](x)
+
+    @property
+    def functions(self):
+        return self._functions
+
+    @property
+    def breakpoints(self):
+        return self._breakpoints
+
+    @functions.setter
+    def functions(self, functions):
+        cv.check_type('functions', functions, Iterable, Callable)
+        self._functions = functions
+
+    @breakpoints.setter
+    def breakpoints(self, breakpoints):
+        cv.check_iterable_type('breakpoints', breakpoints, Real)
+        self._breakpoints = breakpoints
 
 
 class ResonancesWithBackground(EqualityMixin):

--- a/openmc/data/library.py
+++ b/openmc/data/library.py
@@ -22,9 +22,19 @@ class DataLibrary(EqualityMixin):
     def __init__(self):
         self.libraries = []
 
-    def __getitem__(self, material):
+    def get_by_materials(self, value):
+        """Access a library entry by passing a value of the 'materials'
+        attribute of the library entry.
+
+        Returns
+        -------
+        library : dict
+            Dictionary summarizing cross section data from a single file;
+            the dictionary has keys 'path', 'type', and 'materials'.
+
+        """
         for library in self.libraries:
-            if material in library['materials']:
+            if value in library['materials']:
                 return library
         return None
 
@@ -93,6 +103,11 @@ class DataLibrary(EqualityMixin):
         ----------
         path : str
             Path to XML file to read.
+
+        Returns
+        -------
+        data : openmc.data.DataLibrary
+            openmc.data.DataLibrary object initialized from the provided XML
 
         """
 

--- a/openmc/data/library.py
+++ b/openmc/data/library.py
@@ -22,13 +22,12 @@ class DataLibrary(EqualityMixin):
     def __init__(self):
         self.libraries = []
 
-    def get_by_materials(self, value):
-        """Access a library entry by passing a value of the 'materials'
-        attribute of the library entry.
+    def get_by_material(self, value):
+        """Return the library dictionary containing a given material.
 
         Returns
         -------
-        library : dict
+        library : dict or None
             Dictionary summarizing cross section data from a single file;
             the dictionary has keys 'path', 'type', and 'materials'.
 
@@ -107,7 +106,7 @@ class DataLibrary(EqualityMixin):
         Returns
         -------
         data : openmc.data.DataLibrary
-            openmc.data.DataLibrary object initialized from the provided XML
+            Data library object initialized from the provided XML
 
         """
 


### PR DESCRIPTION
This PR adds two additional classes to openmc.data.Function1D and the ability to initialize an openmc.data.DataLibrary object from a cross_sections.xml file.

Function1D additions
-`openmc.data.Piecewise`: A piecewise function which allows one to define a combination of callable functions, each with an interval of applicability.  
-`openmc.data.Combination`: A function which is a combination of other callabe functions, where the method of combination is simply provided as a `numpy.ufunc` operator for each callable.

An example of these two guys:

```python
func1 = lambda x: 1.
func2 = lambda x: 2.

f = openmc.data.Piecewise([func1, func2], [1.])
g = openmc.data.Combination([f, func1], [np.add, np.add])
x = np.linspace(-10, 10, 100)

plt.plot(x, f(x), label='Piecewise')
plt.plot(x, g(x), label='Combination')
plt.legend(loc='best')
plt.ylim(0, 4)
plt.show()
plt.close()
```
Produces:
![piecewise](https://cloud.githubusercontent.com/assets/1037107/20081702/3b8678aa-a51f-11e6-9860-ef17745003f1.png)

The openmc.data.DataLibrary loading from an xml constructor (`openmc.data.DataLibrary.from_xml`) is as its name implies - you initialize a DataLibrary object from a cross_sections.xml file itself.

Why am I doing this? Well, I am putting together a PR for plotting macroscopic xs from openmc.Material objects. These items are a key component of that work.