### PR TITLE
Build OpenMC as a library and pass MPI intracommunicator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,15 +266,105 @@ add_library(faddeeva STATIC src/Faddeeva.c)
 #===============================================================================
 
 set(program "openmc")
-file(GLOB source src/*.F90 src/xml/openmc_fox.F90)
-add_executable(${program} ${source})
+set(LIBOPENMC_FORTRAN_SRC
+  src/algorithm.F90
+  src/angle_distribution.F90
+  src/angleenergy_header.F90
+  src/bank_header.F90
+  src/cmfd_data.F90
+  src/cmfd_execute.F90
+  src/cmfd_header.F90
+  src/cmfd_input.F90
+  src/cmfd_loss_operator.F90
+  src/cmfd_prod_operator.F90
+  src/cmfd_solver.F90
+  src/constants.F90
+  src/cross_section.F90
+  src/dict_header.F90
+  src/distribution_multivariate.F90
+  src/distribution_univariate.F90
+  src/doppler.F90
+  src/eigenvalue.F90
+  src/endf.F90
+  src/endf_header.F90
+  src/energy_distribution.F90
+  src/energy_grid.F90
+  src/error.F90
+  src/finalize.F90
+  src/geometry.F90
+  src/geometry_header.F90
+  src/global.F90
+  src/hdf5_interface.F90
+  src/initialize.F90
+  src/input_xml.F90
+  src/list_header.F90
+  src/material_header.F90
+  src/math.F90
+  src/matrix_header.F90
+  src/mesh.F90
+  src/mesh_header.F90
+  src/message_passing.F90
+  src/mgxs_data.F90
+  src/mgxs_header.F90
+  src/multipole.F90
+  src/multipole_header.F90
+  src/nuclide_header.F90
+  src/output.F90
+  src/particle_header.F90
+  src/particle_restart.F90
+  src/particle_restart_write.F90
+  src/physics_common.F90
+  src/physics.F90
+  src/physics_mg.F90
+  src/plot.F90
+  src/plot_header.F90
+  src/ppmlib.F90
+  src/product_header.F90
+  src/progress_header.F90
+  src/random_lcg.F90
+  src/reaction_header.F90
+  src/relaxng
+  src/sab_header.F90
+  src/scattdata_header.F90
+  src/secondary_correlated.F90
+  src/secondary_kalbach.F90
+  src/secondary_nbody.F90
+  src/secondary_uncorrelated.F90
+  src/set_header.F90
+  src/simulation.F90
+  src/source.F90
+  src/source_header.F90
+  src/state_point.F90
+  src/stl_vector.F90
+  src/string.F90
+  src/summary.F90
+  src/surface_header.F90
+  src/tally.F90
+  src/tally_filter.F90
+  src/tally_filter_header.F90
+  src/tally_header.F90
+  src/tally_initialize.F90
+  src/timer_header.F90
+  src/tracking.F90
+  src/track_output.F90
+  src/trigger.F90
+  src/trigger_header.F90
+  src/urr_header.F90
+  src/vector_header.F90
+  src/volume_calc.F90
+  src/volume_header.F90
+  src/xml_interface.F90
+  src/xml/openmc_fox.F90)
+add_library(libopenmc STATIC ${LIBOPENMC_FORTRAN_SRC})
+set_target_properties(libopenmc PROPERTIES OUTPUT_NAME openmc)
+add_executable(${program} src/main.F90)
 
 # target_include_directories was added in CMake 2.8.11 and is the recommended
 # way to set include directories. For lesser versions, we revert to set_property
 if(CMAKE_VERSION VERSION_LESS 2.8.11)
   include_directories(${HDF5_INCLUDE_DIRS})
 else()
-  target_include_directories(${program} PUBLIC ${HDF5_INCLUDE_DIRS})
+  target_include_directories(libopenmc PUBLIC ${HDF5_INCLUDE_DIRS})
 endif()
 
 # target_compile_options was added in CMake 2.8.12 and is the recommended way to
@@ -288,6 +378,7 @@ if (CMAKE_VERSION VERSION_LESS 2.8.12)
   set_property(TARGET faddeeva PROPERTY COMPILE_FLAGS "${cflags}")
 else()
   target_compile_options(${program} PUBLIC ${f90flags})
+  target_compile_options(libopenmc PUBLIC ${f90flags})
   target_compile_options(faddeeva PRIVATE ${cflags})
 endif()
 
@@ -298,7 +389,8 @@ endforeach()
 
 # target_link_libraries treats any arguments starting with - but not -l as
 # linker flags. Thus, we can pass both linker flags and libraries together.
-target_link_libraries(${program} ${ldflags} ${HDF5_LIBRARIES} fox_dom faddeeva)
+target_link_libraries(libopenmc ${ldflags} ${HDF5_LIBRARIES} fox_dom faddeeva)
+target_link_libraries(${program} ${ldflags} libopenmc)
 
 #===============================================================================
 # Install executable, scripts, manpage, license

--- a/src/cmfd_input.F90
+++ b/src/cmfd_input.F90
@@ -15,6 +15,7 @@ contains
   subroutine configure_cmfd()
 
     use cmfd_header,  only: allocate_cmfd
+    use message_passing, only: master
 
     integer :: color    ! color group of processor
 

--- a/src/cmfd_solver.F90
+++ b/src/cmfd_solver.F90
@@ -301,9 +301,11 @@ contains
 
   subroutine convergence(iter, innerits, iconv)
 
-    use constants,  only: ONE, ZERO
-    use global,     only: cmfd_power_monitor, master
     use, intrinsic :: ISO_FORTRAN_ENV
+
+    use constants,  only: ONE, ZERO
+    use global,     only: cmfd_power_monitor
+    use message_passing, only: master
 
     integer, intent(in) :: iter     ! outer iteration number
     integer, intent(in) :: innerits ! inner iteration nubmer

--- a/src/error.F90
+++ b/src/error.F90
@@ -3,9 +3,7 @@ module error
   use, intrinsic :: ISO_FORTRAN_ENV
   use constants
 
-#ifdef MPI
   use message_passing
-#endif
 
   implicit none
 
@@ -139,7 +137,7 @@ contains
 
 #ifdef MPI
     ! Abort MPI
-    call MPI_ABORT(MPI_COMM_WORLD, code, mpi_err)
+    call MPI_ABORT(mpi_intracomm, code, mpi_err)
 #endif
 
     ! Abort program

--- a/src/finalize.F90
+++ b/src/finalize.F90
@@ -1,16 +1,13 @@
 module finalize
 
+  use hdf5, only: h5tclose_f, h5close_f
+
   use global
+  use hdf5_interface, only: hdf5_bank_t
+  use message_passing
   use output,         only: print_runtime, print_results, &
                             print_overlap_check, write_tallies
   use tally,          only: tally_statistics
-
-#ifdef MPI
-  use message_passing
-#endif
-
-  use hdf5_interface, only: hdf5_bank_t
-  use hdf5, only: h5tclose_f, h5close_f
 
   implicit none
 
@@ -21,7 +18,7 @@ contains
 ! statistics and writing out tallies
 !===============================================================================
 
-  subroutine finalize_run()
+  subroutine openmc_finalize()
 
     integer :: hdf5_err
 
@@ -66,7 +63,7 @@ contains
     call MPI_FINALIZE(mpi_err)
 #endif
 
-  end subroutine finalize_run
+  end subroutine openmc_finalize
 
 !===============================================================================
 ! REDUCE_OVERLAP_COUNT accumulates cell overlap check counts to master
@@ -77,10 +74,10 @@ contains
 #ifdef MPI
       if (master) then
         call MPI_REDUCE(MPI_IN_PLACE, overlap_check_cnt, n_cells, &
-             MPI_INTEGER8, MPI_SUM, 0, MPI_COMM_WORLD, mpi_err)
+             MPI_INTEGER8, MPI_SUM, 0, mpi_intracomm, mpi_err)
       else
         call MPI_REDUCE(overlap_check_cnt, overlap_check_cnt, n_cells, &
-             MPI_INTEGER8, MPI_SUM, 0, MPI_COMM_WORLD, mpi_err)
+             MPI_INTEGER8, MPI_SUM, 0, mpi_intracomm, mpi_err)
       end if
 #endif
 

--- a/src/global.F90
+++ b/src/global.F90
@@ -267,21 +267,6 @@ module global
   ! ============================================================================
   ! PARALLEL PROCESSING VARIABLES
 
-  ! The defaults set here for the number of processors, rank, and master and
-  ! mpi_enabled flag are for when MPI is not being used at all, i.e. a serial
-  ! run. In this case, these variables are still used at times.
-
-  integer :: n_procs     = 1       ! number of processes
-  integer :: rank        = 0       ! rank of process
-  logical :: master      = .true.  ! master process?
-  logical :: mpi_enabled = .false. ! is MPI in use and initialized?
-  integer :: mpi_err               ! MPI error code
-#ifdef MPIF08
-  type(MPI_Datatype) :: MPI_BANK
-#else
-  integer :: MPI_BANK              ! MPI datatype for fission bank
-#endif
-
 #ifdef _OPENMP
   integer :: n_threads = NONE      ! number of OpenMP threads
   integer :: thread_id             ! ID of a given thread

--- a/src/hdf5_interface.F90
+++ b/src/hdf5_interface.F90
@@ -17,7 +17,7 @@ module hdf5_interface
 
   use error, only: fatal_error
 #ifdef PHDF5
-  use message_passing, only: MPI_COMM_WORLD, MPI_INFO_NULL
+  use message_passing, only: mpi_intracomm, MPI_INFO_NULL
 #endif
 
   implicit none
@@ -124,10 +124,10 @@ contains
       call h5pcreate_f(H5P_FILE_ACCESS_F, plist, hdf5_err)
 #ifdef PHDF5
 #ifdef MPIF08
-      call h5pset_fapl_mpio_f(plist, MPI_COMM_WORLD%MPI_VAL, &
+      call h5pset_fapl_mpio_f(plist, mpi_intracomm%MPI_VAL, &
            MPI_INFO_NULL%MPI_VAL, hdf5_err)
 #else
-      call h5pset_fapl_mpio_f(plist, MPI_COMM_WORLD, MPI_INFO_NULL, hdf5_err)
+      call h5pset_fapl_mpio_f(plist, mpi_intracomm, MPI_INFO_NULL, hdf5_err)
 #endif
 #endif
 
@@ -174,10 +174,10 @@ contains
       call h5pcreate_f(H5P_FILE_ACCESS_F, plist, hdf5_err)
 #ifdef PHDF5
 #ifdef MPIF08
-      call h5pset_fapl_mpio_f(plist, MPI_COMM_WORLD%MPI_VAL, &
+      call h5pset_fapl_mpio_f(plist, mpi_intracomm%MPI_VAL, &
            MPI_INFO_NULL%MPI_VAL, hdf5_err)
 #else
-      call h5pset_fapl_mpio_f(plist, MPI_COMM_WORLD, MPI_INFO_NULL, hdf5_err)
+      call h5pset_fapl_mpio_f(plist, mpi_intracomm, MPI_INFO_NULL, hdf5_err)
 #endif
 #endif
 

--- a/src/initialize.F90
+++ b/src/initialize.F90
@@ -48,9 +48,9 @@ contains
 
   subroutine openmc_init(intracomm)
 #ifdef MPIF08
-    type(MPI_Comm), intent(in) :: intracomm
+    type(MPI_Comm), intent(in) :: intracomm     ! MPI intracommunicator
 #else
-    integer, intent(in), optional :: intracomm
+    integer, intent(in), optional :: intracomm  ! MPI intracommunicator
 #endif
 
     ! Start total and initialization timer
@@ -167,9 +167,9 @@ contains
 
   subroutine initialize_mpi(intracomm)
 #ifdef MPIF08
-    type(MPI_Comm), intent(in) :: intracomm
+    type(MPI_Comm), intent(in) :: intracomm  ! MPI intracommunicator
 #else
-    integer, intent(in) :: intracomm
+    integer, intent(in) :: intracomm         ! MPI intracommunicator
 #endif
 
     integer                   :: bank_blocks(5)   ! Count for each datatype

--- a/src/input_xml.F90
+++ b/src/input_xml.F90
@@ -15,6 +15,7 @@ module input_xml
   use hdf5_interface
   use list_header,      only: ListChar, ListInt, ListReal
   use mesh_header,      only: RegularMesh
+  use message_passing
   use mgxs_data,        only: create_macro_xs, read_mgxs
   use multipole,        only: multipole_read
   use output,           only: write_message

--- a/src/main.F90
+++ b/src/main.F90
@@ -1,17 +1,22 @@
 program main
 
   use constants
-  use finalize,          only: finalize_run
+  use finalize,          only: openmc_finalize
   use global
-  use initialize,        only: initialize_run
+  use initialize,        only: openmc_init
+  use message_passing
   use particle_restart,  only: run_particle_restart
   use plot,              only: run_plot
   use simulation,        only: run_simulation
 
   implicit none
 
-  ! set up problem
-  call initialize_run()
+  ! Initialize run -- when run with MPI, pass communicator
+#ifdef MPI
+  call openmc_init(MPI_COMM_WORLD)
+#else
+  call openmc_init()
+#endif
 
   ! start problem based on mode
   select case (run_mode)
@@ -24,6 +29,6 @@ program main
   end select
 
   ! finalize run
-  call finalize_run()
+  call openmc_finalize()
 
 end program main

--- a/src/mesh.F90
+++ b/src/mesh.F90
@@ -1,13 +1,10 @@
 module mesh
 
-#ifdef MPI
-  use message_passing
-#endif
-
   use algorithm,  only: binary_search
   use constants
   use global
   use mesh_header
+  use message_passing
 
   implicit none
 
@@ -207,17 +204,17 @@ contains
     ! collect values from all processors
     if (master) then
       call MPI_REDUCE(MPI_IN_PLACE, cnt, n, MPI_REAL8, MPI_SUM, 0, &
-           MPI_COMM_WORLD, mpi_err)
+           mpi_intracomm, mpi_err)
     else
       ! Receive buffer not significant at other processors
       call MPI_REDUCE(cnt, dummy, n, MPI_REAL8, MPI_SUM, 0, &
-           MPI_COMM_WORLD, mpi_err)
+           mpi_intracomm, mpi_err)
     end if
 
     ! Check if there were sites outside the mesh for any processor
     if (present(sites_outside)) then
       call MPI_REDUCE(outside, sites_outside, 1, MPI_LOGICAL, MPI_LOR, 0, &
-           MPI_COMM_WORLD, mpi_err)
+           mpi_intracomm, mpi_err)
     end if
 
 #else

--- a/src/message_passing.F90
+++ b/src/message_passing.F90
@@ -8,4 +8,21 @@ module message_passing
 #endif
 #endif
 
+  ! The defaults set here for the number of processors, rank, and master and
+  ! mpi_enabled flag are for when MPI is not being used at all, i.e. a serial
+  ! run. In this case, these variables are still used at times.
+
+  integer :: n_procs     = 1       ! number of processes
+  integer :: rank        = 0       ! rank of process
+  logical :: master      = .true.  ! master process?
+  logical :: mpi_enabled = .false. ! is MPI in use and initialized?
+  integer :: mpi_err               ! MPI error code
+#ifdef MPIF08
+  type(MPI_Datatype) :: MPI_BANK   ! MPI datatype for fission bank
+  type(MPI_Comm) :: mpi_intracomm  ! MPI intra-communicator
+#else
+  integer :: MPI_BANK              ! MPI datatype for fission bank
+  integer :: mpi_intracomm         ! MPI intra-communicator
+#endif
+
 end module message_passing

--- a/src/output.F90
+++ b/src/output.F90
@@ -11,6 +11,7 @@ module output
   use math,            only: t_percentile
   use mesh_header,     only: RegularMesh
   use mesh,            only: mesh_indices_to_bin, bin_to_mesh_indices
+  use message_passing, only: master, n_procs
   use nuclide_header
   use particle_header, only: LocalCoord, Particle
   use plot_header

--- a/src/physics.F90
+++ b/src/physics.F90
@@ -9,6 +9,7 @@ module physics
   use material_header,        only: Material
   use math
   use mesh,                   only: get_mesh_indices
+  use message_passing
   use nuclide_header
   use output,                 only: write_message
   use particle_header,        only: Particle

--- a/src/physics_mg.F90
+++ b/src/physics_mg.F90
@@ -9,6 +9,7 @@ module physics_mg
   use math,                   only: rotate_angle
   use mgxs_header,            only: Mgxs, MgxsContainer
   use mesh,                   only: get_mesh_indices
+  use message_passing
   use output,                 only: write_message
   use particle_header,        only: Particle
   use particle_restart_write, only: write_particle_restart

--- a/src/simulation.F90
+++ b/src/simulation.F90
@@ -1,9 +1,5 @@
 module simulation
 
-#ifdef MPI
-  use message_passing
-#endif
-
   use cmfd_execute,    only: cmfd_init_batch, execute_cmfd
   use constants,       only: ZERO
   use eigenvalue,      only: count_source_for_ufs, calculate_average_keff, &
@@ -13,6 +9,7 @@ module simulation
   use eigenvalue,      only: join_bank_from_threads
 #endif
   use global
+  use message_passing
   use output,          only: write_message, header, print_columns, &
                              print_batch_keff, print_generation
   use particle_header, only: Particle
@@ -322,7 +319,7 @@ contains
     if (master) call check_triggers()
 #ifdef MPI
     call MPI_BCAST(satisfy_triggers, 1, MPI_LOGICAL, 0, &
-         MPI_COMM_WORLD, mpi_err)
+         mpi_intracomm, mpi_err)
 #endif
     if (satisfy_triggers .or. &
          (trigger_on .and. current_batch == n_max_batches)) then

--- a/src/source.F90
+++ b/src/source.F90
@@ -15,6 +15,7 @@ module source
   use geometry_header,  only: BASE_UNIVERSE
   use global
   use hdf5_interface,   only: file_create, file_open, file_close, read_dataset
+  use message_passing,  only: rank
   use output,           only: write_message
   use particle_header,  only: Particle
   use random_lcg,       only: prn, set_particle_seed, prn_set_stream

--- a/src/summary.F90
+++ b/src/summary.F90
@@ -8,6 +8,7 @@ module summary
   use hdf5_interface
   use material_header, only: Material
   use mesh_header,     only: RegularMesh
+  use message_passing
   use nuclide_header
   use output,          only: time_stamp
   use surface_header

--- a/src/tracking.F90
+++ b/src/tracking.F90
@@ -8,6 +8,7 @@ module tracking
   use geometry_header,    only: Universe, BASE_UNIVERSE
   use global
   use output,             only: write_message
+  use message_passing
   use particle_header,    only: LocalCoord, Particle
   use physics,            only: collision
   use physics_mg,         only: collision_mg

--- a/src/trigger.F90
+++ b/src/trigger.F90
@@ -10,6 +10,7 @@ module trigger
   use output,         only: warning, write_message
   use mesh,           only: bin_to_mesh_indices
   use mesh_header,    only: RegularMesh
+  use message_passing, only: master
   use trigger_header, only: TriggerObject
   use tally,          only: TallyObject
   use tally_filter,   only: MeshFilter

--- a/src/volume_calc.F90
+++ b/src/volume_calc.F90
@@ -272,11 +272,11 @@ contains
       if (master) then
 #ifdef MPI
         do j = 1, n_procs - 1
-          call MPI_RECV(n, 1, MPI_INTEGER, j, 0, MPI_COMM_WORLD, &
+          call MPI_RECV(n, 1, MPI_INTEGER, j, 0, mpi_intracomm, &
                MPI_STATUS_IGNORE, mpi_err)
 
           allocate(data(2*n))
-          call MPI_RECV(data, 2*n, MPI_INTEGER, j, 1, MPI_COMM_WORLD, &
+          call MPI_RECV(data, 2*n, MPI_INTEGER, j, 1, mpi_intracomm, &
                MPI_STATUS_IGNORE, mpi_err)
           do k = 0, n - 1
             do m = 1, master_indices(i_domain) % size()
@@ -340,8 +340,8 @@ contains
           data(2*k + 2) = master_hits(i_domain) % data(k + 1)
         end do
 
-        call MPI_SEND(n, 1, MPI_INTEGER, 0, 0, MPI_COMM_WORLD, mpi_err)
-        call MPI_SEND(data, 2*n, MPI_INTEGER, 0, 1, MPI_COMM_WORLD, mpi_err)
+        call MPI_SEND(n, 1, MPI_INTEGER, 0, 0, mpi_intracomm, mpi_err)
+        call MPI_SEND(data, 2*n, MPI_INTEGER, 0, 1, mpi_intracomm, mpi_err)
         deallocate(data)
 #endif
       end if


### PR DESCRIPTION
This pull request restructures OpenMC to look a little more like a library. Most importantly, the `openmc_init` subroutine (renamed from `initialize_run` to avoid namespace issues) now accepts an MPI intracommunicator as an argument. These changes will both 1) allow an external application to call and control OpenMC and 2) to indicate to OpenMC to only operate on a subset of MPI processes if need be. The CMake file now builds all files other than main.F90 as a static library (libopenmc).

For those interested -- these changes are to support TH coupling with Nek5000.