### PR TITLE
Minor code cleanup in the score_general_mg routine

### DIFF
--- a/src/tally.F90
+++ b/src/tally.F90
@@ -1131,7 +1131,6 @@ contains
     class(Mgxs), pointer :: nucxs
 
     ! Set the direction and group to use with get_xs
-    ! this only depends on if we
     if (t % estimator == ESTIMATOR_ANALOG .or. &
          t % estimator == ESTIMATOR_COLLISION) then
 
@@ -1387,13 +1386,6 @@ contains
 
       case (SCORE_FISSION)
 
-        ! make sure the correct energy is used
-        if (t % estimator == ESTIMATOR_TRACKLENGTH) then
-          p_g = p % g
-        else
-          p_g = p % last_g
-        end if
-
         if (t % estimator == ESTIMATOR_ANALOG) then
           if (survival_biasing) then
             ! No fission events occur if survival biasing is on -- need to
@@ -1428,13 +1420,6 @@ contains
 
 
       case (SCORE_NU_FISSION)
-
-        ! make sure the correct energy is used
-        if (t % estimator == ESTIMATOR_TRACKLENGTH) then
-          p_g = p % g
-        else
-          p_g = p % last_g
-        end if
 
         if (t % estimator == ESTIMATOR_ANALOG) then
           if (survival_biasing .or. p % fission) then
@@ -1490,13 +1475,6 @@ contains
 
       case (SCORE_PROMPT_NU_FISSION)
 
-        ! make sure the correct energy is used
-        if (t % estimator == ESTIMATOR_TRACKLENGTH) then
-          p_g = p % g
-        else
-          p_g = p % last_g
-        end if
-
         if (t % estimator == ESTIMATOR_ANALOG) then
           if (survival_biasing .or. p % fission) then
             if (t % find_filter(FILTER_ENERGYOUT) > 0) then
@@ -1551,13 +1529,6 @@ contains
 
 
       case (SCORE_DELAYED_NU_FISSION)
-
-        ! make sure the correct energy is used
-        if (t % estimator == ESTIMATOR_TRACKLENGTH) then
-          p_g = p % g
-        else
-          p_g = p % last_g
-        end if
 
         ! Set the delayedgroup filter index and the number of delayed group bins
         dg_filter = t % find_filter(FILTER_DELAYEDGROUP)
@@ -1698,13 +1669,6 @@ contains
         end if
 
       case (SCORE_DECAY_RATE)
-
-        ! make sure the correct energy is used
-        if (t % estimator == ESTIMATOR_TRACKLENGTH) then
-          p_g = p % g
-        else
-          p_g = p % last_g
-        end if
 
         ! Set the delayedgroup filter index and the number of delayed group bins
         dg_filter = t % find_filter(FILTER_DELAYEDGROUP)
@@ -1887,13 +1851,6 @@ contains
 
 
       case (SCORE_KAPPA_FISSION)
-
-        ! make sure the correct energy is used
-        if (t % estimator == ESTIMATOR_TRACKLENGTH) then
-          p_g = p % g
-        else
-          p_g = p % last_g
-        end if
 
         if (t % estimator == ESTIMATOR_ANALOG) then
           if (survival_biasing) then


### PR DESCRIPTION
This short PR removes some lines in `score_general_mg` of tally.F90 which were both unneeded and could have lead to bugs relating to mg-mode tally correctness for survival biasing.