### PR TITLE
Fix printing bug for tallies with AggregateNuclides

### DIFF
--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -195,7 +195,7 @@ class Tally(object):
             if isinstance(nuclide, openmc.Nuclide):
                 string += nuclide.name + ' '
             else:
-                string += nuclide + ' '
+                string += str(nuclide) + ' '
 
         string += '\n'
 


### PR DESCRIPTION
Hey, guys.  I'm just starting to get back in the saddle after my quals hiatus.  This PR fixes a small bug I found while preparing for the upcoming workshop at IRSN.  It occurs when you print a tally with an `AggregateNuclide`.  For example,
```python
u235_plus_u238 = distribcell.summation(nuclides=['U235', 'U238'])
print(u235_plus_u238)
```
gives
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-38-3445b4798372> in <module>()
      1 # Sum across nuclides
      2 u235_plus_u238 = distribcell.summation(nuclides=['U235', 'U238'])
----> 3 print(u235_plus_u238)

/home/smharper/openmc/openmc/tallies.py in __repr__(self)
    196                 string += nuclide.name + ' '
    197             else:
--> 198                 string += nuclide + ' '
    199 
    200         string += '\n'

TypeError: unsupported operand type(s) for +: 'AggregateNuclide' and 'str'
```

With this PR, you will get something that looks like
```
Tally
	ID             =	10004
	Name           =	
	Filters        =	DistribcellFilter
	Nuclides       =	sum(U235, U238) 
	Scores         =	['absorption', 'fission']
	Estimator      =	tracklength
```