### PR TITLE
Wrote method Geometry.get_all_surfaces()

### DIFF
--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -274,13 +274,7 @@ class Geometry(object):
         for cell in root_cells.values():
             reg = cell.region
             surfaces = reg.get_surfaces_from_region(surfaces)
-            
-        #surfaces = self._root_universe.
-        #for cell in self.get_all_cells().values():
-        #    self.get_surfaces_from_region(surfaces, cell.region)
         return surfaces
-    
-    
                 
     def get_materials_by_name(self, name, case_sensitive=False, matching=False):
         """Return a list of materials with matching names.

--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -257,7 +257,49 @@ class Geometry(object):
                     lattices[cell.fill.id] = cell.fill
 
         return lattices
+    
+    def get_all_surfaces(self):
+        """
+        Return all surfaces used in the geometry
 
+        Returns
+        -------
+        collections.OrderedDict
+            Dictionary mapping lattice IDs to :class:`openmc.Surface` instances
+
+        """
+        surfaces = OrderedDict()
+        
+        for cell in self.get_all_cells().values():
+            self.get_surfaces_from_region(surfaces, cell.region)
+        return surfaces
+    
+    def get_surfaces_from_region(self, surfaces, region):
+        """
+        Recursively find all the surfaces referenced by a region and return them
+        
+        Parameters
+        ----------
+        surfaces: collections.OrderedDict
+            Dictionary mapping lattice IDs to :class:`openmc.Surface` instances
+            
+        region: openmc.surface.Region
+            The region of space defined by Surfaces
+        Returns
+        -------
+        collections.OrderedDict
+            Dictionary mapping lattice IDs to :class:`openmc.Surface` instances
+
+        """
+        if isinstance(region, openmc.Halfspace):
+            s = region.surface
+            if s.id not in surfaces:
+                surfaces[s.id] = s
+        else:
+            for reg in region:
+                surfaces = self.get_surfaces_from_region(surfaces, reg)
+        return surfaces
+                
     def get_materials_by_name(self, name, case_sensitive=False, matching=False):
         """Return a list of materials with matching names.
 

--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -271,7 +271,7 @@ class Geometry(object):
         surfaces = OrderedDict()
         
         for cell in self.get_all_cells().values():
-            surfaces = cell.region.update_surfaces(surfaces)
+            surfaces = cell.region.get_surfaces(surfaces)
         return surfaces
                 
     def get_materials_by_name(self, name, case_sensitive=False, matching=False):

--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -265,7 +265,7 @@ class Geometry(object):
         Returns
         -------
         collections.OrderedDict
-            Dictionary mapping lattice IDs to :class:`openmc.Surface` instances
+            Dictionary mapping surface IDs to :class:`openmc.Surface` instances
 
         """
         surfaces = OrderedDict()

--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -270,10 +270,8 @@ class Geometry(object):
         """
         surfaces = OrderedDict()
         
-        root_cells = self._root_universe.cells
-        for cell in root_cells.values():
-            reg = cell.region
-            surfaces = reg.get_surfaces_from_region(surfaces)
+        for cell in self.get_all_cells().values():
+            surfaces = cell.region.get_surfaces_from_region(surfaces)
         return surfaces
                 
     def get_materials_by_name(self, name, case_sensitive=False, matching=False):

--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -270,35 +270,17 @@ class Geometry(object):
         """
         surfaces = OrderedDict()
         
-        for cell in self.get_all_cells().values():
-            self._get_surfaces_from_region(surfaces, cell.region)
+        root_cells = self._root_universe.cells
+        for cell in root_cells.values():
+            reg = cell.region
+            surfaces = reg.get_surfaces_from_region(surfaces)
+            
+        #surfaces = self._root_universe.
+        #for cell in self.get_all_cells().values():
+        #    self.get_surfaces_from_region(surfaces, cell.region)
         return surfaces
     
-    def _get_surfaces_from_region(self, surfaces, region):
-        """
-        Recursively find all the surfaces referenced by a region and return them
-        
-        Parameters
-        ----------
-        surfaces: collections.OrderedDict
-            Dictionary mapping surface IDs to :class:`openmc.Surface` instances
-            
-        region: openmc.surface.Region
-            The region of space defined by Surfaces
-        Returns
-        -------
-        collections.OrderedDict
-            Dictionary mapping surface IDs to :class:`openmc.Surface` instances
-
-        """
-        if isinstance(region, openmc.Halfspace):
-            s = region.surface
-            if s.id not in surfaces:
-                surfaces[s.id] = s
-        else:
-            for reg in region:
-                surfaces = self._get_surfaces_from_region(surfaces, reg)
-        return surfaces
+    
                 
     def get_materials_by_name(self, name, case_sensitive=False, matching=False):
         """Return a list of materials with matching names.

--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -271,10 +271,10 @@ class Geometry(object):
         surfaces = OrderedDict()
         
         for cell in self.get_all_cells().values():
-            self.get_surfaces_from_region(surfaces, cell.region)
+            self._get_surfaces_from_region(surfaces, cell.region)
         return surfaces
     
-    def get_surfaces_from_region(self, surfaces, region):
+    def _get_surfaces_from_region(self, surfaces, region):
         """
         Recursively find all the surfaces referenced by a region and return them
         
@@ -297,7 +297,7 @@ class Geometry(object):
                 surfaces[s.id] = s
         else:
             for reg in region:
-                surfaces = self.get_surfaces_from_region(surfaces, reg)
+                surfaces = self._get_surfaces_from_region(surfaces, reg)
         return surfaces
                 
     def get_materials_by_name(self, name, case_sensitive=False, matching=False):

--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -271,7 +271,7 @@ class Geometry(object):
         surfaces = OrderedDict()
         
         for cell in self.get_all_cells().values():
-            surfaces = cell.region.get_surfaces_from_region(surfaces)
+            surfaces = cell.region.get_surfaces(surfaces)
         return surfaces
                 
     def get_materials_by_name(self, name, case_sensitive=False, matching=False):

--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -271,7 +271,7 @@ class Geometry(object):
         surfaces = OrderedDict()
         
         for cell in self.get_all_cells().values():
-            surfaces = cell.region.get_surfaces(surfaces)
+            surfaces = cell.region.update_surfaces(surfaces)
         return surfaces
                 
     def get_materials_by_name(self, name, case_sensitive=False, matching=False):

--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -281,14 +281,14 @@ class Geometry(object):
         Parameters
         ----------
         surfaces: collections.OrderedDict
-            Dictionary mapping lattice IDs to :class:`openmc.Surface` instances
+            Dictionary mapping surface IDs to :class:`openmc.Surface` instances
             
         region: openmc.surface.Region
             The region of space defined by Surfaces
         Returns
         -------
         collections.OrderedDict
-            Dictionary mapping lattice IDs to :class:`openmc.Surface` instances
+            Dictionary mapping surface IDs to :class:`openmc.Surface` instances
 
         """
         if isinstance(region, openmc.Halfspace):

--- a/openmc/region.py
+++ b/openmc/region.py
@@ -46,7 +46,7 @@ class Region(object):
     def __ne__(self, other):
         return not self == other
 
-    def get_surfaces(self, surfaces=None):
+    def update_surfaces(self, surfaces=None):
         """
         Recursively find all the surfaces referenced by a region and return them
 
@@ -64,7 +64,7 @@ class Region(object):
         if not surfaces:
             surfaces = OrderedDict()
         for region in self:
-            surfaces = region.get_surfaces(surfaces)
+            surfaces = region.update_surfaces(surfaces)
         return surfaces
 
     @staticmethod
@@ -453,7 +453,7 @@ class Complement(Region):
             temp_region = ~self.node
         return temp_region.bounding_box
 
-    def get_surfaces(self, surfaces=None):
+    def update_surfaces(self, surfaces=None):
         """
         Recursively find and return all the surfaces referenced by the node
 
@@ -471,5 +471,5 @@ class Complement(Region):
         if not surfaces:
             surfaces = OrderedDict()
         for region in self.node:
-            surfaces = region.get_surfaces(surfaces)
+            surfaces = region.update_surfaces(surfaces)
         return surfaces

--- a/openmc/region.py
+++ b/openmc/region.py
@@ -46,7 +46,7 @@ class Region(object):
     def __ne__(self, other):
         return not self == other
 
-    def get_surfaces_from_region(self, surfaces = OrderedDict()):
+    def get_surfaces(self, surfaces=None):
         """
         Recursively find all the surfaces referenced by a region and return them
 
@@ -61,8 +61,10 @@ class Region(object):
             Dictionary mapping surface IDs to :class:`openmc.Surface` instances
 
         """
+        if not surfaces:
+            surfaces = OrderedDict()
         for region in self:
-            surfaces = region.get_surfaces_from_region(surfaces)
+            surfaces = region.get_surfaces(surfaces)
         return surfaces
 
     @staticmethod
@@ -451,10 +453,9 @@ class Complement(Region):
             temp_region = ~self.node
         return temp_region.bounding_box
 
-    def get_surfaces_from_region(self, surfaces = OrderedDict()):
+    def get_surfaces(self, surfaces=None):
         """
-        Recursively find all the surfaces referenced by the complement's node and return them
-        Overwrites method Region.get_surfaces_from_region()
+        Recursively find and return all the surfaces referenced by the node
 
         Parameters
         ----------
@@ -467,6 +468,8 @@ class Complement(Region):
             Dictionary mapping surface IDs to :class:`openmc.Surface` instances
 
         """
+        if not surfaces:
+            surfaces = OrderedDict()
         for region in self.node:
-            surfaces = region.get_surfaces_from_region(surfaces)
+            surfaces = region.get_surfaces(surfaces)
         return surfaces

--- a/openmc/region.py
+++ b/openmc/region.py
@@ -61,7 +61,7 @@ class Region(object):
             Dictionary mapping surface IDs to :class:`openmc.Surface` instances
 
         """
-        if not surfaces:
+        if surfaces is None:
             surfaces = OrderedDict()
         for region in self:
             surfaces = region.update_surfaces(surfaces)
@@ -468,7 +468,7 @@ class Complement(Region):
             Dictionary mapping surface IDs to :class:`openmc.Surface` instances
 
         """
-        if not surfaces:
+        if surfaces is None:
             surfaces = OrderedDict()
         for region in self.node:
             surfaces = region.update_surfaces(surfaces)

--- a/openmc/region.py
+++ b/openmc/region.py
@@ -1,5 +1,5 @@
 from abc import ABCMeta, abstractmethod
-from collections import Iterable
+from collections import Iterable, OrderedDict
 
 from six import add_metaclass
 import numpy as np
@@ -45,6 +45,25 @@ class Region(object):
 
     def __ne__(self, other):
         return not self == other
+
+    def get_surfaces_from_region(self, surfaces = OrderedDict()):
+        """
+        Recursively find all the surfaces referenced by a region and return them
+
+        Parameters
+        ----------
+        surfaces: collections.OrderedDict, optional
+            Dictionary mapping surface IDs to :class:`openmc.Surface` instances
+            
+        Returns
+        -------
+        surfaces: collections.OrderedDict
+            Dictionary mapping surface IDs to :class:`openmc.Surface` instances
+
+        """
+        for region in self:
+            surfaces = region.get_surfaces_from_region(surfaces)
+        return surfaces
 
     @staticmethod
     def from_expression(expression, surfaces):

--- a/openmc/region.py
+++ b/openmc/region.py
@@ -450,3 +450,23 @@ class Complement(Region):
         else:
             temp_region = ~self.node
         return temp_region.bounding_box
+
+    def get_surfaces_from_region(self, surfaces = OrderedDict()):
+        """
+        Recursively find all the surfaces referenced by the complement's node and return them
+        Overwrites method Region.get_surfaces_from_region()
+
+        Parameters
+        ----------
+        surfaces: collections.OrderedDict, optional
+            Dictionary mapping surface IDs to :class:`openmc.Surface` instances
+
+        Returns
+        -------
+        surfaces: collections.OrderedDict
+            Dictionary mapping surface IDs to :class:`openmc.Surface` instances
+
+        """
+        for region in self.node:
+            surfaces = region.get_surfaces_from_region(surfaces)
+        return surfaces

--- a/openmc/region.py
+++ b/openmc/region.py
@@ -46,7 +46,7 @@ class Region(object):
     def __ne__(self, other):
         return not self == other
 
-    def update_surfaces(self, surfaces=None):
+    def get_surfaces(self, surfaces=None):
         """
         Recursively find all the surfaces referenced by a region and return them
 
@@ -64,7 +64,7 @@ class Region(object):
         if surfaces is None:
             surfaces = OrderedDict()
         for region in self:
-            surfaces = region.update_surfaces(surfaces)
+            surfaces = region.get_surfaces(surfaces)
         return surfaces
 
     @staticmethod
@@ -453,7 +453,7 @@ class Complement(Region):
             temp_region = ~self.node
         return temp_region.bounding_box
 
-    def update_surfaces(self, surfaces=None):
+    def get_surfaces(self, surfaces=None):
         """
         Recursively find and return all the surfaces referenced by the node
 
@@ -471,5 +471,5 @@ class Complement(Region):
         if surfaces is None:
             surfaces = OrderedDict()
         for region in self.node:
-            surfaces = region.update_surfaces(surfaces)
+            surfaces = region.get_surfaces(surfaces)
         return surfaces

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -1881,7 +1881,7 @@ class Halfspace(Region):
         return '-' + str(self.surface.id) if self.side == '-' \
             else str(self.surface.id)
     
-    def get_surfaces(self, surfaces=None):
+    def update_surfaces(self, surfaces=None):
         """
         Returns the surface that this is a halfspace of.
     

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -1881,7 +1881,7 @@ class Halfspace(Region):
         return '-' + str(self.surface.id) if self.side == '-' \
             else str(self.surface.id)
     
-    def update_surfaces(self, surfaces=None):
+    def get_surfaces(self, surfaces=None):
         """
         Returns the surface that this is a halfspace of.
     

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -1896,7 +1896,7 @@ class Halfspace(Region):
             Dictionary mapping surface IDs to :class:`openmc.Surface` instances
     
         """
-        if not surfaces:
+        if surfaces is None:
             surfaces = OrderedDict()
         
         surfaces[self.surface.id] = self.surface

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -1881,10 +1881,9 @@ class Halfspace(Region):
         return '-' + str(self.surface.id) if self.side == '-' \
             else str(self.surface.id)
     
-    def get_surfaces_from_region(self, surfaces = OrderedDict()):
+    def get_surfaces(self, surfaces=None):
         """
         Returns the surface that this is a halfspace of.
-        Overwrites method Region.get_surfaces_from_region()
     
         Parameters
         ----------
@@ -1897,8 +1896,10 @@ class Halfspace(Region):
             Dictionary mapping surface IDs to :class:`openmc.Surface` instances
     
         """
-        if self.surface.id not in surfaces:
-            surfaces[self.surface.id] = self.surface
+        if not surfaces:
+            surfaces = OrderedDict()
+        
+        surfaces[self.surface.id] = self.surface
         return surfaces
 
 

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -1,5 +1,5 @@
 from abc import ABCMeta
-from collections import Iterable
+from collections import Iterable, OrderedDict
 from numbers import Real, Integral
 from xml.etree import ElementTree as ET
 from math import sqrt
@@ -1880,6 +1880,26 @@ class Halfspace(Region):
     def __str__(self):
         return '-' + str(self.surface.id) if self.side == '-' \
             else str(self.surface.id)
+    
+    def get_surfaces_from_region(self, surfaces = OrderedDict()):
+        """
+        Returns the surface that this is a halfspace of.
+        Overwrites method Region.get_surfaces_from_region()
+    
+        Parameters
+        ----------
+        surfaces: collections.OrderedDict, optional
+            Dictionary mapping surface IDs to :class:`openmc.Surface` instances
+    
+        Returns
+        -------
+        surfaces: collections.OrderedDict
+            Dictionary mapping surface IDs to :class:`openmc.Surface` instances
+    
+        """
+        if self.surface.id not in surfaces:
+            surfaces[self.surface.id] = self.surface
+        return surfaces
 
 
 def get_rectangular_prism(width, height, axis='z', origin=(0., 0.),


### PR DESCRIPTION
The `Geometry` class currently has methods to `get_all_cells()` (and materials, lattices, and so on), but not for surfaces.

The method `Geometry.get_all_surfaces()` goes through all the cells and places each unique surface it finds into an OrderedDict.