### PR TITLE
fix accelerated resonance scattering bugs identified by @paulromano

### DIFF
--- a/src/constants.F90
+++ b/src/constants.F90
@@ -84,6 +84,7 @@ module constants
        ZERO             = 0.0_8,             &
        HALF             = 0.5_8,             &
        ONE              = 1.0_8,             &
+       SQRT_TWO         = 1.4142135623731_8, &
        TWO              = 2.0_8,             &
        THREE            = 3.0_8,             &
        FOUR             = 4.0_8

--- a/src/physics.F90
+++ b/src/physics.F90
@@ -875,9 +875,9 @@ contains
       wgt = wcf * wgt
 
     case (RES_SCAT_DBRC, RES_SCAT_ARES)
-      E_red = sqrt((awr * E) / kT)
-      E_low = (((E_red - FOUR)**2) * kT) / awr
-      E_up  = (((E_red + FOUR)**2) * kT) / awr
+      E_red = sqrt(awr * E / kT)
+      E_low = (max(ZERO, E_red - FOUR)**2) * kT / awr
+      E_up  = ((E_red + FOUR)**2) * kT / awr
 
       ! find lower and upper energy bound indices
       ! lower index
@@ -949,8 +949,8 @@ contains
           ARES_REJECT_LOOP: do
             ! perform Maxwellian rejection sampling
             xi = prn()
-            E_t = 16.0_8 * kT * xi**2
-            R = FOUR * xi * exp(ONE - E_t/kT)
+            E_t = 16.0_8 * xi * xi
+            R = sqrt(TWO * E_t) * exp(HALF  - E_t)
 
             if (prn() < R) then
               ! sample a relative energy using the xs cdf


### PR DESCRIPTION
This PR fixes two bugs identified by @paulromano in the accelerated resonance elastic scattering method:

-- the reduced energy minus `4`, `E_red - 4` can sometimes take on negative values at low energies, in which case the lower bound energy should be `ZERO`
-- in computing the maximum value of the Maxwellian target **velocity** distribution as a function of **energy**, I had been using `kT`, the energy of the most probable velocity, instead of `kT/TWO`, the most probable energy (which should be used since that is what the sampled Maxwellian is a function of, as is apparent by simply identifying the max of the distribution function) ... This bug has a surprisingly small effect on scattering kernels, upscatter probabilities, and reactor eigenvalues because the double differential PDF for `mu` and `v_t` is dominated by 0 K cross sections resonances.  In the Doppler Defect Benchmark 5.0% UOX case, for example, DBRC, the bugged ARES, and the de-bugged ARES methods were all separated by 1 pcm with a 1sigma uncertainty of 5 pcm.