### PR TITLE
Modifying the global default temperature from 293.6 K to 293.607 K.

### DIFF
--- a/src/global.F90
+++ b/src/global.F90
@@ -102,7 +102,7 @@ module global
   integer :: temperature_method = TEMPERATURE_NEAREST
   logical :: temperature_multipole = .false.
   real(8) :: temperature_tolerance = 10.0_8
-  real(8) :: temperature_default = 293.6_8
+  real(8) :: temperature_default = 293.607_8
 
   ! ============================================================================
   ! MULTI-GROUP CROSS SECTION RELATED VARIABLES


### PR DESCRIPTION
This pull request fixes the issue mentioned in #729 by modifying the global default temperature from 293.6 K to 293.607 K (the lowest temperature for light water s(alpha,beta) table is around 293.60601 K in both ENDF71 and JEFF library).