### PR TITLE
Molar mass calculation

### DIFF
--- a/examples/python/pincell/build-xml.py
+++ b/examples/python/pincell/build-xml.py
@@ -51,7 +51,7 @@ o = openmc.Element('O')
 # Instantiate some Materials and register the appropriate Nuclides
 uo2 = openmc.Material(material_id=1, name='UO2 fuel at 2.4% wt enrichment')
 uo2.set_density('g/cm3', 10.29769)
-uo2.add_element(u, 1., enrichment=0.024)
+uo2.add_element(u, 1., enrichment=2.4)
 uo2.add_element(o, 2.)
 
 helium = openmc.Material(material_id=2, name='Helium for gap')

--- a/openmc/data/data.py
+++ b/openmc/data/data.py
@@ -1,6 +1,5 @@
 import itertools
 import os
-import re
 
 
 # Isotopic abundances from M. Berglund and M. E. Wieser, "Isotopic compositions
@@ -151,26 +150,16 @@ def atomic_mass(isotope):
     """
     if not _ATOMIC_MASS:
 
-        # If the isotope represents all natural isotopes of the element
+        # For the isotope represented by all natural isotopes of the element
         # (e.g. C0), set atomic mass manually using the values from Atomic
         # weights of the elements 2013 (IUPAC Technical Report)
         # (doi:10.1515/pac-2015-0305). In cases where an atomic mass range is
         # given (e.g. C), the average value is used.
-        if int(re.split(r"(\d+)", isotope)[1]) == 0:
-            if re.split(r"(\d+)", isotope)[0] == 'C':
-                _ATOMIC_MASS[isotope.lower()] = 12.0106
-            elif re.split(r"(\d+)", isotope)[0] == 'Zn':
-                _ATOMIC_MASS[isotope.lower()] = 65.38
-            elif re.split(r"(\d+)", isotope)[0] == 'Pt':
-                _ATOMIC_MASS[isotope.lower()] = 195.084
-            elif re.split(r"(\d+)", isotope)[0] == 'Os':
-                _ATOMIC_MASS[isotope.lower()] = 190.23
-            elif re.split(r"(\d+)", isotope)[0] == 'Tl':
-                _ATOMIC_MASS[isotope.lower()] = 204.3835
-            else:
-                msg = 'Could not get the atomic mass for zero isotope'\
-                      ' {0}.'.format(isotope)
-                raise ValueError(msg)
+        _ATOMIC_MASS['c0']  = 12.0106
+        _ATOMIC_MASS['zn0'] = 65.38
+        _ATOMIC_MASS['pt0'] = 195.084
+        _ATOMIC_MASS['os0'] = 190.23
+        _ATOMIC_MASS['tl0'] = 204.3835
 
         # Load data from AME2012 file
         mass_file = os.path.join(os.path.dirname(__file__), 'mass.mas12')

--- a/openmc/data/data.py
+++ b/openmc/data/data.py
@@ -1,5 +1,6 @@
 import itertools
 import os
+import re
 
 
 # Isotopic abundances from M. Berglund and M. E. Wieser, "Isotopic compositions
@@ -149,6 +150,28 @@ def atomic_mass(isotope):
 
     """
     if not _ATOMIC_MASS:
+
+        # If the isotope represents all natural isotopes of the element
+        # (e.g. C0), set atomic mass manually using the values from Atomic
+        # weights of the elements 2013 (IUPAC Technical Report)
+        # (doi:10.1515/pac-2015-0305). In cases where an atomic mass range is
+        # given (e.g. C), the average value is used.
+        if int(re.split(r"(\d+)", isotope)[1]) == 0:
+            if re.split(r"(\d+)", isotope)[0] == 'C':
+                _ATOMIC_MASS[isotope.lower()] = 12.0106
+            elif re.split(r"(\d+)", isotope)[0] == 'Zn':
+                _ATOMIC_MASS[isotope.lower()] = 65.38
+            elif re.split(r"(\d+)", isotope)[0] == 'Pt':
+                _ATOMIC_MASS[isotope.lower()] = 195.084
+            elif re.split(r"(\d+)", isotope)[0] == 'Os':
+                _ATOMIC_MASS[isotope.lower()] = 190.23
+            elif re.split(r"(\d+)", isotope)[0] == 'Tl':
+                _ATOMIC_MASS[isotope.lower()] = 204.3835
+            else:
+                msg = 'Could not get the atomic mass for zero isotope'\
+                      ' {0}.'.format(isotope)
+                raise ValueError(msg)
+
         # Load data from AME2012 file
         mass_file = os.path.join(os.path.dirname(__file__), 'mass.mas12')
         with open(mass_file, 'r') as ame:

--- a/openmc/data/data.py
+++ b/openmc/data/data.py
@@ -150,7 +150,7 @@ def atomic_mass(isotope):
     """
     if not _ATOMIC_MASS:
 
-        # For the isotope represented by all natural isotopes of the element
+        # For the isotopes representing all natural isotopes of their element
         # (e.g. C0), set atomic mass manually using the values from Atomic
         # weights of the elements 2013 (IUPAC Technical Report)
         # (doi:10.1515/pac-2015-0305). In cases where an atomic mass range is

--- a/openmc/element.py
+++ b/openmc/element.py
@@ -233,7 +233,7 @@ class Element(object):
 
         # Compute the ratio of the nuclide atomic masses to the element
         # atomic mass
-        if percent_type == 'wo' and len(abundances) > 1:
+        if percent_type == 'wo':
 
             # Compute the element atomic mass
             element_am = 0.

--- a/openmc/element.py
+++ b/openmc/element.py
@@ -233,7 +233,7 @@ class Element(object):
 
         # Compute the ratio of the nuclide atomic masses to the element
         # atomic mass
-        if percent_type == 'wo':
+        if percent_type == 'wo' and len(abundances) > 1:
 
             # Compute the element atomic mass
             element_am = 0.

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -4,7 +4,6 @@ from numbers import Real, Integral
 import warnings
 from xml.etree import ElementTree as ET
 import sys
-import re
 
 from six import string_types
 
@@ -607,7 +606,9 @@ class Material(object):
                 moles += vals[1] / openmc.data.atomic_mass(nuc)
                 mass += vals[1]
 
-        return (mass / moles)
+        # Compute and return the molar mass
+        molar_mass = mass / moles
+        return molar_mass
 
     def _get_nuclide_xml(self, nuclide, distrib=False):
         xml_element = ET.Element("nuclide")

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -64,12 +64,10 @@ class Material(object):
         List in which each item is a 3-tuple consisting of an
         :class:`openmc.Nuclide` instance, the percent density, and the percent
         type ('ao' or 'wo').
-    molar_mass : float
-        The molar mass of the material computed in units of grams per mole of
-        nuclides in a material. This entails that the molar mass does not depend
-        on the magnitude of the sum of atomic amounts of elements and nuclides
-        in the material. For instance, the molar mass of UO2 would be
-        ~90 g/mol.
+    average_molar_mass : float
+        The average molar mass of nuclides in the material in units of grams per
+        mol.  For example, UO2 with 3 nuclides will have an average molar mass
+        of 270 / 3 = 90 g / mol.
 
     """
 
@@ -201,7 +199,7 @@ class Material(object):
         return self._distrib_otf_file
 
     @property
-    def molar_mass(self):
+    def average_molar_mass(self):
 
         # Get a list of all the nuclides, with elements expanded
         nuclide_densities = self.get_nuclide_densities()

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -64,6 +64,12 @@ class Material(object):
         List in which each item is a 3-tuple consisting of an
         :class:`openmc.Nuclide` instance, the percent density, and the percent
         type ('ao' or 'wo').
+    molar_mass : float
+        The molar mass of the material computed in units of grams per mole of
+        nuclides in a material. This entails that the molar mass does not depend
+        on the magnitude of the sum of atomic amounts of elements and nuclides
+        in the material. For instance, the molar mass of UO2 would be
+        ~90 g/mol.
 
     """
 
@@ -193,6 +199,27 @@ class Material(object):
     @property
     def distrib_otf_file(self):
         return self._distrib_otf_file
+
+    @property
+    def molar_mass(self):
+
+        # Get a list of all the nuclides, with elements expanded
+        nuclide_densities = self.get_nuclide_densities()
+
+        # Using the sum of specified atomic or weight amounts as a basis, sum
+        # the mass and moles of the material
+        mass = 0.
+        moles = 0.
+        for nuc, vals in nuclide_densities.items():
+            if vals[2] == 'ao':
+                mass += vals[1] * openmc.data.atomic_mass(nuc)
+                moles += vals[1]
+            else:
+                moles += vals[1] / openmc.data.atomic_mass(nuc)
+                mass += vals[1]
+
+        # Compute and return the molar mass
+        return mass / moles
 
     @id.setter
     def id(self, material_id):
@@ -580,35 +607,6 @@ class Material(object):
                 nuclides[iso.name] = (iso, iso_pct, iso_pct_type)
 
         return nuclides
-
-    def get_molar_mass(self):
-        """Returns the molar mass of the material
-
-        Returns
-        -------
-        molar_mass : float
-            The molar mass of the material
-
-        """
-
-        # Get a list of all the nuclides, with elements expanded
-        nuclide_densities = self.get_nuclide_densities()
-
-        # Using the sum of specified atomic or weight amounts as a basis, sum
-        # the mass and moles of the material
-        mass = 0.
-        moles = 0.
-        for nuc,vals in nuclide_densities.items():
-            if vals[2] == 'ao':
-                mass += vals[1] * openmc.data.atomic_mass(nuc)
-                moles += vals[1]
-            else:
-                moles += vals[1] / openmc.data.atomic_mass(nuc)
-                mass += vals[1]
-
-        # Compute and return the molar mass
-        molar_mass = mass / moles
-        return molar_mass
 
     def _get_nuclide_xml(self, nuclide, distrib=False):
         xml_element = ET.Element("nuclide")

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -4,6 +4,7 @@ from numbers import Real, Integral
 import warnings
 from xml.etree import ElementTree as ET
 import sys
+import re
 
 from six import string_types
 
@@ -580,6 +581,33 @@ class Material(object):
                 nuclides[iso.name] = (iso, iso_pct, iso_pct_type)
 
         return nuclides
+
+    def get_molar_mass(self):
+        """Returns the molar mass of the material
+
+        Returns
+        -------
+        molar_mass : float
+            The molar mass of the material
+
+        """
+
+        # Get a list of all the nuclides, with elements expanded
+        nuclide_densities = self.get_nuclide_densities()
+
+        # Using the sum of specified atomic or weight amounts as a basis, sum
+        # the mass and moles of the material
+        mass = 0.
+        moles = 0.
+        for nuc,vals in nuclide_densities.items():
+            if vals[2] == 'ao':
+                mass += vals[1] * openmc.data.atomic_mass(nuc)
+                moles += vals[1]
+            else:
+                moles += vals[1] / openmc.data.atomic_mass(nuc)
+                mass += vals[1]
+
+        return (mass / moles)
 
     def _get_nuclide_xml(self, nuclide, distrib=False):
         xml_element = ET.Element("nuclide")


### PR DESCRIPTION
This PR implements a molar mass calculation for a Python API material. 

Additionally, two other issues were addressed:
* Fixed enrichment in input file.
* Added calculation of atomic masses for isotopes that represent all natural isotopes of an element (e.g C0).
