### PR TITLE
Fix use of source files for fixed source simulations

### DIFF
--- a/src/input_xml.F90
+++ b/src/input_xml.F90
@@ -411,8 +411,8 @@ contains
         ! Check if source file exists
         inquire(FILE=path_source, EXIST=file_exists)
         if (.not. file_exists) then
-          call fatal_error("Binary source file '" // trim(path_source) &
-               &// "' does not exist!")
+          call fatal_error("Source file '" // trim(path_source) &
+               // "' does not exist!")
         end if
 
       else

--- a/src/simulation.F90
+++ b/src/simulation.F90
@@ -278,10 +278,12 @@ contains
       if (master .and. current_gen /= gen_per_batch) call print_generation()
     elseif (run_mode == MODE_FIXEDSOURCE) then
       ! For fixed-source mode, we need to sample the external source
-      do i = 1, work
-        call set_particle_seed(overall_gen*n_particles + work_index(rank) + i)
-        call sample_external_source(source_bank(i))
-      end do
+      if (path_source == '') then
+        do i = 1, work
+          call set_particle_seed(overall_gen*n_particles + work_index(rank) + i)
+          call sample_external_source(source_bank(i))
+        end do
+      end if
     end if
 
   end subroutine finalize_generation


### PR DESCRIPTION
Before if you tried to run a fixed source simulation with an HDF5 source file, it would crash at the end of the first generation. This PR fixes that and also checks to make sure the source in the source file is sufficiently large.