### PR TITLE
sample target energy directly!

### DIFF
--- a/src/physics.F90
+++ b/src/physics.F90
@@ -875,9 +875,9 @@ contains
       wgt = wcf * wgt
 
     case (RES_SCAT_DBRC, RES_SCAT_ARES)
-      E_red = sqrt((awr * E) / kT)
-      E_low = (((E_red - FOUR)**2) * kT) / awr
-      E_up  = (((E_red + FOUR)**2) * kT) / awr
+      E_red = sqrt(awr * E / kT)
+      E_low = max(ZERO, E_red - FOUR)**2 * kT / awr
+      E_up  = (E_red + FOUR)**2 * kT / awr
 
       ! find lower and upper energy bound indices
       ! lower index


### PR DESCRIPTION
This PR changes the accelerated resonance elastic scattering algorithm based on the double-integral change of variables (`mu`, `v_t` --> `E_rel`, `E_t`) so the `E_rel` **and** `E_t` are now both sampled directly and there is a single rejection criterion (that the resulting `mu` must be on [-1, 1]).  Upscatter probabilities, scattering kernels, and k_eff values look very good using DBRC as a reference (the two methods should and do produce statistically indistinguishable results).

In preliminary testing with a pin cell and a single resonant isotope (U-238) I've observed this to be faster than DBRC, somewhat faster than ares, and within 1% of the standard constant cross section free gas model (`cxs`).  More isotopes should compound this.