### PR TITLE
Specify run_mode in settings.xml, other assorted changes

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -248,7 +248,7 @@ napoleon_use_ivar = True
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
-    'numpy': ('http://docs.scipy.org/doc/numpy/', None),
+    'numpy': ('https://docs.scipy.org/doc/numpy/', None),
     'pandas': ('http://pandas.pydata.org/pandas-docs/stable/', None),
     'matplotlib': ('http://matplotlib.org/', None)
 }

--- a/docs/source/pythonapi/index.rst
+++ b/docs/source/pythonapi/index.rst
@@ -115,7 +115,7 @@ Many of the above classes are derived from several abstract classes:
    openmc.Region
    openmc.Lattice
 
-Two helpers function are also available to create rectangular and hexagonal
+Two helper function are also available to create rectangular and hexagonal
 prisms defined by the intersection of four and six surface half-spaces,
 respectively.
 

--- a/docs/source/pythonapi/index.rst
+++ b/docs/source/pythonapi/index.rst
@@ -115,15 +115,17 @@ Many of the above classes are derived from several abstract classes:
    openmc.Region
    openmc.Lattice
 
-One function is also available to create a hexagonal region defined by the
-intersection of six surface half-spaces.
+Two helpers function are also available to create rectangular and hexagonal
+prisms defined by the intersection of four and six surface half-spaces,
+respectively.
 
 .. autosummary::
    :toctree: generated
    :nosignatures:
    :template: myfunction.rst
 
-   openmc.make_hexagon_region
+   openmc.get_hexagonal_prism
+   openmc.get_rectangular_prism
 
 Constructing Tallies
 --------------------

--- a/docs/source/usersguide/input.rst
+++ b/docs/source/usersguide/input.rst
@@ -94,6 +94,18 @@ Settings Specification -- settings.xml
 All simulation parameters and miscellaneous options are specified in the
 settings.xml file.
 
+``<batches>`` Element
+---------------------
+
+The ``<batches>`` element indicates the total number of batches to execute,
+where each batch corresponds to a tally realization. In a fixed source
+calculation, each batch consists of a number of source particles. In an
+eigenvalue calculation, each batch consists of one or many fission source
+iterations (generations), where each generation itself consists of a number of
+source neutrons.
+
+  *Default*: None
+
 ``<confidence_intervals>`` Element
 ----------------------------------
 
@@ -131,67 +143,6 @@ you care. This element has the following attributes/sub-elements:
     The energy under which particles will be killed.
 
     *Default*: 0.0
-
-.. _eigenvalue:
-
-``<eigenvalue>`` Element
-------------------------
-
-The ``<eigenvalue>`` element indicates that a :math:`k`-eigenvalue calculation
-should be performed. It has the following attributes/sub-elements:
-
-  :batches:
-    The total number of batches, where each batch corresponds to multiple
-    fission source iterations. Batching is done to eliminate correlation between
-    realizations of random variables.
-
-    *Default*: None
-
-  :generations_per_batch:
-    The number of total fission source iterations per batch.
-
-    *Default*: 1
-
-  :inactive:
-    The number of inactive batches. In general, the starting cycles in a
-    criticality calculation can not be used to contribute to tallies since the
-    fission source distribution and eigenvalue are generally not converged
-    immediately.
-
-    *Default*: None
-
-  :particles:
-    The number of neutrons to simulate per fission source iteration.
-
-    *Default*: None
-
-  :keff_trigger:
-    This tag specifies a precision trigger on the combined :math:`k_{eff}`. The
-    trigger is a convergence criterion on the uncertainty of the estimated
-    eigenvalue. It has the following attributes/sub-elements:
-
-    :type:
-      The type of precision trigger. Accepted options are "variance", "std_dev",
-      and "rel_err".
-
-      :variance:
-       Variance of the batch mean :math:`\sigma^2`
-
-      :std_dev:
-        Standard deviation of the batch mean :math:`\sigma`
-
-      :rel_err:
-        Relative error of the batch mean :math:`\frac{\sigma}{\mu}`
-
-      *Default*: None
-
-    :threshold:
-      The precision trigger's convergence criterion for the
-      combined :math:`k_{eff}`.
-
-      *Default*: None
-
-  .. note:: See section on the :ref:`trigger` for more information.
 
 ``<energy_grid>`` Element
 -------------------------
@@ -247,22 +198,56 @@ problem. It has the following attributes/sub-elements:
 
     *Default*: None
 
-``<fixed_source>`` Element
+``<generations_per_batch>`` Element
+-----------------------------------
+
+The ``<generations_per_batch>`` element indicates the number of total fission
+source iterations per batch for an eigenvalue calculation. This element is
+ignored for all run modes other than "eigenvalue".
+
+  *Default*: 1
+
+``<inactive>`` Element
+----------------------
+
+The ``<inactive>`` element indicates the number of inactive batches used in a
+k-eigenvalue calculation. In general, the starting fission source iterations in
+an eigenvalue calculation can not be used to contribute to tallies since the
+fission source distribution and eigenvalue are generally not converged
+immediately.
+
+  *Default*: 0
+
+``<keff_trigger>`` Element
 --------------------------
 
-The ``<fixed_source>`` element indicates that a fixed source calculation should
-be performed. It has the following attributes/sub-elements:
+The ``<keff_trigger>`` element specifies a precision trigger on the combined
+:math:`k_{eff}`. The trigger is a convergence criterion on the uncertainty of
+the estimated eigenvalue. It has the following attributes/sub-elements:
 
-  :batches:
-    The total number of batches. For fixed source calculations, each batch
-    represents a realization of random variables for tallies.
+  :type:
+    The type of precision trigger. Accepted options are "variance", "std_dev",
+    and "rel_err".
+
+    :variance:
+      Variance of the batch mean :math:`\sigma^2`
+
+    :std_dev:
+      Standard deviation of the batch mean :math:`\sigma`
+
+    :rel_err:
+      Relative error of the batch mean :math:`\frac{\sigma}{\mu}`
 
     *Default*: None
 
-  :particles:
-    The number of particles to simulate per batch.
+  :threshold:
+    The precision trigger's convergence criterion for the
+    combined :math:`k_{eff}`.
 
     *Default*: None
+
+.. note:: See section on the :ref:`trigger` for more information.
+
 
 ``<log_grid_bins>`` Element
 ---------------------------
@@ -336,6 +321,15 @@ will abort.
 
   *Default*: Current working directory
 
+``<particles>`` Element
+-----------------------
+
+This element indicates the number of neutrons to simulate per fission source
+iteration when a k-eigenvalue calculation is performed or the number of neutrons
+per batch for a fixed source simulation.
+
+  *Default*: None
+
 ``<ptables>`` Element
 ---------------------
 
@@ -408,7 +402,16 @@ The ``<run_cmfd>`` element indicates whether or not CMFD acceleration should be
 turned on or off. This element has no attributes or sub-elements and can be set
 to either "false" or "true".
 
-  *Defualt*: false
+  *Default*: false
+
+``<run_mode>`` Element
+----------------------
+
+The ``<run_mode>`` element indicates which run mode should be used when OpenMC
+is executed. This element has no attributes or sub-elements and can be set to
+"eigenvalue", "fixed source", "plot", "volume", or "particle restart".
+
+  *Default*: None
 
 ``<seed>`` Element
 ------------------
@@ -774,13 +777,13 @@ number, and particle number, respectively.
 -------------------------
 
 OpenMC includes tally precision triggers which allow the user to define
-uncertainty thresholds on :math:`k_{eff}` in the ``<eigenvalue>`` subelement of
-``settings.xml``, and/or tallies in ``tallies.xml``. When using triggers,
+uncertainty thresholds on :math:`k_{eff}` in the ``<keff_trigger>`` subelement
+of ``settings.xml``, and/or tallies in ``tallies.xml``. When using triggers,
 OpenMC will run until it completes as many batches as defined by ``<batches>``.
-At this point, the uncertainties on all tallied values are computed and
-compared with their corresponding trigger thresholds. If any triggers have not
-been met, OpenMC will continue until either all trigger thresholds have been
-satisfied or ``<max_batches>`` has been reached.
+At this point, the uncertainties on all tallied values are computed and compared
+with their corresponding trigger thresholds. If any triggers have not been met,
+OpenMC will continue until either all trigger thresholds have been satisfied or
+``<max_batches>`` has been reached.
 
 The ``<trigger>`` element provides an active "toggle switch" for tally
 precision trigger(s), the maximum number of batches and the batch interval. It
@@ -793,8 +796,8 @@ has the following attributes/sub-elements:
   :max_batches:
     This describes the maximum number of batches allowed when using trigger(s).
 
-    .. note:: When max_batches is set, the number of ``batches`` shown in
-              ``<eigenvalue>`` element represents minimum number of batches to
+    .. note:: When max_batches is set, the number of ``batches`` shown in the
+              ``<batches>`` element represents minimum number of batches to
               simulate when using the trigger(s).
 
   :batch_interval:

--- a/docs/source/usersguide/input.rst
+++ b/docs/source/usersguide/input.rst
@@ -214,14 +214,15 @@ The ``<inactive>`` element indicates the number of inactive batches used in a
 k-eigenvalue calculation. In general, the starting fission source iterations in
 an eigenvalue calculation can not be used to contribute to tallies since the
 fission source distribution and eigenvalue are generally not converged
-immediately.
+immediately. This element is ignored for all run modes other than "eigenvalue".
 
   *Default*: 0
 
 ``<keff_trigger>`` Element
 --------------------------
 
-The ``<keff_trigger>`` element specifies a precision trigger on the combined
+The ``<keff_trigger>`` element (ignored for all run modes other than
+"eigenvalue".) specifies a precision trigger on the combined
 :math:`k_{eff}`. The trigger is a convergence criterion on the uncertainty of
 the estimated eigenvalue. It has the following attributes/sub-elements:
 

--- a/examples/xml/basic/settings.xml
+++ b/examples/xml/basic/settings.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0"?>
 <settings>
 
-  <!-- Parameters for k-eigenvalue calculation -->
-  <eigenvalue>
-    <batches>15</batches>
-    <inactive>5</inactive>
-    <particles>10000</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>15</batches>
+  <inactive>5</inactive>
+  <particles>10000</particles>
 
   <!-- Starting source -->
   <source>

--- a/examples/xml/boxes/settings.xml
+++ b/examples/xml/boxes/settings.xml
@@ -2,11 +2,10 @@
 <settings>
 
   <!-- Parameters for k-eigenvalue calculation -->
-  <eigenvalue>
-    <batches>15</batches>
-    <inactive>5</inactive>
-    <particles>10000</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>15</batches>
+  <inactive>5</inactive>
+  <particles>10000</particles>
 
   <!-- Starting source -->
   <source>

--- a/examples/xml/lattice/nested/settings.xml
+++ b/examples/xml/lattice/nested/settings.xml
@@ -2,11 +2,10 @@
 <settings>
 
   <!-- Parameters for k-eigenvalue calculation -->
-  <eigenvalue>
-    <batches>20</batches>
-    <inactive>10</inactive>
-    <particles>10000</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>20</batches>
+  <inactive>10</inactive>
+  <particles>10000</particles>
 
   <!-- Starting source -->
   <source>

--- a/examples/xml/lattice/simple/settings.xml
+++ b/examples/xml/lattice/simple/settings.xml
@@ -2,11 +2,10 @@
 <settings>
 
   <!-- Parameters for k-eigenvalue calculation -->
-  <eigenvalue>
-    <batches>20</batches>
-    <inactive>10</inactive>
-    <particles>10000</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>20</batches>
+  <inactive>10</inactive>
+  <particles>10000</particles>
 
   <!-- Starting source -->
   <source>

--- a/examples/xml/pincell/settings.xml
+++ b/examples/xml/pincell/settings.xml
@@ -2,11 +2,10 @@
 <settings>
 
   <!-- Define how many particles to run and for how many batches -->
-  <eigenvalue>
-    <batches>100</batches>
-    <inactive>10</inactive>
-    <particles>1000</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>100</batches>
+  <inactive>10</inactive>
+  <particles>1000</particles>
 
   <!-- The starting source is a uniform distribution over the entire pin
        cell. Note that since this is effectively a 2D model, the z coordinates

--- a/examples/xml/pincell_multigroup/settings.xml
+++ b/examples/xml/pincell_multigroup/settings.xml
@@ -1,14 +1,10 @@
 <?xml version='1.0' encoding='utf-8'?>
 <settings>
-    <eigenvalue>
-        <particles>1000</particles>
-        <batches>100</batches>
-        <inactive>10</inactive>
-    </eigenvalue>
-    <source strength="1.0">
-        <space type="box">
-            <parameters>-0.63 -0.63 -1 0.63 0.63 1</parameters>
-        </space>
-    </source>
-    <energy_mode>multi-group</energy_mode>
+  <run_mode>eigenvalue</run_mode>
+  <source strength="1.0">
+    <space type="box">
+      <parameters>-0.63 -0.63 -1 0.63 0.63 1</parameters>
+    </space>
+  </source>
+  <energy_mode>multi-group</energy_mode>
 </settings>

--- a/examples/xml/reflective/settings.xml
+++ b/examples/xml/reflective/settings.xml
@@ -2,11 +2,10 @@
 <settings>
 
   <!-- Parameters for k-eigenvalue calculation -->
-  <eigenvalue>
-    <batches>500</batches>
-    <inactive>10</inactive>
-    <particles>10000</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>500</batches>
+  <inactive>10</inactive>
+  <particles>10000</particles>
 
   <!-- Starting source -->
   <source>

--- a/openmc/executor.py
+++ b/openmc/executor.py
@@ -44,8 +44,8 @@ def plot_geometry(output=True, openmc_exec='openmc', cwd='.'):
 
 
 def run(particles=None, threads=None, geometry_debug=False,
-        restart_file=None, tracks=False, mpi_procs=1, output=True,
-        openmc_exec='openmc', mpi_exec='mpiexec', cwd='.'):
+        restart_file=None, tracks=False, output=True, cwd='.',
+        openmc_exec='openmc', mpi_args=None):
     """Run an OpenMC simulation.
 
     Parameters
@@ -56,23 +56,23 @@ def run(particles=None, threads=None, geometry_debug=False,
         Number of OpenMP threads. If OpenMC is compiled with OpenMP threading
         enabled, the default is implementation-dependent but is usually equal to
         the number of hardware threads available (or a value set by the
-        OMP_NUM_THREADS environment variable).
+        :envvar:`OMP_NUM_THREADS` environment variable).
     geometry_debug : bool, optional
         Turn on geometry debugging during simulation. Defaults to False.
     restart_file : str, optional
         Path to restart file to use
     tracks : bool, optional
         Write tracks for all particles. Defaults to False.
-    mpi_procs : int, optional
-        Number of MPI processes.
     output : bool, optional
         Capture OpenMC output from standard out. Defaults to True.
+    cwd : str, optional
+        Path to working directory to run in. Defaults to the current working
+        directory.
     openmc_exec : str, optional
         Path to OpenMC executable. Defaults to 'openmc'.
-    mpi_exec : str, optional
-        MPI execute command. Defaults to 'mpiexec'.
-    cwd : str, optional
-        Path to working directory to run in. Defaults to the current working directory.
+    mpi_args : list of str, optional
+        MPI execute command and any additional MPI arguments to pass,
+        e.g. ['mpiexec', '-n', '8'].
 
     """
 
@@ -94,8 +94,8 @@ def run(particles=None, threads=None, geometry_debug=False,
     if tracks:
         post_args += '-t'
 
-    if isinstance(mpi_procs, Integral) and mpi_procs > 1:
-        pre_args += '{} -n {} '.format(mpi_exec, mpi_procs)
+    if mpi_args is not None:
+        pre_args = ' '.join(mpi_args) + ' '
 
     command = pre_args + openmc_exec + ' ' + post_args
 

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -255,7 +255,7 @@ class Material(object):
 
     @depletable.setter
     def depletable(self, depletable):
-        cv.check_type('Depletable flag for Material ID="{}"'.format(self._id),
+        cv.check_type('Depletable flag for Material ID="{}"'.format(self.id),
                       depletable, bool)
         self._depletable = depletable
 
@@ -770,6 +770,9 @@ class Material(object):
 
         if len(self._name) > 0:
             element.set("name", str(self._name))
+
+        if self._depletable:
+            element.set("depletable", "true")
 
         # Create temperature XML subelement
         if self.temperature is not None:

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -56,6 +56,9 @@ class Material(object):
         Units used for `density`. Can be one of 'g/cm3', 'g/cc', 'kg/cm3',
         'atom/b-cm', 'atom/cm3', 'sum', or 'macro'.  The 'macro' unit only
         applies in the case of a multi-group calculation.
+    depletable : bool
+        Indicate whether the material is depletable. This attribute can be used
+        by downstream depletion applications.
     elements : list of tuple
         List in which each item is a 4-tuple consisting of an
         :class:`openmc.Element` instance, the percent density, the percent
@@ -78,6 +81,7 @@ class Material(object):
         self.temperature = temperature
         self._density = None
         self._density_units = ''
+        self._depletable = False
 
         # A list of tuples (nuclide, percent, percent type)
         self._nuclides = []
@@ -127,37 +131,36 @@ class Material(object):
 
     def __repr__(self):
         string = 'Material\n'
-        string += '{0: <16}{1}{2}\n'.format('\tID', '=\t', self._id)
-        string += '{0: <16}{1}{2}\n'.format('\tName', '=\t', self._name)
-        string += '{0: <16}{1}{2}\n'.format('\tTemperature', '=\t',
-                                            self._temperature)
+        string += '{: <16}=\t{}\n'.format('\tID', self._id)
+        string += '{: <16}=\t{}\n'.format('\tName', self._name)
+        string += '{: <16}=\t{}\n'.format('\tTemperature', self._temperature)
 
-        string += '{0: <16}{1}{2}'.format('\tDensity', '=\t', self._density)
-        string += ' [{0}]\n'.format(self._density_units)
+        string += '{: <16}=\t{}'.format('\tDensity', self._density)
+        string += ' [{}]\n'.format(self._density_units)
 
-        string += '{0: <16}\n'.format('\tS(a,b) Tables')
+        string += '{: <16}\n'.format('\tS(a,b) Tables')
 
         for sab in self._sab:
-            string += '{0: <16}{1}{2}\n'.format('\tS(a,b)', '=\t', sab)
+            string += '{: <16}=\t{}\n'.format('\tS(a,b)', sab)
 
-        string += '{0: <16}\n'.format('\tNuclides')
+        string += '{: <16}\n'.format('\tNuclides')
 
         for nuclide, percent, percent_type in self._nuclides:
             string += '{0: <16}'.format('\t{0.name}'.format(nuclide))
-            string += '=\t{0: <12} [{1}]\n'.format(percent, percent_type)
+            string += '=\t{: <12} [{}]\n'.format(percent, percent_type)
 
         if self._macroscopic is not None:
-            string += '{0: <16}\n'.format('\tMacroscopic Data')
-            string += '{0: <16}'.format('\t{0}'.format(self._macroscopic))
+            string += '{: <16}\n'.format('\tMacroscopic Data')
+            string += '{: <16}'.format('\t{}'.format(self._macroscopic))
 
-        string += '{0: <16}\n'.format('\tElements')
+        string += '{: <16}\n'.format('\tElements')
 
         for element, percent, percent_type, enr in self._elements:
             string += '{0: <16}'.format('\t{0.name}'.format(element))
             if enr is None:
-                string += '=\t{0: <12} [{1}]\n'.format(percent, percent_type)
+                string += '=\t{: <12} [{}]\n'.format(percent, percent_type)
             else:
-                string += '=\t{0: <12} [{1}] @ {2} w/o enrichment\n'\
+                string += '=\t{: <12} [{}] @ {} w/o enrichment\n'\
                           .format(percent, percent_type, enr)
 
         return string
@@ -181,6 +184,10 @@ class Material(object):
     @property
     def density_units(self):
         return self._density_units
+
+    @property
+    def depletable(self):
+        return self._depletable
 
     @property
     def elements(self):
@@ -234,7 +241,7 @@ class Material(object):
     @name.setter
     def name(self, name):
         if name is not None:
-            cv.check_type('name for Material ID="{0}"'.format(self._id),
+            cv.check_type('name for Material ID="{}"'.format(self._id),
                           name, string_types)
             self._name = name
         else:
@@ -242,9 +249,15 @@ class Material(object):
 
     @temperature.setter
     def temperature(self, temperature):
-        cv.check_type('Temperature for Material ID="{0}"'.format(self._id),
+        cv.check_type('Temperature for Material ID="{}"'.format(self._id),
                       temperature, (Real, type(None)))
         self._temperature = temperature
+
+    @depletable.setter
+    def depletable(self, depletable):
+        cv.check_type('Depletable flag for Material ID="{}"'.format(self._id),
+                      depletable, bool)
+        self._depletable = depletable
 
     def set_density(self, units, density=None):
         """Set the density of the material
@@ -264,17 +277,17 @@ class Material(object):
 
         if units is 'sum':
             if density is not None:
-                msg = 'Density "{0}" for Material ID="{1}" is ignored ' \
+                msg = 'Density "{}" for Material ID="{}" is ignored ' \
                       'because the unit is "sum"'.format(density, self.id)
                 warnings.warn(msg)
         else:
             if density is None:
-                msg = 'Unable to set the density for Material ID="{0}" ' \
+                msg = 'Unable to set the density for Material ID="{}" ' \
                       'because a density value must be given when not using ' \
                       '"sum" unit'.format(self.id)
                 raise ValueError(msg)
 
-            cv.check_type('the density for Material ID="{0}"'.format(self.id),
+            cv.check_type('the density for Material ID="{}"'.format(self.id),
                           density, Real)
             self._density = density
 
@@ -285,8 +298,8 @@ class Material(object):
                       'version of openmc')
 
         if not isinstance(filename, string_types) and filename is not None:
-            msg = 'Unable to add OTF material file to Material ID="{0}" with a ' \
-                  'non-string name "{1}"'.format(self._id, filename)
+            msg = 'Unable to add OTF material file to Material ID="{}" with a ' \
+                  'non-string name "{}"'.format(self._id, filename)
             raise ValueError(msg)
 
         self._distrib_otf_file = filename
@@ -314,23 +327,23 @@ class Material(object):
         """
 
         if self._macroscopic is not None:
-            msg = 'Unable to add a Nuclide to Material ID="{0}" as a ' \
+            msg = 'Unable to add a Nuclide to Material ID="{}" as a ' \
                   'macroscopic data-set has already been added'.format(self._id)
             raise ValueError(msg)
 
         if not isinstance(nuclide, string_types + (openmc.Nuclide,)):
-            msg = 'Unable to add a Nuclide to Material ID="{0}" with a ' \
-                  'non-Nuclide value "{1}"'.format(self._id, nuclide)
+            msg = 'Unable to add a Nuclide to Material ID="{}" with a ' \
+                  'non-Nuclide value "{}"'.format(self._id, nuclide)
             raise ValueError(msg)
 
         elif not isinstance(percent, Real):
-            msg = 'Unable to add a Nuclide to Material ID="{0}" with a ' \
-                  'non-floating point value "{1}"'.format(self._id, percent)
+            msg = 'Unable to add a Nuclide to Material ID="{}" with a ' \
+                  'non-floating point value "{}"'.format(self._id, percent)
             raise ValueError(msg)
 
         elif percent_type not in ['ao', 'wo', 'at/g-cm']:
-            msg = 'Unable to add a Nuclide to Material ID="{0}" with a ' \
-                  'percent type "{1}"'.format(self._id, percent_type)
+            msg = 'Unable to add a Nuclide to Material ID="{}" with a ' \
+                  'percent type "{}"'.format(self._id, percent_type)
             raise ValueError(msg)
 
         if isinstance(nuclide, openmc.Nuclide):
@@ -353,7 +366,7 @@ class Material(object):
         """
 
         if not isinstance(nuclide, openmc.Nuclide):
-            msg = 'Unable to remove a Nuclide "{0}" in Material ID="{1}" ' \
+            msg = 'Unable to remove a Nuclide "{}" in Material ID="{}" ' \
                   'since it is not a Nuclide'.format(self._id, nuclide)
             raise ValueError(msg)
 
@@ -377,15 +390,15 @@ class Material(object):
         # Ensure no nuclides, elements, or sab are added since these would be
         # incompatible with macroscopics
         if self._nuclides or self._elements or self._sab:
-            msg = 'Unable to add a Macroscopic data set to Material ID="{0}" ' \
-                  'with a macroscopic value "{1}" as an incompatible data ' \
+            msg = 'Unable to add a Macroscopic data set to Material ID="{}" ' \
+                  'with a macroscopic value "{}" as an incompatible data ' \
                   'member (i.e., nuclide, element, or S(a,b) table) ' \
                   'has already been added'.format(self._id, macroscopic)
             raise ValueError(msg)
 
         if not isinstance(macroscopic, string_types + (openmc.Macroscopic,)):
-            msg = 'Unable to add a Macroscopic to Material ID="{0}" with a ' \
-                  'non-Macroscopic value "{1}"'.format(self._id, macroscopic)
+            msg = 'Unable to add a Macroscopic to Material ID="{}" with a ' \
+                  'non-Macroscopic value "{}"'.format(self._id, macroscopic)
             raise ValueError(msg)
 
         if isinstance(macroscopic, openmc.Macroscopic):
@@ -398,7 +411,7 @@ class Material(object):
         if self._macroscopic is None:
             self._macroscopic = macroscopic
         else:
-            msg = 'Unable to add a Macroscopic to Material ID="{0}". ' \
+            msg = 'Unable to add a Macroscopic to Material ID="{}". ' \
                   'Only one Macroscopic allowed per ' \
                   'Material.'.format(self._id)
             raise ValueError(msg)
@@ -422,7 +435,7 @@ class Material(object):
         """
 
         if not isinstance(macroscopic, openmc.Macroscopic):
-            msg = 'Unable to remove a Macroscopic "{0}" in Material ID="{1}" ' \
+            msg = 'Unable to remove a Macroscopic "{}" in Material ID="{}" ' \
                   'since it is not a Macroscopic'.format(self._id, macroscopic)
             raise ValueError(msg)
 
@@ -450,23 +463,23 @@ class Material(object):
         """
 
         if self._macroscopic is not None:
-            msg = 'Unable to add an Element to Material ID="{0}" as a ' \
+            msg = 'Unable to add an Element to Material ID="{}" as a ' \
                   'macroscopic data-set has already been added'.format(self._id)
             raise ValueError(msg)
 
         if not isinstance(element, string_types + (openmc.Element,)):
-            msg = 'Unable to add an Element to Material ID="{0}" with a ' \
-                  'non-Element value "{1}"'.format(self._id, element)
+            msg = 'Unable to add an Element to Material ID="{}" with a ' \
+                  'non-Element value "{}"'.format(self._id, element)
             raise ValueError(msg)
 
         if not isinstance(percent, Real):
-            msg = 'Unable to add an Element to Material ID="{0}" with a ' \
-                  'non-floating point value "{1}"'.format(self._id, percent)
+            msg = 'Unable to add an Element to Material ID="{}" with a ' \
+                  'non-floating point value "{}"'.format(self._id, percent)
             raise ValueError(msg)
 
         if percent_type not in ['ao', 'wo']:
-            msg = 'Unable to add an Element to Material ID="{0}" with a ' \
-                  'percent type "{1}"'.format(self._id, percent_type)
+            msg = 'Unable to add an Element to Material ID="{}" with a ' \
+                  'percent type "{}"'.format(self._id, percent_type)
             raise ValueError(msg)
 
         # Copy this Element to separate it from same Element in other Materials
@@ -477,14 +490,14 @@ class Material(object):
 
         if enrichment is not None:
             if not isinstance(enrichment, Real):
-                msg = 'Unable to add an Element to Material ID="{0}" with a ' \
-                      'non-floating point enrichment value "{1}"'\
+                msg = 'Unable to add an Element to Material ID="{}" with a ' \
+                      'non-floating point enrichment value "{}"'\
                       .format(self._id, enrichment)
                 raise ValueError(msg)
 
             elif element.name != 'U':
-                msg = 'Unable to use enrichment for element {0} which is not ' \
-                      'uranium for Material ID="{1}"'.format(element.name,
+                msg = 'Unable to use enrichment for element {} which is not ' \
+                      'uranium for Material ID="{}"'.format(element.name,
                                                              self._id)
                 raise ValueError(msg)
 
@@ -493,8 +506,8 @@ class Material(object):
             cv.check_greater_than('enrichment', enrichment, 0., equality=True)
 
             if enrichment > 5.0:
-                msg = 'A uranium enrichment of {0} was given for Material ID='\
-                      '"{1}". OpenMC assumes the U234/U235 mass ratio is '\
+                msg = 'A uranium enrichment of {} was given for Material ID='\
+                      '"{}". OpenMC assumes the U234/U235 mass ratio is '\
                       'constant at 0.008, which is only valid at low ' \
                       'enrichments. Consider setting the isotopic ' \
                       'composition manually for enrichments over 5%.'.\
@@ -514,7 +527,7 @@ class Material(object):
         """
 
         if not isinstance(element, openmc.Element):
-            msg = 'Unable to remove "{0}" in Material ID="{1}" ' \
+            msg = 'Unable to remove "{}" in Material ID="{}" ' \
                   'since it is not an Element'.format(self.id, element)
             raise ValueError(msg)
 
@@ -534,13 +547,13 @@ class Material(object):
         """
 
         if self._macroscopic is not None:
-            msg = 'Unable to add an S(a,b) table to Material ID="{0}" as a ' \
+            msg = 'Unable to add an S(a,b) table to Material ID="{}" as a ' \
                   'macroscopic data-set has already been added'.format(self._id)
             raise ValueError(msg)
 
         if not isinstance(name, string_types):
-            msg = 'Unable to add an S(a,b) table to Material ID="{0}" with a ' \
-                        'non-string table name "{1}"'.format(self._id, name)
+            msg = 'Unable to add an S(a,b) table to Material ID="{}" with a ' \
+                        'non-string table name "{}"'.format(self._id, name)
             raise ValueError(msg)
 
         new_name = openmc.data.get_thermal_name(name)

--- a/openmc/summary.py
+++ b/openmc/summary.py
@@ -97,23 +97,25 @@ class Summary(object):
         # Values   - Material objects
         self.materials = {}
 
-        for key in self._f['materials'].keys():
+        for key, group in self._f['materials'].items():
             if key == 'n_materials':
                 continue
 
             material_id = int(key.lstrip('material '))
-            index = self._f['materials'][key]['index'].value
-            name = self._f['materials'][key]['name'].value.decode()
-            density = self._f['materials'][key]['atom_density'].value
-            nuc_densities = self._f['materials'][key]['nuclide_densities'][...]
-            nuclides = self._f['materials'][key]['nuclides'].value
+
+            index = group['index'].value
+            name = group['name'].value.decode()
+            density = group['atom_density'].value
+            nuc_densities = group['nuclide_densities'][...]
+            nuclides = group['nuclides'].value
 
             # Create the Material
             material = openmc.Material(material_id=material_id, name=name)
+            material.depletable = bool(group.attrs['depletable'])
 
             # Read the names of the S(a,b) tables for this Material and add them
-            if 'sab_names' in self._f['materials'][key]:
-                sab_tables = self._f['materials'][key]['sab_names'].value
+            if 'sab_names' in group:
+                sab_tables = group['sab_names'].value
                 for sab_table in sab_tables:
                     name = sab_table.decode()
                     material.add_s_alpha_beta(name)

--- a/src/constants.F90
+++ b/src/constants.F90
@@ -424,7 +424,8 @@ module constants
        MODE_FIXEDSOURCE = 1, & ! Fixed source mode
        MODE_EIGENVALUE  = 2, & ! K eigenvalue mode
        MODE_PLOTTING    = 3, & ! Plotting mode
-       MODE_PARTICLE    = 4    ! Particle restart mode
+       MODE_PARTICLE    = 4, & ! Particle restart mode
+       MODE_VOLUME      = 5    ! Volume calculation mode
 
   !=============================================================================
   ! CMFD CONSTANTS

--- a/src/finalize.F90
+++ b/src/finalize.F90
@@ -5,9 +5,6 @@ module finalize
   use global
   use hdf5_interface, only: hdf5_bank_t
   use message_passing
-  use output,         only: print_runtime, print_results, &
-                            print_overlap_check, write_tallies
-  use tally,          only: tally_statistics
 
   implicit none
 
@@ -21,30 +18,6 @@ contains
   subroutine openmc_finalize()
 
     integer :: hdf5_err
-
-    ! Start finalization timer
-    call time_finalize%start()
-
-    if (run_mode /= MODE_PLOTTING .and. run_mode /= MODE_PARTICLE) then
-      ! Calculate statistics for tallies and write to tallies.out
-      if (master) then
-        if (n_realizations > 1) call tally_statistics()
-      end if
-      if (output_tallies) then
-        if (master) call write_tallies()
-      end if
-      if (check_overlaps) call reduce_overlap_count()
-    end if
-
-    ! Stop timers and show timing statistics
-    call time_finalize%stop()
-    call time_total%stop()
-    if (master .and. (run_mode /= MODE_PLOTTING .and. &
-         run_mode /= MODE_PARTICLE)) then
-      call print_runtime()
-      call print_results()
-      if (check_overlaps) call print_overlap_check()
-    end if
 
     ! Deallocate arrays
     call free_memory()
@@ -64,23 +37,5 @@ contains
 #endif
 
   end subroutine openmc_finalize
-
-!===============================================================================
-! REDUCE_OVERLAP_COUNT accumulates cell overlap check counts to master
-!===============================================================================
-
-  subroutine reduce_overlap_count()
-
-#ifdef MPI
-      if (master) then
-        call MPI_REDUCE(MPI_IN_PLACE, overlap_check_cnt, n_cells, &
-             MPI_INTEGER8, MPI_SUM, 0, mpi_intracomm, mpi_err)
-      else
-        call MPI_REDUCE(overlap_check_cnt, overlap_check_cnt, n_cells, &
-             MPI_INTEGER8, MPI_SUM, 0, mpi_intracomm, mpi_err)
-      end if
-#endif
-
-  end subroutine reduce_overlap_count
 
 end module finalize

--- a/src/input_xml.F90
+++ b/src/input_xml.F90
@@ -2251,6 +2251,13 @@ contains
         call fatal_error("Must specify id of material in materials XML file")
       end if
 
+      ! Check if material is depletable
+      if (check_for_node(node_mat, "depletable")) then
+        call get_node_value(node_mat, "depletable", temp_str)
+        if (to_lower(temp_str) == "true" .or. temp_str == "1") &
+             mat % depletable = .true.
+      end if
+
       ! Check to make sure 'id' hasn't been used
       if (material_dict % has_key(mat % id)) then
         call fatal_error("Two or more materials use the same unique ID: " &

--- a/src/input_xml.F90
+++ b/src/input_xml.F90
@@ -264,16 +264,18 @@ contains
       end if
     end if
 
-    ! Read run parameters
-    call get_run_parameters(node_mode)
+    if (run_mode == MODE_EIGENVALUE .or. run_mode == MODE_FIXEDSOURCE) then
+      ! Read run parameters
+      call get_run_parameters(node_mode)
 
-    ! Check number of active batches, inactive batches, and particles
-    if (n_active <= 0) then
-      call fatal_error("Number of active batches must be greater than zero.")
-    elseif (n_inactive < 0) then
-      call fatal_error("Number of inactive batches must be non-negative.")
-    elseif (n_particles <= 0) then
-      call fatal_error("Number of particles must be greater than zero.")
+      ! Check number of active batches, inactive batches, and particles
+      if (n_active <= 0) then
+        call fatal_error("Number of active batches must be greater than zero.")
+      elseif (n_inactive < 0) then
+        call fatal_error("Number of inactive batches must be non-negative.")
+      elseif (n_particles <= 0) then
+        call fatal_error("Number of particles must be greater than zero.")
+      end if
     end if
 
     ! Copy random number seed if specified
@@ -317,7 +319,10 @@ contains
     ! Get point to list of <source> elements and make sure there is at least one
     call get_node_list(doc, "source", node_source_list)
     n = get_list_size(node_source_list)
-    if (n == 0) call fatal_error("No source specified in settings XML file.")
+
+    if (run_mode == MODE_EIGENVALUE .or. run_mode == MODE_FIXEDSOURCE) then
+      if (n == 0) call fatal_error("No source specified in settings XML file.")
+    end if
 
     ! Allocate array for sources
     allocate(external_source(n))

--- a/src/input_xml.F90
+++ b/src/input_xml.F90
@@ -79,7 +79,6 @@ contains
     integer :: temp_int
     integer :: temp_int_array3(3)
     integer, allocatable :: temp_int_array(:)
-    integer(8) :: temp_long
     real(8), allocatable :: temp_real(:)
     integer :: n_tracks
     logical :: file_exists
@@ -223,44 +222,47 @@ contains
       end if
     end if
 
-    if (check_for_node(doc, "run_mode")) then
-      call get_node_value(doc, "run_mode", temp_str)
-      select case (to_lower(temp_str))
-      case ("eigenvalue")
-        run_mode = MODE_EIGENVALUE
-      case ("fixed source")
-        run_mode = MODE_FIXEDSOURCE
-      case ("plot")
-        run_mode = MODE_PLOTTING
-      case ("particle restart")
-        run_mode = MODE_PARTICLE
-      case ("volume")
-        run_mode = MODE_VOLUME
-      end select
+    ! Check run mode if it hasn't been set from the command line
+    if (run_mode == NONE) then
+      if (check_for_node(doc, "run_mode")) then
+        call get_node_value(doc, "run_mode", temp_str)
+        select case (to_lower(temp_str))
+        case ("eigenvalue")
+          run_mode = MODE_EIGENVALUE
+        case ("fixed source")
+          run_mode = MODE_FIXEDSOURCE
+        case ("plot")
+          run_mode = MODE_PLOTTING
+        case ("particle restart")
+          run_mode = MODE_PARTICLE
+        case ("volume")
+          run_mode = MODE_VOLUME
+        end select
 
-      ! Assume XML specifics <particles>, <batches>, etc. directly
-      node_mode => doc
-    else
-      call warning("<run_mode> should be specified.")
+        ! Assume XML specifics <particles>, <batches>, etc. directly
+        node_mode => doc
+      else
+        call warning("<run_mode> should be specified.")
 
-      ! Make sure that either eigenvalue or fixed source was specified
-      if (.not. check_for_node(doc, "eigenvalue") .and. &
-           .not. check_for_node(doc, "fixed_source")) then
-        call fatal_error("<eigenvalue> or <fixed_source> not specified.")
-      end if
+        ! Make sure that either eigenvalue or fixed source was specified
+        if (.not. check_for_node(doc, "eigenvalue") .and. &
+             .not. check_for_node(doc, "fixed_source")) then
+          call fatal_error("<eigenvalue> or <fixed_source> not specified.")
+        end if
 
-      if (check_for_node(doc, "eigenvalue")) then
-        ! Set run mode
-        if (run_mode == NONE) run_mode = MODE_EIGENVALUE
+        if (check_for_node(doc, "eigenvalue")) then
+          ! Set run mode
+          if (run_mode == NONE) run_mode = MODE_EIGENVALUE
 
-        ! Get pointer to eigenvalue XML block
-        call get_node_ptr(doc, "eigenvalue", node_mode)
-      elseif (check_for_node(doc, "fixed_source")) then
-        ! Set run mode
-        if (run_mode == NONE) run_mode = MODE_FIXEDSOURCE
+          ! Get pointer to eigenvalue XML block
+          call get_node_ptr(doc, "eigenvalue", node_mode)
+        elseif (check_for_node(doc, "fixed_source")) then
+          ! Set run mode
+          if (run_mode == NONE) run_mode = MODE_FIXEDSOURCE
 
-        ! Get pointer to fixed_source XML block
-        call get_node_ptr(doc, "fixed_source", node_mode)
+          ! Get pointer to fixed_source XML block
+          call get_node_ptr(doc, "fixed_source", node_mode)
+        end if
       end if
     end if
 

--- a/src/main.F90
+++ b/src/main.F90
@@ -8,6 +8,7 @@ program main
   use particle_restart,  only: run_particle_restart
   use plot,              only: run_plot
   use simulation,        only: run_simulation
+  use volume_calc,       only: run_volume_calculations
 
   implicit none
 
@@ -26,6 +27,8 @@ program main
     call run_plot()
   case (MODE_PARTICLE)
     if (master) call run_particle_restart()
+  case (MODE_VOLUME)
+    call run_volume_calculations()
   end select
 
   ! finalize run

--- a/src/material_header.F90
+++ b/src/material_header.F90
@@ -31,8 +31,9 @@ module material_header
     character(20), allocatable :: names(:)     ! isotope names
     character(20), allocatable :: sab_names(:) ! name of S(a,b) table
 
-    ! Does this material contain fissionable nuclides?
+    ! Does this material contain fissionable nuclides? Is it depletable?
     logical :: fissionable = .false.
+    logical :: depletable = .false.
 
     ! enforce isotropic scattering in lab
     logical, allocatable :: p0(:)

--- a/src/simulation.F90
+++ b/src/simulation.F90
@@ -39,9 +39,6 @@ contains
     type(Particle) :: p
     integer(8)     :: i_work
 
-    ! Volume calculations
-    if (size(volume_calcs) > 0) call run_volume_calculations()
-
     if (.not. restart_run) call initialize_source()
 
     ! Display header

--- a/src/summary.F90
+++ b/src/summary.F90
@@ -536,6 +536,12 @@ contains
       material_group = create_group(materials_group, "material " // &
            trim(to_str(m%id)))
 
+      if (m % depletable) then
+        call write_attribute(material_group, "depletable", 1)
+      else
+        call write_attribute(material_group, "depletable", 0)
+      end if
+
       ! Write internal OpenMC index for this material
       call write_dataset(material_group, "index", i)
 

--- a/src/timer_header.F90
+++ b/src/timer_header.F90
@@ -42,11 +42,11 @@ contains
 
   function timer_get_value(self) result(elapsed)
     class(Timer), intent(in) :: self   ! the timer
-    real(8)                 :: elapsed ! total elapsed time
+    real(8)                  :: elapsed ! total elapsed time
 
     integer(8) :: end_counts   ! current number of counts
     integer(8) :: count_rate   ! system-dependent counting rate
-    real    :: elapsed_time ! elapsed time since last start
+    real(8)    :: elapsed_time ! elapsed time since last start
 
     if (self % running) then
       call system_clock(end_counts, count_rate)

--- a/tests/test_asymmetric_lattice/inputs_true.dat
+++ b/tests/test_asymmetric_lattice/inputs_true.dat
@@ -205,11 +205,10 @@
 </materials>
 <?xml version='1.0' encoding='utf-8'?>
 <settings>
-    <eigenvalue>
-        <particles>100</particles>
-        <batches>10</batches>
-        <inactive>5</inactive>
-    </eigenvalue>
+    <run_mode>eigenvalue</run_mode>
+    <particles>100</particles>
+    <batches>10</batches>
+    <inactive>5</inactive>
     <source strength="1.0">
         <space type="fission">
             <parameters>-32 -32 0 32 32 32</parameters>

--- a/tests/test_cmfd_feed/settings.xml
+++ b/tests/test_cmfd_feed/settings.xml
@@ -2,11 +2,10 @@
 <settings>
 
   <!-- Parameters for criticality calculation -->
-  <eigenvalue>
-    <batches>20</batches>
-    <inactive>10</inactive>
-    <particles>1000</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>20</batches>
+  <inactive>10</inactive>
+  <particles>1000</particles>
 
   <!-- How verbose output should be -->
   <verbosity value="7" />
@@ -19,7 +18,7 @@
     </space>
   </source>
 
-  <!-- Shannon Entropy --> 
+  <!-- Shannon Entropy -->
   <entropy>
     <dimension> 10 1 1 </dimension>
     <lower_left> -10.0 -1.0 -1.0 </lower_left>

--- a/tests/test_cmfd_nofeed/settings.xml
+++ b/tests/test_cmfd_nofeed/settings.xml
@@ -2,11 +2,10 @@
 <settings>
 
   <!-- Parameters for criticality calculation -->
-  <eigenvalue>
-    <batches>20</batches>
-    <inactive>10</inactive>
-    <particles>1000</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>20</batches>
+  <inactive>10</inactive>
+  <particles>1000</particles>
 
   <!-- How verbose output should be -->
   <verbosity value="7" />
@@ -19,7 +18,7 @@
     </space>
   </source>
 
-  <!-- Shannon Entropy --> 
+  <!-- Shannon Entropy -->
   <entropy>
     <dimension> 10 1 1 </dimension>
     <lower_left> -10.0 -1.0 -1.0 </lower_left>

--- a/tests/test_complex_cell/settings.xml
+++ b/tests/test_complex_cell/settings.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0"?>
 <settings>
 
-  <eigenvalue>
-    <batches>10</batches>
-    <inactive>5</inactive>
-    <particles>1000</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>10</batches>
+  <inactive>5</inactive>
+  <particles>1000</particles>
 
   <source>
     <space type="box">

--- a/tests/test_confidence_intervals/settings.xml
+++ b/tests/test_confidence_intervals/settings.xml
@@ -3,11 +3,10 @@
 
   <confidence_intervals>true</confidence_intervals>
 
-  <eigenvalue>
-    <batches>10</batches>
-    <inactive>2</inactive>
-    <particles>100</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>10</batches>
+  <inactive>2</inactive>
+  <particles>100</particles>
 
   <source>
     <space type="box">

--- a/tests/test_create_fission_neutrons/inputs_true.dat
+++ b/tests/test_create_fission_neutrons/inputs_true.dat
@@ -18,10 +18,9 @@
 </materials>
 <?xml version='1.0' encoding='utf-8'?>
 <settings>
-    <fixed_source>
-        <particles>100</particles>
-        <batches>10</batches>
-    </fixed_source>
+    <run_mode>fixed source</run_mode>
+    <particles>100</particles>
+    <batches>10</batches>
     <source strength="1.0">
         <space type="box">
             <parameters>-1 -1 -1 1 1 1</parameters>

--- a/tests/test_density/settings.xml
+++ b/tests/test_density/settings.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0"?>
 <settings>
 
-  <eigenvalue>
-    <batches>10</batches>
-    <inactive>5</inactive>
-    <particles>1000</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>10</batches>
+  <inactive>5</inactive>
+  <particles>1000</particles>
 
   <source>
     <space type="box">

--- a/tests/test_diff_tally/inputs_true.dat
+++ b/tests/test_diff_tally/inputs_true.dat
@@ -297,11 +297,10 @@
 </materials>
 <?xml version='1.0' encoding='utf-8'?>
 <settings>
-    <eigenvalue>
-        <particles>100</particles>
-        <batches>3</batches>
-        <inactive>0</inactive>
-    </eigenvalue>
+    <run_mode>eigenvalue</run_mode>
+    <particles>100</particles>
+    <batches>3</batches>
+    <inactive>0</inactive>
     <source strength="1.0">
         <space type="box">
             <parameters>-160 -160 -183 160 160 183</parameters>

--- a/tests/test_distribmat/inputs_true.dat
+++ b/tests/test_distribmat/inputs_true.dat
@@ -37,11 +37,10 @@
 </materials>
 <?xml version='1.0' encoding='utf-8'?>
 <settings>
-    <eigenvalue>
-        <particles>1000</particles>
-        <batches>5</batches>
-        <inactive>0</inactive>
-    </eigenvalue>
+    <run_mode>eigenvalue</run_mode>
+    <particles>1000</particles>
+    <batches>5</batches>
+    <inactive>0</inactive>
     <source strength="1.0">
         <space type="box">
             <parameters>-1 -1 -1 1 1 1</parameters>

--- a/tests/test_eigenvalue_genperbatch/settings.xml
+++ b/tests/test_eigenvalue_genperbatch/settings.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0"?>
 <settings>
 
-  <eigenvalue>
-    <batches>7</batches>
-    <inactive>3</inactive>
-    <particles>1000</particles>
-    <generations_per_batch>3</generations_per_batch>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>7</batches>
+  <inactive>3</inactive>
+  <particles>1000</particles>
+  <generations_per_batch>3</generations_per_batch>
 
   <source>
     <space type="box">

--- a/tests/test_eigenvalue_no_inactive/settings.xml
+++ b/tests/test_eigenvalue_no_inactive/settings.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0"?>
 <settings>
 
-  <eigenvalue>
-    <batches>10</batches>
-    <inactive>0</inactive>
-    <particles>1000</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>10</batches>
+  <inactive>0</inactive>
+  <particles>1000</particles>
 
   <source>
     <space type="box">

--- a/tests/test_energy_cutoff/inputs_true.dat
+++ b/tests/test_energy_cutoff/inputs_true.dat
@@ -17,10 +17,9 @@
 </materials>
 <?xml version='1.0' encoding='utf-8'?>
 <settings>
-    <fixed_source>
-        <particles>100</particles>
-        <batches>10</batches>
-    </fixed_source>
+    <run_mode>fixed source</run_mode>
+    <particles>100</particles>
+    <batches>10</batches>
     <source strength="1.0">
         <space type="box">
             <parameters>-1 -1 -1 1 1 1</parameters>

--- a/tests/test_energy_grid/settings.xml
+++ b/tests/test_energy_grid/settings.xml
@@ -3,11 +3,10 @@
 
   <log_grid_bins>20000</log_grid_bins>
 
-  <eigenvalue>
-    <batches>10</batches>
-    <inactive>5</inactive>
-    <particles>1000</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>10</batches>
+  <inactive>5</inactive>
+  <particles>1000</particles>
 
   <source>
     <space type="box">

--- a/tests/test_energy_laws/settings.xml
+++ b/tests/test_energy_laws/settings.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0"?>
 <settings>
-  <eigenvalue>
-    <batches>10</batches>
-    <inactive>5</inactive>
-    <particles>1000</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>10</batches>
+  <inactive>5</inactive>
+  <particles>1000</particles>
   <source>
     <space type="point" parameters="0. 0. 0." />
   </source>

--- a/tests/test_entropy/settings.xml
+++ b/tests/test_entropy/settings.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0"?>
 <settings>
 
-  <eigenvalue>
-    <batches>10</batches>
-    <inactive>5</inactive>
-    <particles>1000</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>10</batches>
+  <inactive>5</inactive>
+  <particles>1000</particles>
 
   <source>
     <space type="box">

--- a/tests/test_filter_distribcell/case-1/settings.xml
+++ b/tests/test_filter_distribcell/case-1/settings.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0"?>
 <settings>
 
-  <eigenvalue>
-    <batches>1</batches>
-    <inactive>0</inactive>
-    <particles>1000</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>1</batches>
+  <inactive>0</inactive>
+  <particles>1000</particles>
 
   <source>
     <space type="box">

--- a/tests/test_filter_distribcell/case-2/settings.xml
+++ b/tests/test_filter_distribcell/case-2/settings.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0"?>
 <settings>
 
-  <eigenvalue>
-    <batches>1</batches>
-    <inactive>0</inactive>
-    <particles>1000</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>1</batches>
+  <inactive>0</inactive>
+  <particles>1000</particles>
 
   <source>
     <space type="box">

--- a/tests/test_filter_distribcell/case-3/settings.xml
+++ b/tests/test_filter_distribcell/case-3/settings.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0"?>
 <settings>
 
-  <eigenvalue>
-    <batches>3</batches>
-    <inactive>0</inactive>
-    <particles>100</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>3</batches>
+  <inactive>0</inactive>
+  <particles>100</particles>
 
   <source>
     <space type="box">

--- a/tests/test_filter_distribcell/case-4/settings.xml
+++ b/tests/test_filter_distribcell/case-4/settings.xml
@@ -1,13 +1,12 @@
 <?xml version='1.0' encoding='utf-8'?>
 <settings>
-    <eigenvalue>
-        <particles>1000</particles>
-    <batches>1</batches>
-    <inactive>0</inactive>
-    </eigenvalue>
-<source>
-        <space type="box">
-            <parameters>-1 -1 -1 1 1 1</parameters>
-        </space>
-    </source>
+  <run_mode>eigenvalue</run_mode>
+  <particles>1000</particles>
+  <batches>1</batches>
+  <inactive>0</inactive>
+  <source>
+    <space type="box">
+      <parameters>-1 -1 -1 1 1 1</parameters>
+    </space>
+  </source>
 </settings>

--- a/tests/test_filter_energyfun/inputs_true.dat
+++ b/tests/test_filter_energyfun/inputs_true.dat
@@ -298,11 +298,10 @@
 </materials>
 <?xml version='1.0' encoding='utf-8'?>
 <settings>
-    <eigenvalue>
-        <particles>100</particles>
-        <batches>10</batches>
-        <inactive>5</inactive>
-    </eigenvalue>
+    <run_mode>eigenvalue</run_mode>
+    <particles>100</particles>
+    <batches>10</batches>
+    <inactive>5</inactive>
     <source strength="1.0">
         <space type="box">
             <parameters>-160 -160 -183 160 160 183</parameters>

--- a/tests/test_filter_mesh/inputs_true.dat
+++ b/tests/test_filter_mesh/inputs_true.dat
@@ -297,11 +297,10 @@
 </materials>
 <?xml version='1.0' encoding='utf-8'?>
 <settings>
-    <eigenvalue>
-        <particles>100</particles>
-        <batches>10</batches>
-        <inactive>5</inactive>
-    </eigenvalue>
+    <run_mode>eigenvalue</run_mode>
+    <particles>100</particles>
+    <batches>10</batches>
+    <inactive>5</inactive>
     <source strength="1.0">
         <space type="box">
             <parameters>-160 -160 -183 160 160 183</parameters>

--- a/tests/test_fixed_source/settings.xml
+++ b/tests/test_fixed_source/settings.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0"?>
 <settings>
 
-  <fixed_source>
-    <batches>10</batches>
-    <particles>100</particles>
-  </fixed_source>
+  <run_mode>fixed source</run_mode>
+  <batches>10</batches>
+  <particles>100</particles>
 
   <temperature_default>294</temperature_default>
 

--- a/tests/test_infinite_cell/settings.xml
+++ b/tests/test_infinite_cell/settings.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0"?>
 <settings>
 
-  <eigenvalue>
-    <batches>10</batches>
-    <inactive>5</inactive>
-    <particles>1000</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>10</batches>
+  <inactive>5</inactive>
+  <particles>1000</particles>
 
   <source>
     <space type="box">

--- a/tests/test_iso_in_lab/inputs_true.dat
+++ b/tests/test_iso_in_lab/inputs_true.dat
@@ -297,11 +297,10 @@
 </materials>
 <?xml version='1.0' encoding='utf-8'?>
 <settings>
-    <eigenvalue>
-        <particles>100</particles>
-        <batches>10</batches>
-        <inactive>5</inactive>
-    </eigenvalue>
+    <run_mode>eigenvalue</run_mode>
+    <particles>100</particles>
+    <batches>10</batches>
+    <inactive>5</inactive>
     <source strength="1.0">
         <space type="box">
             <parameters>-160 -160 -183 160 160 183</parameters>

--- a/tests/test_lattice/settings.xml
+++ b/tests/test_lattice/settings.xml
@@ -10,11 +10,10 @@
   ===============================================================
   -->
 
-  <eigenvalue>
-    <batches>10</batches>
-    <inactive>5</inactive>
-    <particles>100</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>10</batches>
+  <inactive>5</inactive>
+  <particles>100</particles>
 
   <source>
     <space type="box">

--- a/tests/test_lattice_hex/settings.xml
+++ b/tests/test_lattice_hex/settings.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings>
-  <eigenvalue>
-    <batches>10</batches>
-    <inactive>5</inactive>
-    <particles>500</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>10</batches>
+  <inactive>5</inactive>
+  <particles>500</particles>
 
   <source>
     <space type="box">

--- a/tests/test_lattice_mixed/settings.xml
+++ b/tests/test_lattice_mixed/settings.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings>
-  <eigenvalue>
-    <batches>10</batches>
-    <inactive>5</inactive>
-    <particles>500</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>10</batches>
+  <inactive>5</inactive>
+  <particles>500</particles>
 
   <source>
     <space type="box">

--- a/tests/test_lattice_multiple/settings.xml
+++ b/tests/test_lattice_multiple/settings.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0"?>
 <settings>
 
-  <eigenvalue>
-    <batches>10</batches>
-    <inactive>5</inactive>
-    <particles>100</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>10</batches>
+  <inactive>5</inactive>
+  <particles>100</particles>
 
   <source>
     <space type="box">

--- a/tests/test_mg_basic/inputs_true.dat
+++ b/tests/test_mg_basic/inputs_true.dat
@@ -84,11 +84,10 @@
 </materials>
 <?xml version='1.0' encoding='utf-8'?>
 <settings>
-    <eigenvalue>
-        <particles>100</particles>
-        <batches>10</batches>
-        <inactive>5</inactive>
-    </eigenvalue>
+    <run_mode>eigenvalue</run_mode>
+    <particles>100</particles>
+    <batches>10</batches>
+    <inactive>5</inactive>
     <source strength="1.0">
         <space type="box">
             <parameters>0.0 0.0 0.0 10.0 10.0 5.0</parameters>

--- a/tests/test_mg_max_order/inputs_true.dat
+++ b/tests/test_mg_max_order/inputs_true.dat
@@ -30,11 +30,10 @@
 </materials>
 <?xml version='1.0' encoding='utf-8'?>
 <settings>
-    <eigenvalue>
-        <particles>100</particles>
-        <batches>10</batches>
-        <inactive>5</inactive>
-    </eigenvalue>
+    <run_mode>eigenvalue</run_mode>
+    <particles>100</particles>
+    <batches>10</batches>
+    <inactive>5</inactive>
     <source strength="1.0">
         <space type="box">
             <parameters>0.0 0.0 0.0 10.0 10.0 5.0</parameters>

--- a/tests/test_mg_nuclide/inputs_true.dat
+++ b/tests/test_mg_nuclide/inputs_true.dat
@@ -84,11 +84,10 @@
 </materials>
 <?xml version='1.0' encoding='utf-8'?>
 <settings>
-    <eigenvalue>
-        <particles>100</particles>
-        <batches>10</batches>
-        <inactive>5</inactive>
-    </eigenvalue>
+    <run_mode>eigenvalue</run_mode>
+    <particles>100</particles>
+    <batches>10</batches>
+    <inactive>5</inactive>
     <source strength="1.0">
         <space type="box">
             <parameters>0.0 0.0 0.0 10.0 10.0 5.0</parameters>

--- a/tests/test_mg_tallies/inputs_true.dat
+++ b/tests/test_mg_tallies/inputs_true.dat
@@ -84,11 +84,10 @@
 </materials>
 <?xml version='1.0' encoding='utf-8'?>
 <settings>
-    <eigenvalue>
-        <particles>100</particles>
-        <batches>10</batches>
-        <inactive>5</inactive>
-    </eigenvalue>
+    <run_mode>eigenvalue</run_mode>
+    <particles>100</particles>
+    <batches>10</batches>
+    <inactive>5</inactive>
     <source strength="1.0">
         <space type="box">
             <parameters>0.0 0.0 0.0 10.0 10.0 5.0</parameters>

--- a/tests/test_mgxs_library_ce_to_mg/inputs_true.dat
+++ b/tests/test_mgxs_library_ce_to_mg/inputs_true.dat
@@ -38,11 +38,10 @@
 </materials>
 <?xml version='1.0' encoding='utf-8'?>
 <settings>
-    <eigenvalue>
-        <particles>100</particles>
-        <batches>10</batches>
-        <inactive>5</inactive>
-    </eigenvalue>
+    <run_mode>eigenvalue</run_mode>
+    <particles>100</particles>
+    <batches>10</batches>
+    <inactive>5</inactive>
     <source strength="1.0">
         <space type="fission">
             <parameters>-0.63 -0.63 -1 0.63 0.63 1</parameters>

--- a/tests/test_mgxs_library_ce_to_mg/test_mgxs_library_ce_to_mg.py
+++ b/tests/test_mgxs_library_ce_to_mg/test_mgxs_library_ce_to_mg.py
@@ -41,10 +41,9 @@ class MGXSTestHarness(PyAPITestHarness):
     def _run_openmc(self):
         # Initial run
         if self._opts.mpi_exec is not None:
-            returncode = openmc.run(mpi_procs=self._opts.mpi_np,
-                                    openmc_exec=self._opts.exe,
-                                    mpi_exec=self._opts.mpi_exec)
-
+            mpi_args = [self._opts.mpi_exec, '-n', self._opts.mpi_np]
+            returncode = openmc.run(openmc_exec=self._opts.exe,
+                                    mpi_args=mpi_args)
         else:
             returncode = openmc.run(openmc_exec=self._opts.exe)
 
@@ -74,10 +73,9 @@ class MGXSTestHarness(PyAPITestHarness):
 
         # Re-run MG mode.
         if self._opts.mpi_exec is not None:
-            returncode = openmc.run(mpi_procs=self._opts.mpi_np,
-                                    openmc_exec=self._opts.exe,
-                                    mpi_exec=self._opts.mpi_exec)
-
+            mpi_args = [self._opts.mpi_exec, '-n', self._opts.mpi_np]
+            returncode = openmc.run(openmc_exec=self._opts.exe,
+                                    mpi_args=mpi_args)
         else:
             returncode = openmc.run(openmc_exec=self._opts.exe)
 

--- a/tests/test_mgxs_library_condense/inputs_true.dat
+++ b/tests/test_mgxs_library_condense/inputs_true.dat
@@ -38,11 +38,10 @@
 </materials>
 <?xml version='1.0' encoding='utf-8'?>
 <settings>
-    <eigenvalue>
-        <particles>100</particles>
-        <batches>10</batches>
-        <inactive>5</inactive>
-    </eigenvalue>
+    <run_mode>eigenvalue</run_mode>
+    <particles>100</particles>
+    <batches>10</batches>
+    <inactive>5</inactive>
     <source strength="1.0">
         <space type="fission">
             <parameters>-0.63 -0.63 -1 0.63 0.63 1</parameters>

--- a/tests/test_mgxs_library_distribcell/inputs_true.dat
+++ b/tests/test_mgxs_library_distribcell/inputs_true.dat
@@ -65,11 +65,10 @@
 </materials>
 <?xml version='1.0' encoding='utf-8'?>
 <settings>
-    <eigenvalue>
-        <particles>100</particles>
-        <batches>10</batches>
-        <inactive>5</inactive>
-    </eigenvalue>
+    <run_mode>eigenvalue</run_mode>
+    <particles>100</particles>
+    <batches>10</batches>
+    <inactive>5</inactive>
     <source strength="1.0">
         <space type="fission">
             <parameters>-10.71 -10.71 -1 10.71 10.71 1</parameters>

--- a/tests/test_mgxs_library_hdf5/inputs_true.dat
+++ b/tests/test_mgxs_library_hdf5/inputs_true.dat
@@ -38,11 +38,10 @@
 </materials>
 <?xml version='1.0' encoding='utf-8'?>
 <settings>
-    <eigenvalue>
-        <particles>100</particles>
-        <batches>10</batches>
-        <inactive>5</inactive>
-    </eigenvalue>
+    <run_mode>eigenvalue</run_mode>
+    <particles>100</particles>
+    <batches>10</batches>
+    <inactive>5</inactive>
     <source strength="1.0">
         <space type="fission">
             <parameters>-0.63 -0.63 -1 0.63 0.63 1</parameters>

--- a/tests/test_mgxs_library_mesh/inputs_true.dat
+++ b/tests/test_mgxs_library_mesh/inputs_true.dat
@@ -297,11 +297,10 @@
 </materials>
 <?xml version='1.0' encoding='utf-8'?>
 <settings>
-    <eigenvalue>
-        <particles>100</particles>
-        <batches>10</batches>
-        <inactive>5</inactive>
-    </eigenvalue>
+    <run_mode>eigenvalue</run_mode>
+    <particles>100</particles>
+    <batches>10</batches>
+    <inactive>5</inactive>
     <source strength="1.0">
         <space type="box">
             <parameters>-160 -160 -183 160 160 183</parameters>

--- a/tests/test_mgxs_library_no_nuclides/inputs_true.dat
+++ b/tests/test_mgxs_library_no_nuclides/inputs_true.dat
@@ -38,11 +38,10 @@
 </materials>
 <?xml version='1.0' encoding='utf-8'?>
 <settings>
-    <eigenvalue>
-        <particles>100</particles>
-        <batches>10</batches>
-        <inactive>5</inactive>
-    </eigenvalue>
+    <run_mode>eigenvalue</run_mode>
+    <particles>100</particles>
+    <batches>10</batches>
+    <inactive>5</inactive>
     <source strength="1.0">
         <space type="fission">
             <parameters>-0.63 -0.63 -1 0.63 0.63 1</parameters>

--- a/tests/test_mgxs_library_nuclides/inputs_true.dat
+++ b/tests/test_mgxs_library_nuclides/inputs_true.dat
@@ -38,11 +38,10 @@
 </materials>
 <?xml version='1.0' encoding='utf-8'?>
 <settings>
-    <eigenvalue>
-        <particles>100</particles>
-        <batches>10</batches>
-        <inactive>5</inactive>
-    </eigenvalue>
+    <run_mode>eigenvalue</run_mode>
+    <particles>100</particles>
+    <batches>10</batches>
+    <inactive>5</inactive>
     <source strength="1.0">
         <space type="fission">
             <parameters>-0.63 -0.63 -1 0.63 0.63 1</parameters>

--- a/tests/test_multipole/inputs_true.dat
+++ b/tests/test_multipole/inputs_true.dat
@@ -34,11 +34,10 @@
 </materials>
 <?xml version='1.0' encoding='utf-8'?>
 <settings>
-    <eigenvalue>
-        <particles>1000</particles>
-        <batches>5</batches>
-        <inactive>0</inactive>
-    </eigenvalue>
+    <run_mode>eigenvalue</run_mode>
+    <particles>1000</particles>
+    <batches>5</batches>
+    <inactive>0</inactive>
     <source strength="1.0">
         <space type="box">
             <parameters>-1 -1 -1 1 1 1</parameters>

--- a/tests/test_output/settings.xml
+++ b/tests/test_output/settings.xml
@@ -3,11 +3,10 @@
 
   <output summary="true" />
 
-  <eigenvalue>
-    <batches>10</batches>
-    <inactive>5</inactive>
-    <particles>1000</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>10</batches>
+  <inactive>5</inactive>
+  <particles>1000</particles>
 
   <source>
     <space type="box">

--- a/tests/test_particle_restart_eigval/settings.xml
+++ b/tests/test_particle_restart_eigval/settings.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0"?>
 <settings>
 
-  <eigenvalue>
-    <batches>12</batches>
-    <inactive>5</inactive>
-    <particles>1200</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>12</batches>
+  <inactive>5</inactive>
+  <particles>1200</particles>
 
   <source>
     <space type="box">

--- a/tests/test_particle_restart_fixed/settings.xml
+++ b/tests/test_particle_restart_fixed/settings.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0"?>
 <settings>
 
-  <fixed_source>
-    <batches>12</batches>
-    <particles>1000</particles>
-  </fixed_source>
+  <run_mode>fixed source</run_mode>
+  <batches>12</batches>
+  <particles>1000</particles>
 
   <source>
     <space type="box">

--- a/tests/test_periodic/inputs_true.dat
+++ b/tests/test_periodic/inputs_true.dat
@@ -25,11 +25,10 @@
 </materials>
 <?xml version='1.0' encoding='utf-8'?>
 <settings>
-    <eigenvalue>
-        <particles>1000</particles>
-        <batches>4</batches>
-        <inactive>0</inactive>
-    </eigenvalue>
+    <run_mode>eigenvalue</run_mode>
+    <particles>1000</particles>
+    <batches>4</batches>
+    <inactive>0</inactive>
     <source strength="1.0">
         <space type="box">
             <parameters>-5.0 -5.0 -5.0 5.0 5.0 5.0</parameters>

--- a/tests/test_plot/settings.xml
+++ b/tests/test_plot/settings.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0"?>
 <settings>
 
-  <eigenvalue>
-    <batches>10</batches>
-    <inactive>5</inactive>
-    <particles>1000</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>10</batches>
+  <inactive>5</inactive>
+  <particles>1000</particles>
 
   <source>
     <space type="box">

--- a/tests/test_ptables_off/settings.xml
+++ b/tests/test_ptables_off/settings.xml
@@ -3,11 +3,10 @@
 
   <ptables>false</ptables>
 
-  <eigenvalue>
-    <batches>10</batches>
-    <inactive>5</inactive>
-    <particles>1000</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>10</batches>
+  <inactive>5</inactive>
+  <particles>1000</particles>
 
   <source>
     <space type="box">

--- a/tests/test_quadric_surfaces/settings.xml
+++ b/tests/test_quadric_surfaces/settings.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0"?>
 <settings>
 
-  <eigenvalue>
-    <batches>10</batches>
-    <inactive>5</inactive>
-    <particles>1000</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>10</batches>
+  <inactive>5</inactive>
+  <particles>1000</particles>
 
   <source>
     <space type="point" parameters="0. 0. 0." />

--- a/tests/test_reflective_plane/settings.xml
+++ b/tests/test_reflective_plane/settings.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0"?>
 <settings>
 
-  <eigenvalue>
-    <batches>10</batches>
-    <inactive>5</inactive>
-    <particles>1000</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>10</batches>
+  <inactive>5</inactive>
+  <particles>1000</particles>
 
   <source>
     <space type="box">

--- a/tests/test_resonance_scattering/inputs_true.dat
+++ b/tests/test_resonance_scattering/inputs_true.dat
@@ -15,11 +15,10 @@
 </materials>
 <?xml version='1.0' encoding='utf-8'?>
 <settings>
-    <eigenvalue>
-        <particles>1000</particles>
-        <batches>10</batches>
-        <inactive>5</inactive>
-    </eigenvalue>
+    <run_mode>eigenvalue</run_mode>
+    <particles>1000</particles>
+    <batches>10</batches>
+    <inactive>5</inactive>
     <source strength="1.0">
         <space type="box">
             <parameters>-4 -4 -4 4 4 4</parameters>

--- a/tests/test_rotation/settings.xml
+++ b/tests/test_rotation/settings.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0"?>
 <settings>
 
-  <eigenvalue>
-    <batches>10</batches>
-    <inactive>5</inactive>
-    <particles>1000</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>10</batches>
+  <inactive>5</inactive>
+  <particles>1000</particles>
 
   <source>
     <space type="box">

--- a/tests/test_salphabeta/settings.xml
+++ b/tests/test_salphabeta/settings.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0"?>
 <settings>
 
-  <eigenvalue>
-    <batches>10</batches>
-    <inactive>5</inactive>
-    <particles>1000</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>10</batches>
+  <inactive>5</inactive>
+  <particles>1000</particles>
 
   <source>
     <space type="box">

--- a/tests/test_score_current/settings.xml
+++ b/tests/test_score_current/settings.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0"?>
 <settings>
 
-  <eigenvalue>
-    <batches>10</batches>
-    <inactive>5</inactive>
-    <particles>100</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>10</batches>
+  <inactive>5</inactive>
+  <particles>100</particles>
 
   <source>
     <space type="box">

--- a/tests/test_seed/settings.xml
+++ b/tests/test_seed/settings.xml
@@ -3,11 +3,10 @@
 
   <seed>239407351</seed>
 
-  <eigenvalue>
-    <batches>10</batches>
-    <inactive>5</inactive>
-    <particles>1000</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>10</batches>
+  <inactive>5</inactive>
+  <particles>1000</particles>
 
   <source>
     <space type="box">

--- a/tests/test_source/inputs_true.dat
+++ b/tests/test_source/inputs_true.dat
@@ -13,11 +13,10 @@
 </materials>
 <?xml version='1.0' encoding='utf-8'?>
 <settings>
-    <eigenvalue>
-        <particles>1000</particles>
-        <batches>10</batches>
-        <inactive>5</inactive>
-    </eigenvalue>
+    <run_mode>eigenvalue</run_mode>
+    <particles>1000</particles>
+    <batches>10</batches>
+    <inactive>5</inactive>
     <source strength="0.5">
         <space type="cartesian">
             <x parameters="-3.0 3.0" type="uniform" />

--- a/tests/test_sourcepoint_batch/settings.xml
+++ b/tests/test_sourcepoint_batch/settings.xml
@@ -4,11 +4,10 @@
   <state_point batches="2 3 4 5 8"/>
   <source_point batches="2 5 8"/>
 
-  <eigenvalue>
-    <batches>10</batches>
-    <inactive>5</inactive>
-    <particles>1000</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>10</batches>
+  <inactive>5</inactive>
+  <particles>1000</particles>
 
   <source>
     <space type="box">

--- a/tests/test_sourcepoint_latest/settings.xml
+++ b/tests/test_sourcepoint_latest/settings.xml
@@ -3,11 +3,10 @@
 
   <source_point batches="0" overwrite_latest="true"/>
 
-  <eigenvalue>
-    <batches>10</batches>
-    <inactive>5</inactive>
-    <particles>1000</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>10</batches>
+  <inactive>5</inactive>
+  <particles>1000</particles>
 
   <source>
     <space type="box">

--- a/tests/test_sourcepoint_restart/settings.xml
+++ b/tests/test_sourcepoint_restart/settings.xml
@@ -4,11 +4,10 @@
   <state_point batches="7 10" />
   <source_point batches="7" separate="true" />
 
-  <eigenvalue>
-    <batches>10</batches>
-    <inactive>5</inactive>
-    <particles>1000</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>10</batches>
+  <inactive>5</inactive>
+  <particles>1000</particles>
 
   <source>
     <space type="box">

--- a/tests/test_statepoint_batch/settings.xml
+++ b/tests/test_statepoint_batch/settings.xml
@@ -3,11 +3,10 @@
 
   <state_point batches="3 6 9" />
 
-  <eigenvalue>
-    <batches>10</batches>
-    <inactive>5</inactive>
-    <particles>1000</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>10</batches>
+  <inactive>5</inactive>
+  <particles>1000</particles>
 
   <source>
     <space type="box">

--- a/tests/test_statepoint_restart/settings.xml
+++ b/tests/test_statepoint_restart/settings.xml
@@ -3,11 +3,10 @@
 
   <state_point batches="7 10" />
 
-  <eigenvalue>
-    <batches>10</batches>
-    <inactive>5</inactive>
-    <particles>1000</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>10</batches>
+  <inactive>5</inactive>
+  <particles>1000</particles>
 
   <source>
     <space type="box">

--- a/tests/test_statepoint_restart/test_statepoint_restart.py
+++ b/tests/test_statepoint_restart/test_statepoint_restart.py
@@ -50,11 +50,10 @@ class StatepointRestartTestHarness(TestHarness):
 
         # Run OpenMC
         if self._opts.mpi_exec is not None:
-            returncode = openmc.run(mpi_procs=self._opts.mpi_np,
-                                    restart_file=statepoint,
+            mpi_args = [self._opts.mpi_exec, '-n', self._opts.mpi_np]
+            returncode = openmc.run(restart_file=statepoint,
                                     openmc_exec=self._opts.exe,
-                                    mpi_exec=self._opts.mpi_exec)
-
+                                    mpi_args=mpi_args)
         else:
             returncode = openmc.run(openmc_exec=self._opts.exe,
                                     restart_file=statepoint)

--- a/tests/test_statepoint_sourcesep/settings.xml
+++ b/tests/test_statepoint_sourcesep/settings.xml
@@ -4,11 +4,10 @@
   <state_point batches="10" />
   <source_point separate="true" />
 
-  <eigenvalue>
-    <batches>10</batches>
-    <inactive>5</inactive>
-    <particles>1000</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>10</batches>
+  <inactive>5</inactive>
+  <particles>1000</particles>
 
   <source>
     <space type="box">

--- a/tests/test_survival_biasing/settings.xml
+++ b/tests/test_survival_biasing/settings.xml
@@ -8,11 +8,10 @@
     <weight_avg>1.2</weight_avg>
   </cutoff>
 
-  <eigenvalue>
-    <batches>10</batches>
-    <inactive>5</inactive>
-    <particles>1000</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>10</batches>
+  <inactive>5</inactive>
+  <particles>1000</particles>
 
   <source>
     <space type="box">

--- a/tests/test_tallies/inputs_true.dat
+++ b/tests/test_tallies/inputs_true.dat
@@ -297,11 +297,10 @@
 </materials>
 <?xml version='1.0' encoding='utf-8'?>
 <settings>
-    <eigenvalue>
-        <particles>400</particles>
-        <batches>5</batches>
-        <inactive>0</inactive>
-    </eigenvalue>
+    <run_mode>eigenvalue</run_mode>
+    <particles>400</particles>
+    <batches>5</batches>
+    <inactive>0</inactive>
     <source strength="1.0">
         <space type="box">
             <parameters>-160 -160 -183 160 160 183</parameters>

--- a/tests/test_tally_aggregation/inputs_true.dat
+++ b/tests/test_tally_aggregation/inputs_true.dat
@@ -297,11 +297,10 @@
 </materials>
 <?xml version='1.0' encoding='utf-8'?>
 <settings>
-    <eigenvalue>
-        <particles>100</particles>
-        <batches>10</batches>
-        <inactive>5</inactive>
-    </eigenvalue>
+    <run_mode>eigenvalue</run_mode>
+    <particles>100</particles>
+    <batches>10</batches>
+    <inactive>5</inactive>
     <source strength="1.0">
         <space type="box">
             <parameters>-160 -160 -183 160 160 183</parameters>

--- a/tests/test_tally_arithmetic/inputs_true.dat
+++ b/tests/test_tally_arithmetic/inputs_true.dat
@@ -297,11 +297,10 @@
 </materials>
 <?xml version='1.0' encoding='utf-8'?>
 <settings>
-    <eigenvalue>
-        <particles>100</particles>
-        <batches>10</batches>
-        <inactive>5</inactive>
-    </eigenvalue>
+    <run_mode>eigenvalue</run_mode>
+    <particles>100</particles>
+    <batches>10</batches>
+    <inactive>5</inactive>
     <source strength="1.0">
         <space type="box">
             <parameters>-160 -160 -183 160 160 183</parameters>

--- a/tests/test_tally_assumesep/settings.xml
+++ b/tests/test_tally_assumesep/settings.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0"?>
 <settings>
 
-  <eigenvalue>
-    <batches>10</batches>
-    <inactive>5</inactive>
-    <particles>100</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>10</batches>
+  <inactive>5</inactive>
+  <particles>100</particles>
 
   <source>
     <space type="box">

--- a/tests/test_tally_nuclides/settings.xml
+++ b/tests/test_tally_nuclides/settings.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0"?>
 <settings>
 
-  <eigenvalue>
-    <batches>10</batches>
-    <inactive>5</inactive>
-    <particles>100</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>10</batches>
+  <inactive>5</inactive>
+  <particles>100</particles>
 
   <source>
     <space>

--- a/tests/test_tally_slice_merge/inputs_true.dat
+++ b/tests/test_tally_slice_merge/inputs_true.dat
@@ -297,11 +297,10 @@
 </materials>
 <?xml version='1.0' encoding='utf-8'?>
 <settings>
-    <eigenvalue>
-        <particles>100</particles>
-        <batches>10</batches>
-        <inactive>5</inactive>
-    </eigenvalue>
+    <run_mode>eigenvalue</run_mode>
+    <particles>100</particles>
+    <batches>10</batches>
+    <inactive>5</inactive>
     <source strength="1.0">
         <space type="box">
             <parameters>-160 -160 -183 160 160 183</parameters>

--- a/tests/test_trace/settings.xml
+++ b/tests/test_trace/settings.xml
@@ -3,11 +3,10 @@
 
   <trace>5 1 453</trace>
 
-  <eigenvalue>
-    <batches>10</batches>
-    <inactive>5</inactive>
-    <particles>1000</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>10</batches>
+  <inactive>5</inactive>
+  <particles>1000</particles>
 
   <source>
     <space type="box">

--- a/tests/test_track_output/settings.xml
+++ b/tests/test_track_output/settings.xml
@@ -1,19 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings>
 
-<!--  <cross_sections> -->
-<!--   cross_sections.xml-->
-<!--  </cross_sections>-->
-
   <!-- Parameters for criticality calculation -->
-  <eigenvalue>
-    <batches>2</batches>
-    <inactive>0</inactive>
-    <particles>100</particles>
-  </eigenvalue>
-
-  <!-- How verbose output should be -->
-  <verbosity value="7" />
+  <run_mode>eigenvalue</run_mode>
+  <batches>2</batches>
+  <inactive>0</inactive>
+  <particles>100</particles>
 
   <!-- Starting source -->
   <source>
@@ -26,5 +18,5 @@
     1 1 1
     1 1 2
   </track>
-  
+
 </settings>

--- a/tests/test_translation/settings.xml
+++ b/tests/test_translation/settings.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0"?>
 <settings>
 
-  <eigenvalue>
-    <batches>10</batches>
-    <inactive>5</inactive>
-    <particles>1000</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>10</batches>
+  <inactive>5</inactive>
+  <particles>1000</particles>
 
   <source>
     <space type="box">

--- a/tests/test_trigger_batch_interval/settings.xml
+++ b/tests/test_trigger_batch_interval/settings.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0"?>
 <settings>
-   <eigenvalue>
-    <batches>15</batches>
-    <inactive>5</inactive>
-    <particles>1000</particles>
-    <keff_trigger>
-      <type>std_dev</type>
-      <threshold>0.004</threshold>
-    </keff_trigger>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>15</batches>
+  <inactive>5</inactive>
+  <particles>1000</particles>
+  <keff_trigger>
+    <type>std_dev</type>
+    <threshold>0.004</threshold>
+  </keff_trigger>
 
   <trigger>
     <active>true</active>

--- a/tests/test_trigger_no_batch_interval/settings.xml
+++ b/tests/test_trigger_no_batch_interval/settings.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0"?>
 <settings>
-   <eigenvalue>
-    <batches>15</batches>
-    <inactive>5</inactive>
-    <particles>1000</particles>
-    <keff_trigger>
-      <type>std_dev</type>
-      <threshold>0.004</threshold>
-    </keff_trigger>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>15</batches>
+  <inactive>5</inactive>
+  <particles>1000</particles>
+  <keff_trigger>
+    <type>std_dev</type>
+    <threshold>0.004</threshold>
+  </keff_trigger>
 
   <trigger>
     <active>true</active>

--- a/tests/test_trigger_no_status/settings.xml
+++ b/tests/test_trigger_no_status/settings.xml
@@ -1,20 +1,19 @@
 <?xml version="1.0"?>
 <settings>
-   <eigenvalue>
-    <batches>10</batches>
-    <inactive>5</inactive>
-    <particles>1000</particles>
-    <keff_trigger>
-      <type>std_dev</type>
-      <threshold>0.009</threshold>
-    </keff_trigger>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>10</batches>
+  <inactive>5</inactive>
+  <particles>1000</particles>
+  <keff_trigger>
+    <type>std_dev</type>
+    <threshold>0.009</threshold>
+  </keff_trigger>
   <trigger>
     <active>false</active>
     <max_batches>15</max_batches>
     <batch_interval>1</batch_interval>
   </trigger>
-  
+
 
   <source>
     <space>

--- a/tests/test_trigger_tallies/settings.xml
+++ b/tests/test_trigger_tallies/settings.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0"?>
 <settings>
-   <eigenvalue>
-    <batches>10</batches>
-    <inactive>5</inactive>
-    <particles>1000</particles>
-    <keff_trigger>
-      <type>std_dev</type>
-      <threshold>0.001</threshold>
-    </keff_trigger>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>10</batches>
+  <inactive>5</inactive>
+  <particles>1000</particles>
+  <keff_trigger>
+    <type>std_dev</type>
+    <threshold>0.001</threshold>
+  </keff_trigger>
 
   <trigger>
     <active>true</active>

--- a/tests/test_triso/inputs_true.dat
+++ b/tests/test_triso/inputs_true.dat
@@ -430,11 +430,10 @@
 </materials>
 <?xml version='1.0' encoding='utf-8'?>
 <settings>
-    <eigenvalue>
-        <particles>100</particles>
-        <batches>5</batches>
-        <inactive>0</inactive>
-    </eigenvalue>
+    <run_mode>eigenvalue</run_mode>
+    <particles>100</particles>
+    <batches>5</batches>
+    <inactive>0</inactive>
     <source strength="1.0">
         <space type="point">
             <parameters>0.0 0.0 0.0</parameters>

--- a/tests/test_uniform_fs/settings.xml
+++ b/tests/test_uniform_fs/settings.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0"?>
 <settings>
 
-  <eigenvalue>
-    <batches>10</batches>
-    <inactive>5</inactive>
-    <particles>1000</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>10</batches>
+  <inactive>5</inactive>
+  <particles>1000</particles>
 
   <source>
     <space type="box" parameters="-10 -10 -10 10 10 10" />

--- a/tests/test_universe/settings.xml
+++ b/tests/test_universe/settings.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0"?>
 <settings>
 
-  <eigenvalue>
-    <batches>10</batches>
-    <inactive>5</inactive>
-    <particles>1000</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>10</batches>
+  <inactive>5</inactive>
+  <particles>1000</particles>
 
   <source>
     <space type="box">

--- a/tests/test_void/settings.xml
+++ b/tests/test_void/settings.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0"?>
 <settings>
 
-  <eigenvalue>
-    <batches>10</batches>
-    <inactive>5</inactive>
-    <particles>100</particles>
-  </eigenvalue>
+  <run_mode>eigenvalue</run_mode>
+  <batches>10</batches>
+  <inactive>5</inactive>
+  <particles>100</particles>
 
   <source>
     <space>

--- a/tests/test_volume_calc/inputs_true.dat
+++ b/tests/test_volume_calc/inputs_true.dat
@@ -26,11 +26,10 @@
 </materials>
 <?xml version='1.0' encoding='utf-8'?>
 <settings>
-    <eigenvalue>
-        <particles>1000</particles>
-        <batches>4</batches>
-        <inactive>0</inactive>
-    </eigenvalue>
+    <run_mode>eigenvalue</run_mode>
+    <particles>1000</particles>
+    <batches>4</batches>
+    <inactive>0</inactive>
     <source strength="1.0">
         <space type="box">
             <parameters>-1.0 -1.0 -5.0 1.0 1.0 5.0</parameters>

--- a/tests/test_volume_calc/inputs_true.dat
+++ b/tests/test_volume_calc/inputs_true.dat
@@ -26,15 +26,7 @@
 </materials>
 <?xml version='1.0' encoding='utf-8'?>
 <settings>
-    <run_mode>eigenvalue</run_mode>
-    <particles>1000</particles>
-    <batches>4</batches>
-    <inactive>0</inactive>
-    <source strength="1.0">
-        <space type="box">
-            <parameters>-1.0 -1.0 -5.0 1.0 1.0 5.0</parameters>
-        </space>
-    </source>
+    <run_mode>volume</run_mode>
     <volume_calc>
         <domain_type>cell</domain_type>
         <domain_ids>1 2 3</domain_ids>

--- a/tests/test_volume_calc/results_true.dat
+++ b/tests/test_volume_calc/results_true.dat
@@ -1,4 +1,3 @@
-k-combined: 4.165450e-02 3.582533e-04
 Volume calculation 0
 Domain 1: 31.4693 +/- 0.0721 cm^3
 Domain 2: 2.0933 +/- 0.0310 cm^3

--- a/tests/test_volume_calc/test_volume_calc.py
+++ b/tests/test_volume_calc/test_volume_calc.py
@@ -52,22 +52,12 @@ class VolumeTest(PyAPITestHarness):
 
         # Define settings
         settings = openmc.Settings()
-        settings.particles = 1000
-        settings.batches = 4
-        settings.inactive = 0
-        settings.source = openmc.Source(space=openmc.stats.Box(
-            [-1., -1., -5.], [1., 1., 5.]))
+        settings.run_mode = 'volume'
         settings.volume_calculations = vol_calcs
         settings.export_to_xml()
 
     def _get_results(self):
-        # Read the statepoint file.
-        statepoint = os.path.join(os.getcwd(), self._sp_name)
-        sp = openmc.StatePoint(statepoint)
-
-        # Write out k-combined.
-        outstr = 'k-combined: {:12.6e} {:12.6e}\n'.format(*sp.k_combined)
-
+        outstr = ''
         for i, filename in enumerate(sorted(glob.glob(os.path.join(
                 os.getcwd(), 'volume_*.h5')))):
             outstr += 'Volume calculation {}\n'.format(i)
@@ -83,6 +73,9 @@ class VolumeTest(PyAPITestHarness):
 
         return outstr
 
+    def _test_output_created(self):
+        pass
+
 if __name__ == '__main__':
-    harness = VolumeTest('statepoint.4.h5')
+    harness = VolumeTest('')
     harness.main()

--- a/tests/testing_harness.py
+++ b/tests/testing_harness.py
@@ -24,7 +24,7 @@ class TestHarness(object):
         self.parser = OptionParser()
         self.parser.add_option('--exe', dest='exe', default='openmc')
         self.parser.add_option('--mpi_exec', dest='mpi_exec', default=None)
-        self.parser.add_option('--mpi_np', dest='mpi_np', type=int, default=2)
+        self.parser.add_option('--mpi_np', dest='mpi_np', default='2')
         self.parser.add_option('--update', dest='update', action='store_true',
                                default=False)
         self._opts = None
@@ -62,9 +62,9 @@ class TestHarness(object):
 
     def _run_openmc(self):
         if self._opts.mpi_exec is not None:
-            returncode = openmc.run(mpi_procs=self._opts.mpi_np,
-                                    openmc_exec=self._opts.exe,
-                                    mpi_exec=self._opts.mpi_exec)
+            returncode = openmc.run(
+                openmc_exec=self._opts.exe,
+                mpi_args=[self._opts.mpi_exec, '-n', self._opts.mpi_np])
 
         else:
             returncode = openmc.run(openmc_exec=self._opts.exe)
@@ -190,8 +190,7 @@ class ParticleRestartTestHarness(TestHarness):
         # Set arguments
         args = {'openmc_exec': self._opts.exe}
         if self._opts.mpi_exec is not None:
-            args.update({'mpi_procs': self._opts.mpi_np,
-                         'mpi_exec': self._opts.mpi_exec})
+            args['mpi_args'] = [self._opts.mpi_exec, '-n', self._opts.mpi_np]
 
         # Initial run
         returncode = openmc.run(**args)


### PR DESCRIPTION
The major change in this PR is addressing #789 by adding a `<run_mode>` element in the settings.xml format that indicates what mode OpenMC should be run in. `<eigenvalue>` and `<fixed_source>` have been removed, and the `<particles>`, `<batches>`, `<inactive>`, `<generations_per_batch>`, and `<keff_trigger>` elements are now children of `<settings>`. A user is now able to independently run a stochastic volume calculation which was not possible before.

A few other minor changes:
- I've added a `depletable` attribute to `openmc.Material`. OpenMC doesn't use this directly; rather it can be used by a downstream code to determine what materials are depletable.
- `openmc.run(...)` now takes an `mpi_args` argument that is a list of MPI arguments to be prepended, e.g. `openmc.run(..., mpi_args=['mpiexec', '-n', '16'])`. Often, a user needs to specify other arguments to `mpiexec` (I use `-bind-to` quite frequently) which is not possible with the current implementation.
- Fix documentation generation for `get_hexagonal_prism` and `get_rectangular_prism`.