### PR TITLE
Allow materials with density units='sum' to be exported

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -762,9 +762,9 @@ class Material(object):
             subelement.text = str(self.temperature)
 
         # Create density XML subelement
-        if self._density is not None:
+        if self._density is not None or self._density_units == 'sum':
             subelement = ET.SubElement(element, "density")
-            if self._density_units is not 'sum':
+            if self._density_units != 'sum':
                 subelement.set("value", str(self._density))
             subelement.set("units", self._density_units)
         else:


### PR DESCRIPTION
Thanks to @cjosey for pointing out the issue.