### PR TITLE
Fix argument in h5sget_simple_extend_ndims_f

### DIFF
--- a/src/hdf5_interface.F90
+++ b/src/hdf5_interface.F90
@@ -2589,7 +2589,7 @@ contains
 
   subroutine get_ndims(obj_id, ndims)
     integer(HID_T), intent(in)  :: obj_id
-    integer(HID_T), intent(out) :: ndims
+    integer,        intent(out) :: ndims
 
     integer          :: hdf5_err
     integer          :: type

--- a/src/mgxs_header.F90
+++ b/src/mgxs_header.F90
@@ -430,7 +430,8 @@ module mgxs_header
                                                                   ! in that  conversion
 
       character(MAX_LINE_LEN)     :: temp_str
-      integer(HID_T)              :: xsdata, xsdata_grp, scatt_grp, ndims
+      integer(HID_T)              :: xsdata, xsdata_grp, scatt_grp
+      integer                     :: ndims
       integer(HSIZE_T)            :: dims(2)
       real(8), allocatable        :: temp_arr(:), temp_2d(:, :)
       real(8), allocatable        :: temp_beta(:, :)
@@ -1113,7 +1114,8 @@ module mgxs_header
                                                                     ! in that  conversion
 
       character(MAX_LINE_LEN)     :: temp_str
-      integer(HID_T)              :: xsdata, xsdata_grp, scatt_grp, ndims
+      integer(HID_T)              :: xsdata, xsdata_grp, scatt_grp
+      integer                     :: ndims
       integer(HSIZE_T)            :: dims(4)
       integer, allocatable        :: int_arr(:)
       real(8), allocatable        :: temp_1d(:), temp_3d(:, :, :)


### PR DESCRIPTION
One of @samuelshaner's recent PRs added a `get_ndims` subroutine in our HDF5 interface. One of the arguments in a call to `h5sget_simple_extent_ndims_f` was not of the right type (and just happened to go unnoticed -- with HDF5 1.10 it does not build).