### PR TITLE
Use multidimensional array for tally results rather than derived type

### DIFF
--- a/docs/source/io_formats/statepoint.rst
+++ b/docs/source/io_formats/statepoint.rst
@@ -224,12 +224,12 @@ if run_mode == 'k-eigenvalue':
     Tallying moment orders for Legendre and spherical harmonic tally expansions
     (*e.g.*, 'P2', 'Y1,2', etc.).
 
-**/tallies/tally <uid>/results** (Compound type)
+**/tallies/tally <uid>/results** (*double[][][2]*)
 
-    Accumulated sum and sum-of-squares for each bin of the i-th tally. This is a
-    two-dimensional array, the first dimension of which represents combinations
-    of filter bins and the second dimensions of which represents scoring
-    bins. Each element of the array has fields 'sum' and 'sum_sq'.
+    Accumulated sum and sum-of-squares for each bin of the i-th tally. The first
+    dimension represents combinations of filter bins, the second dimensions
+    represents scoring bins, and the third dimension has two entries for the sum
+    and the sum-of-squares.
 
 **/source_present** (*int*)
 

--- a/openmc/particle_restart.py
+++ b/openmc/particle_restart.py
@@ -1,3 +1,5 @@
+import h5py
+
 class Particle(object):
     """Information used to restart a specific particle that caused a simulation to
     fail.
@@ -33,12 +35,6 @@ class Particle(object):
     """
 
     def __init__(self, filename):
-        import h5py
-        if h5py.__version__ == '2.6.0':
-            raise ImportError("h5py 2.6.0 has a known bug which makes it "
-                              "incompatible with OpenMC's HDF5 files. "
-                              "Please switch to a different version.")
-
         self._f = h5py.File(filename, 'r')
 
         # Ensure filetype and revision are correct

--- a/openmc/statepoint.py
+++ b/openmc/statepoint.py
@@ -5,6 +5,7 @@ import warnings
 import glob
 
 import numpy as np
+import h5py
 
 import openmc
 import openmc.checkvalue as cv
@@ -104,12 +105,6 @@ class StatePoint(object):
     """
 
     def __init__(self, filename, autolink=True):
-        import h5py
-        if h5py.__version__ == '2.6.0':
-            raise ImportError("h5py 2.6.0 has a known bug which makes it "
-                              "incompatible with OpenMC's HDF5 files. "
-                              "Please switch to a different version.")
-
         self._f = h5py.File(filename, 'r')
 
         # Ensure filetype and revision are correct
@@ -209,13 +204,13 @@ class StatePoint(object):
     def global_tallies(self):
         if self._global_tallies is None:
             data = self._f['global_tallies'].value
-            gt = np.zeros_like(data, dtype=[
+            gt = np.zeros(data.shape[0], dtype=[
                 ('name', 'a14'), ('sum', 'f8'), ('sum_sq', 'f8'),
                 ('mean', 'f8'), ('std_dev', 'f8')])
             gt['name'] = ['k-collision', 'k-absorption', 'k-tracklength',
                           'leakage']
-            gt['sum'] = data['sum']
-            gt['sum_sq'] = data['sum_sq']
+            gt['sum'] = data[:,1]
+            gt['sum_sq'] = data[:,2]
 
             # Calculate mean and sample standard deviation of mean
             n = self.n_realizations

--- a/openmc/summary.py
+++ b/openmc/summary.py
@@ -2,6 +2,7 @@ from collections import Iterable
 import re
 
 import numpy as np
+import h5py
 
 import openmc
 from openmc.region import Region
@@ -23,15 +24,6 @@ class Summary(object):
     """
 
     def __init__(self, filename):
-        # A user may not have h5py, but they can still use the rest of the
-        # Python API so we'll only try to import h5py if the user actually inits
-        # a Summary object.
-        import h5py
-        if h5py.__version__ == '2.6.0':
-            raise ImportError("h5py 2.6.0 has a known bug which makes it "
-                              "incompatible with OpenMC's HDF5 files. "
-                              "Please switch to a different version.")
-
         openmc.reset_auto_ids()
 
         if not filename.endswith(('.h5', '.hdf5')):

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -13,6 +13,7 @@ from xml.etree import ElementTree as ET
 
 from six import string_types
 import numpy as np
+import h5py
 
 import openmc
 import openmc.checkvalue as cv
@@ -269,20 +270,14 @@ class Tally(object):
             return None
 
         if not self._results_read:
-            import h5py
-            if h5py.__version__ == '2.6.0':
-                raise ImportError("h5py 2.6.0 has a known bug which makes it "
-                                  "incompatible with OpenMC's HDF5 files. "
-                                  "Please switch to a different version.")
-
             # Open the HDF5 statepoint file
             f = h5py.File(self._sp_filename, 'r')
 
             # Extract Tally data from the file
             data = f['tallies/tally {0}/results'.format(
                 self.id)].value
-            sum = data['sum']
-            sum_sq = data['sum_sq']
+            sum = data[:,:,0]
+            sum_sq = data[:,:,1]
 
             # Reshape the results arrays
             sum = np.reshape(sum, self.shape)
@@ -1726,8 +1721,6 @@ class Tally(object):
 
         # HDF5 binary file
         if format == 'hdf5':
-            import h5py
-
             filename = directory + '/' + filename + '.h5'
 
             if append:

--- a/openmc/volume.py
+++ b/openmc/volume.py
@@ -5,6 +5,7 @@ from warnings import warn
 
 import numpy as np
 import pandas as pd
+import h5py
 
 import openmc
 import openmc.checkvalue as cv
@@ -187,8 +188,6 @@ class VolumeCalculation(object):
             Results of the stochastic volume calculation
 
         """
-        import h5py
-
         with h5py.File(filename, 'r') as f:
             domain_type = f.attrs['domain_type'].decode()
             samples = f.attrs['samples']

--- a/src/cmfd_data.F90
+++ b/src/cmfd_data.F90
@@ -164,7 +164,7 @@ contains
                      * t%stride) + 1
 
                 ! Get flux
-                flux = t % results(1,score_index) % sum
+                flux = t % results(RESULT_SUM,1,score_index)
                 cmfd % flux(h,i,j,k) = flux
 
                 ! Detect zero flux, abort if located
@@ -175,10 +175,10 @@ contains
                 end if
 
                 ! Get total rr and convert to total xs
-                cmfd % totalxs(h,i,j,k) = t % results(2,score_index) % sum / flux
+                cmfd % totalxs(h,i,j,k) = t % results(RESULT_SUM,2,score_index) / flux
 
                 ! Get p1 scatter rr and convert to p1 scatter xs
-                cmfd % p1scattxs(h,i,j,k) = t % results(3,score_index) % sum / flux
+                cmfd % p1scattxs(h,i,j,k) = t % results(RESULT_SUM,3,score_index) / flux
 
                 ! Calculate diffusion coefficient
                 cmfd % diffcof(h,i,j,k) = ONE/(3.0_8*(cmfd % totalxs(h,i,j,k) - &
@@ -211,19 +211,18 @@ contains
                        * t%stride) + 1
 
                   ! Get scattering
-                  cmfd % scattxs(h,g,i,j,k) = t % results(1,score_index) % sum /&
+                  cmfd % scattxs(h,g,i,j,k) = t % results(RESULT_SUM,1,score_index) /&
                        cmfd % flux(h,i,j,k)
 
                   ! Get nu-fission
-                  cmfd % nfissxs(h,g,i,j,k) = t % results(2,score_index) % sum /&
+                  cmfd % nfissxs(h,g,i,j,k) = t % results(RESULT_SUM,2,score_index) /&
                        cmfd % flux(h,i,j,k)
 
                   ! Bank source
                   cmfd % openmc_src(g,i,j,k) = cmfd % openmc_src(g,i,j,k) + &
-                       t % results(2,score_index) % sum
+                       t % results(RESULT_SUM,2,score_index)
                   cmfd % keff_bal = cmfd % keff_bal + &
-                       t % results(2,score_index) % sum / &
-                       dble(t % n_realizations)
+                       t % results(RESULT_SUM,2,score_index) / t % n_realizations
 
                 end do INGROUP
 
@@ -243,67 +242,67 @@ contains
                 matching_bins(i_filter_surf) = OUT_LEFT
                 score_index = sum((matching_bins(1:size(t % filters)) - 1) &
                      * t % stride) + 1
-                cmfd % current(1,h,i,j,k) = t % results(1,score_index) % sum
+                cmfd % current(1,h,i,j,k) = t % results(RESULT_SUM,1,score_index)
 
                 matching_bins(i_filter_surf) = IN_LEFT
                 score_index = sum((matching_bins(1:size(t % filters)) - 1) &
                      * t % stride) + 1
-                cmfd % current(2,h,i,j,k) = t % results(1,score_index) % sum
+                cmfd % current(2,h,i,j,k) = t % results(RESULT_SUM,1,score_index)
 
                 ! Right surface
                 matching_bins(i_filter_surf) = IN_RIGHT
                 score_index = sum((matching_bins(1:size(t % filters)) - 1) &
                      * t % stride) + 1
-                cmfd % current(3,h,i,j,k) = t % results(1,score_index) % sum
+                cmfd % current(3,h,i,j,k) = t % results(RESULT_SUM,1,score_index)
 
                 matching_bins(i_filter_surf) = OUT_RIGHT
                 score_index = sum((matching_bins(1:size(t % filters)) - 1) &
                      * t % stride) + 1
-                cmfd % current(4,h,i,j,k) = t % results(1,score_index) % sum
+                cmfd % current(4,h,i,j,k) = t % results(RESULT_SUM,1,score_index)
 
                 ! Back surface
                 matching_bins(i_filter_surf) = OUT_BACK
                 score_index = sum((matching_bins(1:size(t % filters)) - 1) &
                      * t % stride) + 1
-                cmfd % current(5,h,i,j,k) = t % results(1,score_index) % sum
+                cmfd % current(5,h,i,j,k) = t % results(RESULT_SUM,1,score_index)
 
                 matching_bins(i_filter_surf) = IN_BACK
                 score_index = sum((matching_bins(1:size(t % filters)) - 1) &
                      * t % stride) + 1
-                cmfd % current(6,h,i,j,k) = t % results(1,score_index) % sum
+                cmfd % current(6,h,i,j,k) = t % results(RESULT_SUM,1,score_index)
 
                 ! Front surface
                 matching_bins(i_filter_surf) = IN_FRONT
                 score_index = sum((matching_bins(1:size(t % filters)) - 1) &
                      * t % stride) + 1
-                cmfd % current(7,h,i,j,k) = t % results(1,score_index) % sum
+                cmfd % current(7,h,i,j,k) = t % results(RESULT_SUM,1,score_index)
 
                 matching_bins(i_filter_surf) = OUT_FRONT
                 score_index = sum((matching_bins(1:size(t % filters)) - 1) &
                      * t % stride) + 1
-                cmfd % current(8,h,i,j,k) = t % results(1,score_index) % sum
+                cmfd % current(8,h,i,j,k) = t % results(RESULT_SUM,1,score_index)
 
                 ! Bottom surface
                 matching_bins(i_filter_surf) = OUT_BOTTOM
                 score_index = sum((matching_bins(1:size(t % filters)) - 1) &
                      * t % stride) + 1
-                cmfd % current(9,h,i,j,k) = t % results(1,score_index) % sum
+                cmfd % current(9,h,i,j,k) = t % results(RESULT_SUM,1,score_index)
 
                 matching_bins(i_filter_surf) = IN_BOTTOM
                 score_index = sum((matching_bins(1:size(t % filters)) - 1) &
                      * t % stride) + 1
-                cmfd % current(10,h,i,j,k) = t % results(1,score_index) % sum
+                cmfd % current(10,h,i,j,k) = t % results(RESULT_SUM,1,score_index)
 
                 ! Top surface
                 matching_bins(i_filter_surf) = IN_TOP
                 score_index = sum((matching_bins(1:size(t % filters)) - 1) &
                      * t % stride) + 1
-                cmfd % current(11,h,i,j,k) = t % results(1,score_index) % sum
+                cmfd % current(11,h,i,j,k) = t % results(RESULT_SUM,1,score_index)
 
                 matching_bins(i_filter_surf) = OUT_TOP
                 score_index = sum((matching_bins(1:size(t % filters)) - 1) &
                      * t % stride) + 1
-                cmfd % current(12,h,i,j,k) = t % results(1,score_index) % sum
+                cmfd % current(12,h,i,j,k) = t % results(RESULT_SUM,1,score_index)
 
               end if TALLY
 

--- a/src/cmfd_execute.F90
+++ b/src/cmfd_execute.F90
@@ -365,22 +365,18 @@ contains
 
   subroutine cmfd_tally_reset()
 
-    use global,  only: n_cmfd_tallies, cmfd_tallies
+    use global,  only: cmfd_tallies
     use output,  only: write_message
-    use tally,   only: reset_result
 
     integer :: i ! loop counter
 
     ! Print message
     call write_message("CMFD tallies reset", 7)
 
-    ! Begin loop around CMFD tallies
-    do i = 1, n_cmfd_tallies
-
-      ! Reset that tally
+    ! Reset CMFD tallies
+    do i = 1, size(cmfd_tallies)
       cmfd_tallies(i) % n_realizations = 0
-      call reset_result(cmfd_tallies(i) % results)
-
+      cmfd_tallies(i) % results(:,:,:) = ZERO
     end do
 
   end subroutine cmfd_tally_reset

--- a/src/constants.F90
+++ b/src/constants.F90
@@ -269,6 +269,12 @@ module constants
   ! ============================================================================
   ! TALLY-RELATED CONSTANTS
 
+  ! Tally result entries
+  integer, parameter :: &
+       RESULT_VALUE  = 1, &
+       RESULT_SUM    = 2, &
+       RESULT_SUM_SQ = 3
+
   ! Tally type
   integer, parameter :: &
        TALLY_VOLUME          = 1, &

--- a/src/eigenvalue.F90
+++ b/src/eigenvalue.F90
@@ -374,7 +374,7 @@ contains
   subroutine calculate_generation_keff()
 
     ! Get keff for this generation by subtracting off the starting value
-    keff_generation = global_tallies(K_TRACKLENGTH) % value - keff_generation
+    keff_generation = global_tallies(RESULT_VALUE, K_TRACKLENGTH) - keff_generation
 
 #ifdef MPI
     ! Combine values across all processors
@@ -466,14 +466,14 @@ contains
     k_combined = ZERO
 
     ! Copy estimates of k-effective and its variance (not variance of the mean)
-    kv(1) = global_tallies(K_COLLISION) % sum / n
-    kv(2) = global_tallies(K_ABSORPTION) % sum / n
-    kv(3) = global_tallies(K_TRACKLENGTH) % sum / n
-    cov(1,1) = (global_tallies(K_COLLISION) % sum_sq - &
+    kv(1) = global_tallies(RESULT_SUM, K_COLLISION) / n
+    kv(2) = global_tallies(RESULT_SUM, K_ABSORPTION) / n
+    kv(3) = global_tallies(RESULT_SUM, K_TRACKLENGTH) / n
+    cov(1,1) = (global_tallies(RESULT_SUM_SQ, K_COLLISION) - &
          n * kv(1) * kv(1)) / (n - 1)
-    cov(2,2) = (global_tallies(K_ABSORPTION) % sum_sq - &
+    cov(2,2) = (global_tallies(RESULT_SUM_SQ, K_ABSORPTION) - &
          n * kv(2) * kv(2)) / (n - 1)
-    cov(3,3) = (global_tallies(K_TRACKLENGTH) % sum_sq - &
+    cov(3,3) = (global_tallies(RESULT_SUM_SQ, K_TRACKLENGTH) - &
          n * kv(3) * kv(3)) / (n - 1)
 
     ! Calculate covariances based on sums with Bessel's correction

--- a/src/finalize.F90
+++ b/src/finalize.F90
@@ -9,7 +9,7 @@ module finalize
   use message_passing
 #endif
 
-  use hdf5_interface, only: hdf5_bank_t, hdf5_tallyresult_t
+  use hdf5_interface, only: hdf5_bank_t
   use hdf5, only: h5tclose_f, h5close_f
 
   implicit none
@@ -53,7 +53,6 @@ contains
     call free_memory()
 
     ! Release compound datatypes
-    call h5tclose_f(hdf5_tallyresult_t, hdf5_err)
     call h5tclose_f(hdf5_bank_t, hdf5_err)
 
     ! Close FORTRAN interface.
@@ -62,7 +61,6 @@ contains
 #ifdef MPI
     ! Free all MPI types
     call MPI_TYPE_FREE(MPI_BANK, mpi_err)
-    call MPI_TYPE_FREE(MPI_TALLYRESULT, mpi_err)
 
     ! If MPI is in use and enabled, terminate it
     call MPI_FINALIZE(mpi_err)

--- a/src/global.F90
+++ b/src/global.F90
@@ -1,5 +1,11 @@
 module global
 
+  use, intrinsic :: ISO_C_BINDING
+
+#ifdef MPIF08
+  use mpi_f08
+#endif
+
   use bank_header,      only: Bank
   use cmfd_header
   use constants
@@ -14,14 +20,10 @@ module global
   use set_header,       only: SetInt
   use surface_header,   only: SurfaceContainer
   use source_header,    only: SourceDistribution
-  use tally_header,     only: TallyObject, TallyResult
+  use tally_header,     only: TallyObject
   use trigger_header,   only: KTrigger
   use timer_header,     only: Timer
   use volume_header,    only: VolumeCalculation
-
-#ifdef MPIF08
-  use mpi_f08
-#endif
 
   implicit none
 
@@ -164,7 +166,7 @@ module global
   !   3) track-length estimate of k-eff
   !   4) leakage fraction
 
-  type(TallyResult), allocatable, target :: global_tallies(:)
+  real(C_DOUBLE), allocatable, target :: global_tallies(:,:)
 
   ! It is possible to protect accumulate operations on global tallies by using
   ! an atomic update. However, when multiple threads accumulate to the same
@@ -272,10 +274,8 @@ module global
   integer :: mpi_err               ! MPI error code
 #ifdef MPIF08
   type(MPI_Datatype) :: MPI_BANK
-  type(MPI_Datatype) :: MPI_TALLYRESULT
 #else
   integer :: MPI_BANK              ! MPI datatype for fission bank
-  integer :: MPI_TALLYRESULT       ! MPI datatype for TallyResult
 #endif
 
 #ifdef _OPENMP

--- a/src/initialize.F90
+++ b/src/initialize.F90
@@ -211,6 +211,8 @@ contains
     call MPI_TYPE_CREATE_STRUCT(5, bank_blocks, bank_disp, &
          bank_types, MPI_BANK, mpi_err)
     call MPI_TYPE_COMMIT(MPI_BANK, mpi_err)
+
+  end subroutine initialize_mpi
 #endif
 
 !===============================================================================

--- a/src/initialize.F90
+++ b/src/initialize.F90
@@ -12,7 +12,7 @@ module initialize
                              &BASE_UNIVERSE
   use global
   use hdf5_interface,  only: file_open, read_dataset, file_close, hdf5_bank_t,&
-                             hdf5_tallyresult_t, hdf5_integer8_t
+                             hdf5_integer8_t
   use input_xml,       only: read_input_xml, cells_in_univ_dict, read_plots_xml
   use material_header, only: Material
   use mgxs_data,       only: read_mgxs, create_macro_xs
@@ -22,7 +22,7 @@ module initialize
   use state_point,     only: load_state_point
   use string,          only: to_str, starts_with, ends_with, str_to_int
   use summary,         only: write_summary
-  use tally_header,    only: TallyObject, TallyResult
+  use tally_header,    only: TallyObject
   use tally_initialize,only: configure_tallies
   use tally_filter
   use tally,           only: init_tally_routines
@@ -169,21 +169,11 @@ contains
     integer                   :: bank_blocks(5)   ! Count for each datatype
 #ifdef MPIF08
     type(MPI_Datatype)        :: bank_types(5)
-    type(MPI_Datatype)        :: result_types(1)
-    type(MPI_Datatype)        :: temp_type
 #else
     integer                   :: bank_types(5)    ! Datatypes
-    integer                   :: result_types(1)  ! Datatypes
-    integer                   :: temp_type        ! temporary derived type
 #endif
     integer(MPI_ADDRESS_KIND) :: bank_disp(5)     ! Displacements
-    integer                   :: result_blocks(1) ! Count for each datatype
-    integer(MPI_ADDRESS_KIND) :: result_disp(1)   ! Displacements
-    integer(MPI_ADDRESS_KIND) :: result_base_disp ! Base displacement
-    integer(MPI_ADDRESS_KIND) :: lower_bound      ! Lower bound for TallyResult
-    integer(MPI_ADDRESS_KIND) :: extent           ! Extent for TallyResult
     type(Bank)       :: b
-    type(TallyResult) :: tr
 
     ! Indicate that MPI is turned on
     mpi_enabled = .true.
@@ -221,36 +211,6 @@ contains
     call MPI_TYPE_CREATE_STRUCT(5, bank_blocks, bank_disp, &
          bank_types, MPI_BANK, mpi_err)
     call MPI_TYPE_COMMIT(MPI_BANK, mpi_err)
-
-    ! ==========================================================================
-    ! CREATE MPI_TALLYRESULT TYPE
-
-    ! Determine displacements for MPI_BANK type
-    call MPI_GET_ADDRESS(tr%value, result_base_disp, mpi_err)
-    call MPI_GET_ADDRESS(tr%sum, result_disp(1), mpi_err)
-
-    ! Adjust displacements
-    result_disp = result_disp - result_base_disp
-
-    ! Define temporary type for TallyResult
-    result_blocks = (/ 2 /)
-    result_types = (/ MPI_REAL8 /)
-    call MPI_TYPE_CREATE_STRUCT(1, result_blocks, result_disp, result_types, &
-         temp_type, mpi_err)
-
-    ! Adjust lower-bound and extent of type for tally score
-    lower_bound = 0
-    extent      = result_disp(1) + 16
-    call MPI_TYPE_CREATE_RESIZED(temp_type, lower_bound, extent, &
-         MPI_TALLYRESULT, mpi_err)
-
-    ! Commit derived type for tally scores
-    call MPI_TYPE_COMMIT(MPI_TALLYRESULT, mpi_err)
-
-    ! Free temporary MPI type
-    call MPI_TYPE_FREE(temp_type, mpi_err)
-
-  end subroutine initialize_mpi
 #endif
 
 !===============================================================================
@@ -259,7 +219,6 @@ contains
 
   subroutine hdf5_initialize()
 
-    type(TallyResult), target :: tmp(2)          ! temporary TallyResult
     type(Bank),        target :: tmpb(2)         ! temporary Bank
     integer                   :: hdf5_err
     integer(HID_T)            :: coordinates_t   ! HDF5 type for 3 reals
@@ -267,14 +226,6 @@ contains
 
     ! Initialize FORTRAN interface.
     call h5open_f(hdf5_err)
-
-    ! Create the compound datatype for TallyResult
-    call h5tcreate_f(H5T_COMPOUND_F, h5offsetof(c_loc(tmp(1)), &
-         c_loc(tmp(2))), hdf5_tallyresult_t, hdf5_err)
-    call h5tinsert_f(hdf5_tallyresult_t, "sum", h5offsetof(c_loc(tmp(1)), &
-         c_loc(tmp(1)%sum)), H5T_NATIVE_DOUBLE, hdf5_err)
-    call h5tinsert_f(hdf5_tallyresult_t, "sum_sq", h5offsetof(c_loc(tmp(1)), &
-         c_loc(tmp(1)%sum_sq)), H5T_NATIVE_DOUBLE, hdf5_err)
 
     ! Create compound type for xyz and uvw
     call h5tarray_create_f(H5T_NATIVE_DOUBLE, 1, dims, coordinates_t, hdf5_err)

--- a/src/input_xml.F90
+++ b/src/input_xml.F90
@@ -2039,7 +2039,6 @@ contains
     type(Library), allocatable :: libraries(:)
     type(VectorReal), allocatable :: nuc_temps(:) ! List of T to read for each nuclide
     type(VectorReal), allocatable :: sab_temps(:) ! List of T to read for each S(a,b)
-    character(MAX_LINE_LEN) :: temp_str
     real(8), allocatable    :: material_temps(:)
     logical                 :: file_exists
     character(MAX_FILE_LEN) :: env_variable

--- a/src/math.F90
+++ b/src/math.F90
@@ -1,8 +1,9 @@
 module math
 
+  use, intrinsic :: ISO_C_BINDING
+
   use constants
   use random_lcg, only: prn
-  use ISO_C_BINDING
 
   implicit none
 

--- a/src/output.F90
+++ b/src/output.F90
@@ -611,7 +611,7 @@ contains
       t_value = t_percentile(ONE - alpha/TWO, n_realizations - 1)
 
       ! Adjust sum_sq
-      global_tallies(:) % sum_sq = t_value * global_tallies(:) % sum_sq
+      global_tallies(RESULT_SUM_SQ,:) = t_value * global_tallies(RESULT_SUM_SQ,:)
 
       ! Adjust combined estimator
       if (n_realizations > 3) then
@@ -623,26 +623,26 @@ contains
     ! write global tallies
     if (n_realizations > 1) then
       if (run_mode == MODE_EIGENVALUE) then
-        write(ou,102) "k-effective (Collision)", global_tallies(K_COLLISION) &
-             % sum, global_tallies(K_COLLISION) % sum_sq
-        write(ou,102) "k-effective (Track-length)", global_tallies(K_TRACKLENGTH) &
-             % sum, global_tallies(K_TRACKLENGTH) % sum_sq
-        write(ou,102) "k-effective (Absorption)", global_tallies(K_ABSORPTION) &
-             % sum, global_tallies(K_ABSORPTION) % sum_sq
+        write(ou,102) "k-effective (Collision)", global_tallies(RESULT_SUM, &
+             K_COLLISION), global_tallies(RESULT_SUM_SQ, K_COLLISION)
+        write(ou,102) "k-effective (Track-length)", global_tallies(RESULT_SUM, &
+             K_TRACKLENGTH), global_tallies(RESULT_SUM_SQ, K_TRACKLENGTH)
+        write(ou,102) "k-effective (Absorption)", global_tallies(RESULT_SUM, &
+             K_ABSORPTION), global_tallies(RESULT_SUM_SQ, K_ABSORPTION)
         if (n_realizations > 3) write(ou,102) "Combined k-effective", k_combined
       end if
-      write(ou,102) "Leakage Fraction", global_tallies(LEAKAGE) % sum, &
-           global_tallies(LEAKAGE) % sum_sq
+      write(ou,102) "Leakage Fraction", global_tallies(RESULT_SUM, LEAKAGE), &
+           global_tallies(RESULT_SUM_SQ, LEAKAGE)
     else
       if (master) call warning("Could not compute uncertainties -- only one &
            &active batch simulated!")
 
       if (run_mode == MODE_EIGENVALUE) then
-        write(ou,103) "k-effective (Collision)", global_tallies(K_COLLISION) % sum
-        write(ou,103) "k-effective (Track-length)", global_tallies(K_TRACKLENGTH)  % sum
-        write(ou,103) "k-effective (Absorption)", global_tallies(K_ABSORPTION) % sum
+        write(ou,103) "k-effective (Collision)", global_tallies(RESULT_SUM, K_COLLISION)
+        write(ou,103) "k-effective (Track-length)", global_tallies(RESULT_SUM, K_TRACKLENGTH)
+        write(ou,103) "k-effective (Absorption)", global_tallies(RESULT_SUM, K_ABSORPTION)
       end if
-      write(ou,103) "Leakage Fraction", global_tallies(LEAKAGE) % sum
+      write(ou,103) "Leakage Fraction", global_tallies(RESULT_SUM, LEAKAGE)
     end if
     write(ou,*)
 
@@ -765,7 +765,7 @@ contains
         end if
 
         ! Multiply uncertainty by t-value
-        t % results % sum_sq = t_value * t % results % sum_sq
+        t % results(RESULT_SUM_SQ,:,:) = t_value * t % results(RESULT_SUM_SQ,:,:)
       end if
 
       ! Write header block
@@ -876,8 +876,8 @@ contains
                    score_names(abs(t % score_bins(k)))
               write(UNIT=unit_tally, FMT='(1X,2A,1X,A,"+/- ",A)') &
                    repeat(" ", indent), score_name, &
-                   to_str(t % results(score_index,filter_index) % sum), &
-                   trim(to_str(t % results(score_index,filter_index) % sum_sq))
+                   to_str(t % results(RESULT_SUM,score_index,filter_index)), &
+                   trim(to_str(t % results(RESULT_SUM_SQ,score_index,filter_index)))
             case (SCORE_SCATTER_PN, SCORE_NU_SCATTER_PN)
               score_index = score_index - 1
               do n_order = 0, t % moment_order(k)
@@ -886,9 +886,8 @@ contains
                      score_names(abs(t % score_bins(k)))
                 write(UNIT=unit_tally, FMT='(1X,2A,1X,A,"+/- ",A)') &
                      repeat(" ", indent), score_name, &
-                     to_str(t % results(score_index,filter_index) % sum), &
-                     trim(to_str(t % results(score_index,filter_index) &
-                     % sum_sq))
+                     to_str(t % results(RESULT_SUM,score_index,filter_index)), &
+                     trim(to_str(t % results(RESULT_SUM_SQ,score_index,filter_index)))
               end do
               k = k + t % moment_order(k)
             case (SCORE_SCATTER_YN, SCORE_NU_SCATTER_YN, SCORE_FLUX_YN, &
@@ -902,9 +901,9 @@ contains
                        // score_names(abs(t % score_bins(k)))
                   write(UNIT=unit_tally, FMT='(1X,2A,1X,A,"+/- ",A)') &
                        repeat(" ", indent), score_name, &
-                       to_str(t % results(score_index,filter_index) % sum), &
-                       trim(to_str(t % results(score_index,filter_index)&
-                       % sum_sq))
+                       to_str(t % results(RESULT_SUM,score_index,filter_index)), &
+                       trim(to_str(t % results(RESULT_SUM_SQ,score_index,&
+                       filter_index)))
                 end do
               end do
               k = k + (t % moment_order(k) + 1)**2 - 1
@@ -916,8 +915,8 @@ contains
               end if
               write(UNIT=unit_tally, FMT='(1X,2A,1X,A,"+/- ",A)') &
                    repeat(" ", indent), score_name, &
-                   to_str(t % results(score_index,filter_index) % sum), &
-                   trim(to_str(t % results(score_index,filter_index) % sum_sq))
+                   to_str(t % results(RESULT_SUM,score_index,filter_index)), &
+                   trim(to_str(t % results(RESULT_SUM_SQ,score_index,filter_index)))
             end select
           end do
           indent = indent - 2
@@ -1020,16 +1019,16 @@ contains
              * t % stride) + 1
         write(UNIT=unit_tally, FMT='(5X,A,T35,A,"+/- ",A)') &
              "Outgoing Current on Left", &
-             to_str(t % results(1,filter_index) % sum), &
-             trim(to_str(t % results(1,filter_index) % sum_sq))
+             to_str(t % results(RESULT_SUM,1,filter_index)), &
+             trim(to_str(t % results(RESULT_SUM_SQ,1,filter_index)))
 
         matching_bins(i_filter_surf) = IN_LEFT
         filter_index = sum((matching_bins(1:size(t % filters)) - 1) &
              * t % stride) + 1
         write(UNIT=unit_tally, FMT='(5X,A,T35,A,"+/- ",A)') &
              "Incoming Current on Left", &
-             to_str(t % results(1,filter_index) % sum), &
-             trim(to_str(t % results(1,filter_index) % sum_sq))
+             to_str(t % results(RESULT_SUM,1,filter_index)), &
+             trim(to_str(t % results(RESULT_SUM_SQ,1,filter_index)))
 
         ! Right Surface
         matching_bins(i_filter_surf) = OUT_RIGHT
@@ -1037,16 +1036,16 @@ contains
              * t % stride) + 1
         write(UNIT=unit_tally, FMT='(5X,A,T35,A,"+/- ",A)') &
              "Outgoing Current on Right", &
-             to_str(t % results(1,filter_index) % sum), &
-             trim(to_str(t % results(1,filter_index) % sum_sq))
+             to_str(t % results(RESULT_SUM,1,filter_index)), &
+             trim(to_str(t % results(RESULT_SUM_SQ,1,filter_index)))
 
         matching_bins(i_filter_surf) = IN_RIGHT
         filter_index = sum((matching_bins(1:size(t % filters)) - 1) &
              * t % stride) + 1
         write(UNIT=unit_tally, FMT='(5X,A,T35,A,"+/- ",A)') &
              "Incoming Current on Right", &
-             to_str(t % results(1,filter_index) % sum), &
-             trim(to_str(t % results(1,filter_index) % sum_sq))
+             to_str(t % results(RESULT_SUM,1,filter_index)), &
+             trim(to_str(t % results(RESULT_SUM_SQ,1,filter_index)))
 
         if (n_dim >= 2) then
 
@@ -1056,16 +1055,16 @@ contains
                * t % stride) + 1
           write(UNIT=unit_tally, FMT='(5X,A,T35,A,"+/- ",A)') &
                "Outgoing Current on Back", &
-               to_str(t % results(1,filter_index) % sum), &
-               trim(to_str(t % results(1,filter_index) % sum_sq))
+               to_str(t % results(RESULT_SUM,1,filter_index)), &
+               trim(to_str(t % results(RESULT_SUM_SQ,1,filter_index)))
 
           matching_bins(i_filter_surf) = IN_BACK
           filter_index = sum((matching_bins(1:size(t % filters)) - 1) &
                * t % stride) + 1
           write(UNIT=unit_tally, FMT='(5X,A,T35,A,"+/- ",A)') &
                "Incoming Current on Back", &
-               to_str(t % results(1,filter_index) % sum), &
-               trim(to_str(t % results(1,filter_index) % sum_sq))
+               to_str(t % results(RESULT_SUM,1,filter_index)), &
+               trim(to_str(t % results(RESULT_SUM_SQ,1,filter_index)))
 
           ! Front Surface
           matching_bins(i_filter_surf) = OUT_FRONT
@@ -1073,16 +1072,16 @@ contains
                * t % stride) + 1
           write(UNIT=unit_tally, FMT='(5X,A,T35,A,"+/- ",A)') &
                "Net Current on Front", &
-               to_str(t % results(1,filter_index) % sum), &
-               trim(to_str(t % results(1,filter_index) % sum_sq))
+               to_str(t % results(RESULT_SUM,1,filter_index)), &
+               trim(to_str(t % results(RESULT_SUM_SQ,1,filter_index)))
 
           matching_bins(i_filter_surf) = IN_FRONT
           filter_index = sum((matching_bins(1:size(t % filters)) - 1) &
                * t % stride) + 1
           write(UNIT=unit_tally, FMT='(5X,A,T35,A,"+/- ",A)') &
                "Net Current on Front", &
-               to_str(t % results(1,filter_index) % sum), &
-               trim(to_str(t % results(1,filter_index) % sum_sq))
+               to_str(t % results(RESULT_SUM,1,filter_index)), &
+               trim(to_str(t % results(RESULT_SUM_SQ,1,filter_index)))
         end if
 
         if (n_dim == 3) then
@@ -1092,16 +1091,16 @@ contains
                * t % stride) + 1
           write(UNIT=unit_tally, FMT='(5X,A,T35,A,"+/- ",A)') &
                "Outgoing Current on Bottom", &
-               to_str(t % results(1,filter_index) % sum), &
-               trim(to_str(t % results(1,filter_index) % sum_sq))
+               to_str(t % results(RESULT_SUM,1,filter_index)), &
+               trim(to_str(t % results(RESULT_SUM_SQ,1,filter_index)))
 
           matching_bins(i_filter_surf) = IN_BOTTOM
           filter_index = sum((matching_bins(1:size(t % filters)) - 1) &
                * t % stride) + 1
           write(UNIT=unit_tally, FMT='(5X,A,T35,A,"+/- ",A)') &
                "Incoming Current on Bottom", &
-               to_str(t % results(1,filter_index) % sum), &
-               trim(to_str(t % results(1,filter_index) % sum_sq))
+               to_str(t % results(RESULT_SUM,1,filter_index)), &
+               trim(to_str(t % results(RESULT_SUM_SQ,1,filter_index)))
 
           ! Top Surface
           matching_bins(i_filter_surf) = OUT_TOP
@@ -1109,16 +1108,16 @@ contains
                * t % stride) + 1
           write(UNIT=unit_tally, FMT='(5X,A,T35,A,"+/- ",A)') &
                "Outgoing Current on Top", &
-               to_str(t % results(1,filter_index) % sum), &
-               trim(to_str(t % results(1,filter_index) % sum_sq))
+               to_str(t % results(RESULT_SUM,1,filter_index)), &
+               trim(to_str(t % results(RESULT_SUM_SQ,1,filter_index)))
 
           matching_bins(i_filter_surf) = IN_TOP
           filter_index = sum((matching_bins(1:size(t % filters)) - 1) &
                * t % stride) + 1
           write(UNIT=unit_tally, FMT='(5X,A,T35,A,"+/- ",A)') &
                "Incoming Current on Top", &
-               to_str(t % results(1,filter_index) % sum), &
-               trim(to_str(t % results(1,filter_index) % sum_sq))
+               to_str(t % results(RESULT_SUM,1,filter_index)), &
+               trim(to_str(t % results(RESULT_SUM_SQ,1,filter_index)))
         end if
       end do
     end do

--- a/src/physics_mg.F90
+++ b/src/physics_mg.F90
@@ -119,16 +119,16 @@ contains
 
       ! Score implicit absorption estimate of keff
 !$omp atomic
-      global_tallies(K_ABSORPTION) % value = &
-           global_tallies(K_ABSORPTION) % value + p % absorb_wgt * &
+      global_tallies(RESULT_VALUE, K_ABSORPTION) = &
+           global_tallies(RESULT_VALUE, K_ABSORPTION) + p % absorb_wgt * &
            material_xs % nu_fission / material_xs % absorption
     else
       ! See if disappearance reaction happens
       if (material_xs % absorption > prn() * material_xs % total) then
         ! Score absorption estimate of keff
 !$omp atomic
-        global_tallies(K_ABSORPTION) % value = &
-             global_tallies(K_ABSORPTION) % value + p % wgt * &
+        global_tallies(RESULT_VALUE, K_ABSORPTION) = &
+             global_tallies(RESULT_VALUE, K_ABSORPTION) + p % wgt * &
              material_xs % nu_fission / material_xs % absorption
 
         p % alive = .false.

--- a/src/simulation.F90
+++ b/src/simulation.F90
@@ -20,8 +20,7 @@ module simulation
   use source,          only: initialize_source, sample_external_source
   use state_point,     only: write_state_point, write_source_point
   use string,          only: to_str
-  use tally,           only: synchronize_tallies, setup_active_usertallies, &
-                             reset_result
+  use tally,           only: synchronize_tallies, setup_active_usertallies
   use trigger,         only: check_triggers
   use tracking,        only: transport
   use volume_calc,     only: run_volume_calculations
@@ -220,7 +219,7 @@ contains
       if (ufs) call count_source_for_ufs()
 
       ! Store current value of tracklength k
-      keff_generation = global_tallies(K_TRACKLENGTH) % value
+      keff_generation = global_tallies(RESULT_VALUE, K_TRACKLENGTH)
     end if
 
   end subroutine initialize_generation
@@ -237,24 +236,24 @@ contains
 !$omp parallel
 !$omp critical
     if (run_mode == MODE_EIGENVALUE) then
-      global_tallies(K_COLLISION) % value = &
-           global_tallies(K_COLLISION) % value + global_tally_collision
-      global_tallies(K_ABSORPTION) % value = &
-           global_tallies(K_ABSORPTION) % value + global_tally_absorption
-      global_tallies(K_TRACKLENGTH) % value = &
-           global_tallies(K_TRACKLENGTH) % value + global_tally_tracklength
+      global_tallies(RESULT_VALUE, K_COLLISION) = &
+           global_tallies(RESULT_VALUE, K_COLLISION) + global_tally_collision
+      global_tallies(RESULT_VALUE, K_ABSORPTION) = &
+           global_tallies(RESULT_VALUE, K_ABSORPTION) + global_tally_absorption
+      global_tallies(RESULT_VALUE, K_TRACKLENGTH) = &
+           global_tallies(RESULT_VALUE, K_TRACKLENGTH) + global_tally_tracklength
     end if
-    global_tallies(LEAKAGE) % value = &
-         global_tallies(LEAKAGE) % value + global_tally_leakage
+    global_tallies(RESULT_VALUE, LEAKAGE) = &
+         global_tallies(RESULT_VALUE, LEAKAGE) + global_tally_leakage
 !$omp end critical
 
     ! reset private tallies
     if (run_mode == MODE_EIGENVALUE) then
-      global_tally_collision = 0
-      global_tally_absorption = 0
-      global_tally_tracklength = 0
+      global_tally_collision = ZERO
+      global_tally_absorption = ZERO
+      global_tally_tracklength = ZERO
     end if
-    global_tally_leakage = 0
+    global_tally_leakage = ZERO
 !$omp end parallel
 
     if (run_mode == MODE_EIGENVALUE) then
@@ -302,7 +301,7 @@ contains
 
     ! Reset global tally results
     if (.not. active_batches) then
-      call reset_result(global_tallies)
+      global_tallies(:,:) = ZERO
       n_realizations = 0
     end if
 

--- a/src/tally_header.F90
+++ b/src/tally_header.F90
@@ -1,22 +1,14 @@
 module tally_header
 
+  use, intrinsic :: ISO_C_BINDING
+
+  use hdf5
+
   use constants,           only: NONE, N_FILTER_TYPES
   use tally_filter_header, only: TallyFilterContainer
   use trigger_header,      only: TriggerObject
 
-  use, intrinsic :: ISO_C_BINDING
-
   implicit none
-
-!===============================================================================
-! TALLYRESULT provides accumulation of results in a particular tally bin
-!===============================================================================
-
-  type, bind(C) :: TallyResult
-    real(C_DOUBLE) :: value    = 0.
-    real(C_DOUBLE) :: sum      = 0.
-    real(C_DOUBLE) :: sum_sq   = 0.
-  end type TallyResult
 
 !===============================================================================
 ! TALLYOBJECT describes a user-specified tally. The region of phase space to
@@ -68,7 +60,7 @@ module tally_header
 
     integer :: total_filter_bins
     integer :: total_score_bins
-    type(TallyResult), allocatable :: results(:,:)
+    real(C_DOUBLE), allocatable :: results(:,:,:)
 
     ! reset property - allows a tally to be reset after every batch
     logical :: reset = .false.
@@ -79,6 +71,79 @@ module tally_header
     ! Tally precision triggers
     integer                           :: n_triggers = 0  ! # of triggers
     type(TriggerObject),  allocatable :: triggers(:)     ! Array of triggers
+
+  contains
+    procedure :: write_results_hdf5
+    procedure :: read_results_hdf5
   end type TallyObject
+
+contains
+
+  subroutine write_results_hdf5(this, group_id)
+    class(TallyObject), intent(in) :: this
+    integer(HID_T),     intent(in) :: group_id
+
+    integer :: hdf5_err
+    integer(HID_T) :: dset, dspace
+    integer(HID_T) :: memspace
+    integer(HSIZE_T) :: dims(3)
+    integer(HSIZE_T) :: dims_slab(3)
+    integer(HSIZE_T) :: offset(3) = [1,0,0]
+
+    ! Create file dataspace
+    dims_slab(:) = shape(this % results)
+    dims_slab(1) = 2
+    call h5screate_simple_f(3, dims_slab, dspace, hdf5_err)
+
+    ! Create memory dataspace that contains only SUM and SUM_SQ values
+    dims(:) = shape(this % results)
+    call h5screate_simple_f(3, dims, memspace, hdf5_err)
+    call h5sselect_hyperslab_f(memspace, H5S_SELECT_SET_F, offset, dims_slab, &
+         hdf5_err)
+
+    ! Create and write to dataset
+    call h5dcreate_f(group_id, "results", H5T_NATIVE_DOUBLE, dspace, dset, &
+         hdf5_err)
+    call h5dwrite_f(dset, H5T_NATIVE_DOUBLE, this % results, dims_slab, &
+         hdf5_err, mem_space_id=memspace)
+
+    ! Close identifiers
+    call h5dclose_f(dset, hdf5_err)
+    call h5sclose_f(memspace, hdf5_err)
+    call h5sclose_f(dspace, hdf5_err)
+  end subroutine write_results_hdf5
+
+  subroutine read_results_hdf5(this, group_id)
+    class(TallyObject), intent(inout) :: this
+    integer(HID_T),     intent(in) :: group_id
+
+    integer :: hdf5_err
+    integer(HID_T) :: dset, dspace
+    integer(HID_T) :: memspace
+    integer(HSIZE_T) :: dims(3)
+    integer(HSIZE_T) :: dims_slab(3)
+    integer(HSIZE_T) :: offset(3) = [1,0,0]
+
+    ! Create file dataspace
+    dims_slab(:) = shape(this % results)
+    dims_slab(1) = 2
+    call h5screate_simple_f(3, dims_slab, dspace, hdf5_err)
+
+    ! Create memory dataspace that contains only SUM and SUM_SQ values
+    dims(:) = shape(this % results)
+    call h5screate_simple_f(3, dims, memspace, hdf5_err)
+    call h5sselect_hyperslab_f(memspace, H5S_SELECT_SET_F, offset, dims_slab, &
+         hdf5_err)
+
+    ! Create and write to dataset
+    call h5dopen_f(group_id, "results", dset, hdf5_err)
+    call h5dread_f(dset, H5T_NATIVE_DOUBLE, this % results, dims_slab, &
+         hdf5_err, mem_space_id=memspace)
+
+    ! Close identifiers
+    call h5dclose_f(dset, hdf5_err)
+    call h5sclose_f(memspace, hdf5_err)
+    call h5sclose_f(dspace, hdf5_err)
+  end subroutine read_results_hdf5
 
 end module tally_header

--- a/src/tally_initialize.F90
+++ b/src/tally_initialize.F90
@@ -20,7 +20,8 @@ contains
   subroutine configure_tallies()
 
     ! Allocate global tallies
-    allocate(global_tallies(N_GLOBAL_TALLIES))
+    allocate(global_tallies(3, N_GLOBAL_TALLIES))
+    global_tallies(:,:) = ZERO
 
     call setup_tally_arrays()
 
@@ -62,7 +63,8 @@ contains
       t % total_score_bins = t % n_score_bins * t % n_nuclide_bins
 
       ! Allocate results array
-      allocate(t % results(t % total_score_bins, t % total_filter_bins))
+      allocate(t % results(3, t % total_score_bins, t % total_filter_bins))
+      t % results(:,:,:) = ZERO
 
     end do TALLY_LOOP
 

--- a/src/trigger.F90
+++ b/src/trigger.F90
@@ -432,17 +432,19 @@ contains
     real(8), intent(inout)     :: rel_err         ! tally relative error
     integer, intent(in)        :: score_index     ! tally results score index
     integer, intent(in)        :: filter_index    ! tally results filter index
-    integer                    :: n               ! number of realizations
-    real(8)                    :: mean            ! tally mean
-    type(TallyResult)          :: tally_result    ! pointer to TallyResult
-    type(TallyObject), pointer :: t               ! tally pointer
+    type(TallyObject), intent(in) :: t            ! tally
+
+    integer :: n               ! number of realizations
+    real(8) :: mean            ! tally mean
+    real(8) :: tally_sum, tally_sum_sq     ! results for a single tally bin
 
     n = t % n_realizations
-    tally_result = t % results(score_index, filter_index)
+    tally_sum = t % results(RESULT_SUM, score_index, filter_index)
+    tally_sum_sq = t % results(RESULT_SUM_SQ, score_index, filter_index)
 
     ! Compute the tally mean and standard deviation
-    mean    = tally_result % sum / n
-    std_dev = sqrt((tally_result % sum_sq / n - mean * mean) / (n - 1))
+    mean    = tally_sum / n
+    std_dev = sqrt((tally_sum_sq / n - mean * mean) / (n - 1))
 
     ! Compute the relative error if the mean is non-zero
     if (mean == ZERO) then


### PR DESCRIPTION
This pull request changes the data structure used for tally results from a 2D array of `type(TallyResult)` to a 3D array of doubles (It also changes global tallies from `type(TallyResult)` to a 2D array of doubles). There are three primary reasons I'm making this change:

1. It avoids the bug in h5py 2.6.0 that is currently causing headaches for a number of users.
2. It actually results in savings in diskspace when statepoints are written. The reason is because `type(TallyResult)` is effectively a struct of three doubles, and when we define the HDF5 compound type, we only specify that two of them be written to file. However (I didn't realize this until working on this PR) the HDF5 implementation actually uses the struct as-is, and just gives offsets for the two fields (sum and sum_sq) that are actually written. So for every tally bin, it requires 24 bytes even though there is only 16 bytes of real data. Converting over to a simple 3D array of doubles allows us to just write a hyperslab to the HDF5 which truly requires 16 bytes per tally bin.
3. A simpler data structure will probably enable better performance optimizations, namely vectorization. I haven't looked into it too deeply, but I did run a case with > 1GB of tally data and this branch performed 20% better than develop. YMMV. The statepoint produced with the develop branch requires 1.8 GB whereas this branch required 1.2 GB, pretty much exactly as one would expect.