### PR TITLE
Fix RELAX NG schema

### DIFF
--- a/src/relaxng/geometry.rnc
+++ b/src/relaxng/geometry.rnc
@@ -6,8 +6,8 @@ element geometry {
     (element universe { xsd:int } | attribute universe { xsd:int })? &
     (
       (element fill { xsd:int } | attribute fill { xsd:int }) |
-      (element material { ( xsd:int | "void" )+ } |
-        attribute material { ( xsd:int | "void" )+ })
+      (element material { list { ( xsd:int | "void" )+ } } |
+        attribute material { list { ( xsd:int | "void" )+ } })
     ) &
     (element temperature { list { xsd:double+ } } |
       attribute temperature { list { xsd:double+ } } )? &

--- a/src/relaxng/geometry.rng
+++ b/src/relaxng/geometry.rng
@@ -47,20 +47,24 @@
             </choice>
             <choice>
               <element name="material">
-                <oneOrMore>
-                  <choice>
-                    <data type="int"/>
-                    <value>void</value>
-                  </choice>
-                </oneOrMore>
+                <list>
+                  <oneOrMore>
+                    <choice>
+                      <data type="int"/>
+                      <value>void</value>
+                    </choice>
+                  </oneOrMore>
+                </list>
               </element>
               <attribute name="material">
-                <oneOrMore>
-                  <choice>
-                    <data type="int"/>
-                    <value>void</value>
-                  </choice>
-                </oneOrMore>
+                <list>
+                  <oneOrMore>
+                    <choice>
+                      <data type="int"/>
+                      <value>void</value>
+                    </choice>
+                  </oneOrMore>
+                </list>
               </attribute>
             </choice>
           </choice>

--- a/src/relaxng/settings.rnc
+++ b/src/relaxng/settings.rnc
@@ -51,6 +51,8 @@ element settings {
 
   element run_cmfd { xsd:boolean }? &
 
+  element run_mode { xsd:string }? &
+
   element seed { xsd:positiveInteger }? &
 
   element source {

--- a/src/relaxng/settings.rng
+++ b/src/relaxng/settings.rng
@@ -223,6 +223,11 @@
       </element>
     </optional>
     <optional>
+      <element name="run_mode">
+        <data type="string"/>
+      </element>
+    </optional>
+    <optional>
       <element name="seed">
         <data type="positiveInteger"/>
       </element>


### PR DESCRIPTION
This pull request fixes an error in the schema for geometry.xml (discussed [here](https://groups.google.com/d/topic/openmc-users/Ac1BQV_4ee4/discussion)) as well as an omission in the one for settings.xml (forgot to add the new `<run_mode>` element).