### PR TITLE
Cloning of geometry and materials

### DIFF
--- a/openmc/cell.py
+++ b/openmc/cell.py
@@ -504,6 +504,20 @@ class Cell(object):
 
         return universes
 
+    def clone(self):
+        """Create a copy of this cell with a new unique ID, and clones
+        the cell's region and fill."""
+
+        clone = copy.deepcopy(self)
+        clone.id = None
+
+        if self.region is not None:
+            clone.region = self.region.clone()
+        if self.fill is not None:
+            clone.fill = self.fill.clone()
+
+        return clone
+    
     def create_xml_subelement(self, xml_element):
         element = ET.Element("cell")
         element.set("id", str(self.id))

--- a/openmc/cell.py
+++ b/openmc/cell.py
@@ -505,13 +505,13 @@ class Cell(object):
 
         return universes
 
-    def clone(self, memoize=None):
+    def clone(self, memo=None):
         """Create a copy of this cell with a new unique ID, and clones
         the cell's region and fill.
 
         Parameters
         ----------
-        memoize : defaultdict(dict) or None
+        memo : defaultdict(dict) or None
             A nested dictionary of previously cloned objects. This parameter
             is used internally and should not be specified by the user.
 
@@ -522,25 +522,26 @@ class Cell(object):
 
         """
 
-        if memoize is None:
-            memoize = defaultdict(dict)
+        if memo is None:
+            memo = defaultdict(dict)
 
         # If no nemoize'd clone exists, instantiate one
-        if self.id not in memoize['cells']:
+        if self.id not in memo['cells']:
             clone = deepcopy(self)
             clone.id = None
             if self.region is not None:
-                clone.region = self.region.clone(memoize)
+                clone.region = self.region.clone(memo)
             if self.fill is not None:
                 if self.fill_type == 'distribmat':
-                    clone.fill = [fill.clone(memoize) for fill in self.fill]
+                    clone.fill = [fill.clone(memo) if fill is not None else None
+                                  for fill in self.fill]
                 else:
-                    clone.fill = self.fill.clone(memoize)
+                    clone.fill = self.fill.clone(memo)
 
             # Memoize the clone
-            memoize['cells'][self.id] = clone
+            memo['cells'][self.id] = clone
 
-        return memoize['cells'][self.id]
+        return memo['cells'][self.id]
     
     def create_xml_subelement(self, xml_element):
         element = ET.Element("cell")

--- a/openmc/cell.py
+++ b/openmc/cell.py
@@ -1,4 +1,4 @@
-from collections import OrderedDict, Iterable, defaultdict
+from collections import OrderedDict, Iterable
 from copy import deepcopy
 from math import cos, sin, pi
 from numbers import Real, Integral
@@ -511,7 +511,7 @@ class Cell(object):
 
         Parameters
         ----------
-        memo : defaultdict(dict) or None
+        memo : dict or None
             A nested dictionary of previously cloned objects. This parameter
             is used internally and should not be specified by the user.
 
@@ -523,10 +523,10 @@ class Cell(object):
         """
 
         if memo is None:
-            memo = defaultdict(dict)
+            memo = {}
 
         # If no nemoize'd clone exists, instantiate one
-        if self.id not in memo['cells']:
+        if self not in memo:
             clone = deepcopy(self)
             clone.id = None
             if self.region is not None:
@@ -539,9 +539,9 @@ class Cell(object):
                     clone.fill = self.fill.clone(memo)
 
             # Memoize the clone
-            memo['cells'][self.id] = clone
+            memo[self] = clone
 
-        return memo['cells'][self.id]
+        return memo[self]
     
     def create_xml_subelement(self, xml_element):
         element = ET.Element("cell")

--- a/openmc/cell.py
+++ b/openmc/cell.py
@@ -507,7 +507,20 @@ class Cell(object):
 
     def clone(self, memoize=None):
         """Create a copy of this cell with a new unique ID, and clones
-        the cell's region and fill."""
+        the cell's region and fill.
+
+        Parameters
+        ----------
+        memoize : defaultdict(dict) or None
+            A nested dictionary of previously cloned objects. This parameter
+            is used internally and should not be specified by the user.
+
+        Returns
+        -------
+        clone : openmc.Cell
+            The clone of this cell
+
+        """
 
         if memoize is None:
             memoize = defaultdict(dict)

--- a/openmc/cell.py
+++ b/openmc/cell.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict, Iterable
+from copy import deepcopy
 from math import cos, sin, pi
 from numbers import Real, Integral
 from xml.etree import ElementTree as ET
@@ -508,7 +509,7 @@ class Cell(object):
         """Create a copy of this cell with a new unique ID, and clones
         the cell's region and fill."""
 
-        clone = copy.deepcopy(self)
+        clone = deepcopy(self)
         clone.id = None
 
         if self.region is not None:

--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict, Iterable
+from copy import deepcopy
 from xml.etree import ElementTree as ET
 
 from six import string_types
@@ -497,3 +498,11 @@ class Geometry(object):
 
         # Recursively traverse the CSG tree to count all cell instances
         self.root_universe._determine_paths()
+
+    def clone(self):
+        """Create a copy of this geometry with new unique IDs for all of its
+        enclosed materials, surfaces, cells, universes and lattices."""
+
+        clone = deepcopy(self)
+        clone.root_universe = deepcopy(self.root_universe)
+        return clone

--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -504,5 +504,5 @@ class Geometry(object):
         enclosed materials, surfaces, cells, universes and lattices."""
 
         clone = deepcopy(self)
-        clone.root_universe = deepcopy(self.root_universe)
+        clone.root_universe = self.root_universe.clone()
         return clone

--- a/openmc/lattice.py
+++ b/openmc/lattice.py
@@ -417,7 +417,20 @@ class Lattice(object):
 
     def clone(self, memoize=None):
         """Create a copy of this lattice with a new unique ID, and clones
-        all universes within this lattice."""
+        all universes within this lattice.
+
+        Parameters
+        ----------
+        memoize : defaultdict(dict) or None
+            A nested dictionary of previously cloned objects. This parameter
+            is used internally and should not be specified by the user.
+
+        Returns
+        -------
+        clone : openmc.Lattice
+            The clone of this lattice
+
+        """
 
         if memoize is None:
             memoize = defaultdict(dict)

--- a/openmc/lattice.py
+++ b/openmc/lattice.py
@@ -2,6 +2,7 @@ from __future__ import division
 
 from abc import ABCMeta
 from collections import OrderedDict, Iterable
+from copy import deepcopy
 from math import sqrt, floor
 from numbers import Real, Integral
 from xml.etree import ElementTree as ET
@@ -418,7 +419,7 @@ class Lattice(object):
         """Create a copy of this lattice with a new unique ID, and clones
         all universes within this lattice."""
 
-        clone = copy.deepcopy(self)
+        clone = deepcopy(self)
         clone.id = None
 
         # Clone all unique universes in the lattice
@@ -427,9 +428,17 @@ class Lattice(object):
             univ_clones[univ_id] = univ_clones[univ_id].clone()
 
         # Assign universe clones to the lattice clone
-        for index in self.indices:
-            univ_id = self.universe[index].id
-            clone.universes[index] = univ_clones[univ_id]
+        for i in self.indices:
+            if isinstance(self, RectLattice):
+                univ_id = self.universes[i].id
+                clone.universes[i] = univ_clones[univ_id]
+            else:
+                if self.ndim == 2:
+                    univ_id = self.universes[i[0]][i[1]].id
+                    clone.universes[i[0]][i[1]] = univ_clones[univ_id]
+                else:
+                    univ_id = self.universes[i[0]][i[1]][i[2]].id
+                    clone.universes[i[0]][i[1]][i[2]] = univ_clones[univ_id]
 
         return clone
 

--- a/openmc/lattice.py
+++ b/openmc/lattice.py
@@ -414,6 +414,25 @@ class Lattice(object):
                 return []
         return [(self, idx)] + u.find(p)
 
+    def clone(self):
+        """Create a copy of this lattice with a new unique ID, and clones
+        all universes within this lattice."""
+
+        clone = copy.deepcopy(self)
+        clone.id = None
+
+        # Clone all unique universes in the lattice
+        univ_clones = self.get_unique_universes()
+        for univ_id in univ_clones:
+            univ_clones[univ_id] = univ_clones[univ_id].clone()
+
+        # Assign universe clones to the lattice clone
+        for index in self.indices:
+            univ_id = self.universe[index].id
+            clone.universes[index] = univ_clones[univ_id]
+
+        return clone
+
 
 class RectLattice(Lattice):
     """A lattice consisting of rectangular prisms.

--- a/openmc/lattice.py
+++ b/openmc/lattice.py
@@ -415,13 +415,13 @@ class Lattice(object):
                 return []
         return [(self, idx)] + u.find(p)
 
-    def clone(self, memoize=None):
+    def clone(self, memo=None):
         """Create a copy of this lattice with a new unique ID, and clones
         all universes within this lattice.
 
         Parameters
         ----------
-        memoize : defaultdict(dict) or None
+        memo : defaultdict(dict) or None
             A nested dictionary of previously cloned objects. This parameter
             is used internally and should not be specified by the user.
 
@@ -432,18 +432,21 @@ class Lattice(object):
 
         """
 
-        if memoize is None:
-            memoize = defaultdict(dict)
+        if memo is None:
+            memo = defaultdict(dict)
 
         # If no nemoize'd clone exists, instantiate one
-        if self.id not in memoize['lattices']:
+        if self.id not in memo['lattices']:
             clone = deepcopy(self)
             clone.id = None
+
+            if self.outer is not None:
+                clone.outer = self.outer.clone()
 
             # Clone all unique universes in the lattice
             univ_clones = self.get_unique_universes()
             for univ_id in univ_clones:
-                univ_clones[univ_id] = univ_clones[univ_id].clone(memoize)
+                univ_clones[univ_id] = univ_clones[univ_id].clone(memo)
 
             # Assign universe clones to the lattice clone
             for i in self.indices:
@@ -459,9 +462,9 @@ class Lattice(object):
                         clone.universes[i[0]][i[1]][i[2]] = univ_clones[univ_id]
 
             # Memoize the clone
-            memoize['lattices'][self.id] = clone
+            memo['lattices'][self.id] = clone
 
-        return memoize['lattices'][self.id]
+        return memo['lattices'][self.id]
 
 
 class RectLattice(Lattice):

--- a/openmc/lattice.py
+++ b/openmc/lattice.py
@@ -443,23 +443,17 @@ class Lattice(object):
             if self.outer is not None:
                 clone.outer = self.outer.clone(memo)
 
-            # Clone all unique universes in the lattice
-            univ_clones = self.get_unique_universes()
-            for univ_id in univ_clones:
-                univ_clones[univ_id] = univ_clones[univ_id].clone(memo)
-
             # Assign universe clones to the lattice clone
             for i in self.indices:
                 if isinstance(self, RectLattice):
-                    univ_id = self.universes[i].id
-                    clone.universes[i] = univ_clones[univ_id]
+                    clone.universes[i] = self.universes[i].clone()
                 else:
                     if self.ndim == 2:
-                        univ_id = self.universes[i[0]][i[1]].id
-                        clone.universes[i[0]][i[1]] = univ_clones[univ_id]
+                        clone.universes[i[0]][i[1]] = \
+                            self.universes[i[0]][i[1]].clone()
                     else:
-                        univ_id = self.universes[i[0]][i[1]][i[2]].id
-                        clone.universes[i[0]][i[1]][i[2]] = univ_clones[univ_id]
+                        clone.universes[i[0]][i[1]][i[2]] = \
+                            self.universes[i[0]][i[1]][i[2]].clone()
 
             # Memoize the clone
             memo[self] = clone

--- a/openmc/lattice.py
+++ b/openmc/lattice.py
@@ -1,7 +1,7 @@
 from __future__ import division
 
 from abc import ABCMeta
-from collections import OrderedDict, Iterable, defaultdict
+from collections import OrderedDict, Iterable
 from copy import deepcopy
 from math import sqrt, floor
 from numbers import Real, Integral
@@ -421,7 +421,7 @@ class Lattice(object):
 
         Parameters
         ----------
-        memo : defaultdict(dict) or None
+        memo : dict or None
             A nested dictionary of previously cloned objects. This parameter
             is used internally and should not be specified by the user.
 
@@ -433,15 +433,15 @@ class Lattice(object):
         """
 
         if memo is None:
-            memo = defaultdict(dict)
+            memo = {}
 
         # If no nemoize'd clone exists, instantiate one
-        if self.id not in memo['lattices']:
+        if self not in memo:
             clone = deepcopy(self)
             clone.id = None
 
             if self.outer is not None:
-                clone.outer = self.outer.clone()
+                clone.outer = self.outer.clone(memo)
 
             # Clone all unique universes in the lattice
             univ_clones = self.get_unique_universes()
@@ -462,9 +462,9 @@ class Lattice(object):
                         clone.universes[i[0]][i[1]][i[2]] = univ_clones[univ_id]
 
             # Memoize the clone
-            memo['lattices'][self.id] = clone
+            memo[self] = clone
 
-        return memo['lattices'][self.id]
+        return memo[self]
 
 
 class RectLattice(Lattice):

--- a/openmc/lattice.py
+++ b/openmc/lattice.py
@@ -446,14 +446,14 @@ class Lattice(object):
             # Assign universe clones to the lattice clone
             for i in self.indices:
                 if isinstance(self, RectLattice):
-                    clone.universes[i] = self.universes[i].clone()
+                    clone.universes[i] = self.universes[i].clone(memo)
                 else:
                     if self.ndim == 2:
                         clone.universes[i[0]][i[1]] = \
-                            self.universes[i[0]][i[1]].clone()
+                            self.universes[i[0]][i[1]].clone(memo)
                     else:
                         clone.universes[i[0]][i[1]][i[2]] = \
-                            self.universes[i[0]][i[1]][i[2]].clone()
+                            self.universes[i[0]][i[1]][i[2]].clone(memo)
 
             # Memoize the clone
             memo[self] = clone

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -1,4 +1,4 @@
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 from copy import deepcopy
 from numbers import Real, Integral
 import warnings
@@ -799,12 +799,21 @@ class Material(object):
 
         return nuclides
 
-    def clone(self):
+    def clone(self, memoize=None):
         """Create a copy of this material with a new unique ID."""
 
-        clone = deepcopy(self)
-        clone.id = None
-        return clone
+        if memoize is None:
+            memoize = defaultdict(dict)
+
+        # If no nemoize'd clone exists, instantiate one
+        if self.id not in memoize['materials']:
+            clone = deepcopy(self)
+            clone.id = None
+
+            # Memoize the clone
+            memoize['materials'][self.id] = clone
+
+        return memoize['materials'][self.id]
 
     def _get_nuclide_xml(self, nuclide, distrib=False):
         xml_element = ET.Element("nuclide")

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -1100,6 +1100,13 @@ class Materials(cv.CheckedList):
         for material in self:
             material.make_isotropic_in_lab()
 
+    def clone(self):
+        """Create a copy of this material with a new unique ID."""
+
+        clone = copy.deepcopy(self)
+        clone.id = None
+        return clone
+
     def _create_material_subelements(self, root_element):
         for material in self:
             root_element.append(material.to_xml_element(self.cross_sections))

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -816,7 +816,7 @@ class Material(object):
         """
 
         if memo is None:
-            memo = dict
+            memo = {}
 
         # If no nemoize'd clone exists, instantiate one
         if self not in memo:

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -800,7 +800,20 @@ class Material(object):
         return nuclides
 
     def clone(self, memoize=None):
-        """Create a copy of this material with a new unique ID."""
+        """Create a copy of this material with a new unique ID.
+
+        Parameters
+        ----------
+        memoize : defaultdict(dict) or None
+            A nested dictionary of previously cloned objects. This parameter
+            is used internally and should not be specified by the user.
+
+        Returns
+        -------
+        clone : openmc.Material
+            The clone of this material
+
+        """
 
         if memoize is None:
             memoize = defaultdict(dict)

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -799,12 +799,12 @@ class Material(object):
 
         return nuclides
 
-    def clone(self, memoize=None):
+    def clone(self, memo=None):
         """Create a copy of this material with a new unique ID.
 
         Parameters
         ----------
-        memoize : defaultdict(dict) or None
+        memo : defaultdict(dict) or None
             A nested dictionary of previously cloned objects. This parameter
             is used internally and should not be specified by the user.
 
@@ -815,18 +815,18 @@ class Material(object):
 
         """
 
-        if memoize is None:
-            memoize = defaultdict(dict)
+        if memo is None:
+            memo = defaultdict(dict)
 
         # If no nemoize'd clone exists, instantiate one
-        if self.id not in memoize['materials']:
+        if self.id not in memo['materials']:
             clone = deepcopy(self)
             clone.id = None
 
             # Memoize the clone
-            memoize['materials'][self.id] = clone
+            memo['materials'][self.id] = clone
 
-        return memoize['materials'][self.id]
+        return memo['materials'][self.id]
 
     def _get_nuclide_xml(self, nuclide, distrib=False):
         xml_element = ET.Element("nuclide")

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -799,6 +799,13 @@ class Material(object):
 
         return nuclides
 
+    def clone(self):
+        """Create a copy of this material with a new unique ID."""
+
+        clone = deepcopy(self)
+        clone.id = None
+        return clone
+
     def _get_nuclide_xml(self, nuclide, distrib=False):
         xml_element = ET.Element("nuclide")
         xml_element.set("name", nuclide[0].name)
@@ -1099,13 +1106,6 @@ class Materials(cv.CheckedList):
     def make_isotropic_in_lab(self):
         for material in self:
             material.make_isotropic_in_lab()
-
-    def clone(self):
-        """Create a copy of this material with a new unique ID."""
-
-        clone = copy.deepcopy(self)
-        clone.id = None
-        return clone
 
     def _create_material_subelements(self, root_element):
         for material in self:

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -1,4 +1,4 @@
-from collections import OrderedDict, defaultdict
+from collections import OrderedDict
 from copy import deepcopy
 from numbers import Real, Integral
 import warnings
@@ -804,7 +804,7 @@ class Material(object):
 
         Parameters
         ----------
-        memo : defaultdict(dict) or None
+        memo : dict or None
             A nested dictionary of previously cloned objects. This parameter
             is used internally and should not be specified by the user.
 
@@ -816,17 +816,17 @@ class Material(object):
         """
 
         if memo is None:
-            memo = defaultdict(dict)
+            memo = dict
 
         # If no nemoize'd clone exists, instantiate one
-        if self.id not in memo['materials']:
+        if self not in memo:
             clone = deepcopy(self)
             clone.id = None
 
             # Memoize the clone
-            memo['materials'][self.id] = clone
+            memo[self] = clone
 
-        return memo['materials'][self.id]
+        return memo[self]
 
     def _get_nuclide_xml(self, nuclide, distrib=False):
         xml_element = ET.Element("nuclide")

--- a/openmc/region.py
+++ b/openmc/region.py
@@ -225,7 +225,25 @@ class Region(object):
     @abstractmethod
     def clone(self, memoize=None):
         """Create a copy of this region - each of the surfaces in the
-        region's nodes will be cloned and will have new unique IDs."""
+        region's nodes will be cloned and will have new unique IDs.
+
+        Parameters
+        ----------
+        memoize : defaultdict(dict) or None
+            A nested dictionary of previously cloned objects. This parameter
+            is used internally and should not be specified by the user.
+
+        Returns
+        -------
+        clone : openmc.Region
+            The clone of this region
+
+        Raises
+        ------
+        NotImplementedError
+            This method is not implemented for the abstract region class.
+
+        """
         raise NotImplementedError('The clone method is not implemented for '
                                   'the abstract region class.')
 
@@ -310,7 +328,20 @@ class Intersection(Region):
 
     def clone(self, memoize=None):
         """Create a copy of this region - each of the surfaces in the
-        intersection's nodes will be cloned and will have new unique IDs."""
+        intersection's nodes will be cloned and will have new unique IDs.
+
+        Parameters
+        ----------
+        memoize : defaultdict(dict) or None
+            A nested dictionary of previously cloned objects. This parameter
+            is used internally and should not be specified by the user.
+
+        Returns
+        -------
+        clone : openmc.Intersection
+            The clone of this intersection
+
+        """
 
         if memoize is None:
             memoize = defaultdict(dict)
@@ -398,7 +429,20 @@ class Union(Region):
 
     def clone(self, memoize=None):
         """Create a copy of this region - each of the surfaces in the
-        union's nodes will be cloned and will have new unique IDs."""
+        union's nodes will be cloned and will have new unique IDs.
+
+        Parameters
+        ----------
+        memoize : defaultdict(dict) or None
+            A nested dictionary of previously cloned objects. This parameter
+            is used internally and should not be specified by the user.
+
+        Returns
+        -------
+        clone : openmc.Union
+            The clone of this union
+
+        """
 
         if memoize is None:
             memoize = defaultdict(dict)
@@ -506,7 +550,20 @@ class Complement(Region):
 
     def clone(self, memoize=None):
         """Create a copy of this region - each of the surfaces in the
-        complement's node will be cloned and will have new unique IDs."""
+        complement's node will be cloned and will have new unique IDs.
+
+        Parameters
+        ----------
+        memoize : defaultdict(dict) or None
+            A nested dictionary of previously cloned objects. This parameter
+            is used internally and should not be specified by the user.
+
+        Returns
+        -------
+        clone : openmc.Complement
+            The clone of this complement
+
+        """
 
         if memoize is None:
             memoize = defaultdict(dict)

--- a/openmc/region.py
+++ b/openmc/region.py
@@ -1,5 +1,5 @@
 from abc import ABCMeta, abstractmethod
-from collections import Iterable, OrderedDict
+from collections import Iterable, OrderedDict, defaultdict
 from copy import deepcopy
 
 from six import add_metaclass
@@ -223,10 +223,11 @@ class Region(object):
         return output[0]
 
     @abstractmethod
-    def clone(self):
+    def clone(self, memoize=None):
         """Create a copy of this region - each of the surfaces in the
         region's nodes will be cloned and will have new unique IDs."""
-        return False
+        raise NotImplementedError('The clone method is not implemented for '
+                                  'the abstract region class.')
 
 
 class Intersection(Region):
@@ -307,12 +308,15 @@ class Intersection(Region):
         check_type('nodes', nodes, Iterable, Region)
         self._nodes = nodes
 
-    def clone(self):
+    def clone(self, memoize=None):
         """Create a copy of this region - each of the surfaces in the
         intersection's nodes will be cloned and will have new unique IDs."""
 
+        if memoize is None:
+            memoize = defaultdict(dict)
+
         clone = deepcopy(self)
-        clone.nodes = [n.clone() for n in self.nodes]
+        clone.nodes = [n.clone(memoize) for n in self.nodes]
         return clone
 
 
@@ -392,12 +396,15 @@ class Union(Region):
         check_type('nodes', nodes, Iterable, Region)
         self._nodes = nodes
 
-    def clone(self):
+    def clone(self, memoize=None):
         """Create a copy of this region - each of the surfaces in the
         union's nodes will be cloned and will have new unique IDs."""
 
+        if memoize is None:
+            memoize = defaultdict(dict)
+
         clone = copy.deepcopy(self)
-        clone.nodes = [n.clone() for n in self.nodes]
+        clone.nodes = [n.clone(memoize) for n in self.nodes]
         return clone
 
 
@@ -497,10 +504,13 @@ class Complement(Region):
             surfaces = region.get_surfaces(surfaces)
         return surfaces
 
-    def clone(self):
+    def clone(self, memoize=None):
         """Create a copy of this region - each of the surfaces in the
         complement's node will be cloned and will have new unique IDs."""
 
+        if memoize is None:
+            memoize = defaultdict(dict)
+
         clone = copy.deepcopy(self)
-        clone.node = self.node.clone()
+        clone.node = self.node.clone(memoize)
         return clone

--- a/openmc/region.py
+++ b/openmc/region.py
@@ -221,6 +221,12 @@ class Region(object):
         # at the end
         return output[0]
 
+    @abstractmethod
+    def clone(self):
+        """Create a copy of this region - each of the surfaces in the
+        region's nodes will be cloned and will have new unique IDs."""
+        return False
+
 
 class Intersection(Region):
     r"""Intersection of two or more regions.
@@ -300,6 +306,15 @@ class Intersection(Region):
         check_type('nodes', nodes, Iterable, Region)
         self._nodes = nodes
 
+    @abstractmethod
+    def clone(self):
+        """Create a copy of this region - each of the surfaces in the
+        intersection's nodes will be cloned and will have new unique IDs."""
+
+        clone = copy.deepcopy(self)
+        clone.nodes = [n.clone() for n in self.nodes]
+        return clone
+
 
 class Union(Region):
     r"""Union of two or more regions.
@@ -376,6 +391,14 @@ class Union(Region):
     def nodes(self, nodes):
         check_type('nodes', nodes, Iterable, Region)
         self._nodes = nodes
+
+    def clone(self):
+        """Create a copy of this region - each of the surfaces in the
+        union's nodes will be cloned and will have new unique IDs."""
+
+        clone = copy.deepcopy(self)
+        clone.nodes = [n.clone() for n in self.nodes]
+        return clone
 
 
 class Complement(Region):
@@ -473,3 +496,11 @@ class Complement(Region):
         for region in self.node:
             surfaces = region.get_surfaces(surfaces)
         return surfaces
+
+    def clone(self):
+        """Create a copy of this region - each of the surfaces in the
+        complement's node will be cloned and will have new unique IDs."""
+
+        clone = copy.deepcopy(self)
+        clone.node = self.node.clone()
+        return clone

--- a/openmc/region.py
+++ b/openmc/region.py
@@ -1,5 +1,6 @@
 from abc import ABCMeta, abstractmethod
 from collections import Iterable, OrderedDict
+from copy import deepcopy
 
 from six import add_metaclass
 import numpy as np
@@ -306,12 +307,11 @@ class Intersection(Region):
         check_type('nodes', nodes, Iterable, Region)
         self._nodes = nodes
 
-    @abstractmethod
     def clone(self):
         """Create a copy of this region - each of the surfaces in the
         intersection's nodes will be cloned and will have new unique IDs."""
 
-        clone = copy.deepcopy(self)
+        clone = deepcopy(self)
         clone.nodes = [n.clone() for n in self.nodes]
         return clone
 

--- a/openmc/region.py
+++ b/openmc/region.py
@@ -223,13 +223,13 @@ class Region(object):
         return output[0]
 
     @abstractmethod
-    def clone(self, memoize=None):
+    def clone(self, memo=None):
         """Create a copy of this region - each of the surfaces in the
         region's nodes will be cloned and will have new unique IDs.
 
         Parameters
         ----------
-        memoize : defaultdict(dict) or None
+        memo : defaultdict(dict) or None
             A nested dictionary of previously cloned objects. This parameter
             is used internally and should not be specified by the user.
 
@@ -326,13 +326,13 @@ class Intersection(Region):
         check_type('nodes', nodes, Iterable, Region)
         self._nodes = nodes
 
-    def clone(self, memoize=None):
+    def clone(self, memo=None):
         """Create a copy of this region - each of the surfaces in the
         intersection's nodes will be cloned and will have new unique IDs.
 
         Parameters
         ----------
-        memoize : defaultdict(dict) or None
+        memo : defaultdict(dict) or None
             A nested dictionary of previously cloned objects. This parameter
             is used internally and should not be specified by the user.
 
@@ -343,11 +343,11 @@ class Intersection(Region):
 
         """
 
-        if memoize is None:
-            memoize = defaultdict(dict)
+        if memo is None:
+            memo = defaultdict(dict)
 
         clone = deepcopy(self)
-        clone.nodes = [n.clone(memoize) for n in self.nodes]
+        clone.nodes = [n.clone(memo) for n in self.nodes]
         return clone
 
 
@@ -427,13 +427,13 @@ class Union(Region):
         check_type('nodes', nodes, Iterable, Region)
         self._nodes = nodes
 
-    def clone(self, memoize=None):
+    def clone(self, memo=None):
         """Create a copy of this region - each of the surfaces in the
         union's nodes will be cloned and will have new unique IDs.
 
         Parameters
         ----------
-        memoize : defaultdict(dict) or None
+        memo : defaultdict(dict) or None
             A nested dictionary of previously cloned objects. This parameter
             is used internally and should not be specified by the user.
 
@@ -444,11 +444,11 @@ class Union(Region):
 
         """
 
-        if memoize is None:
-            memoize = defaultdict(dict)
+        if memo is None:
+            memo = defaultdict(dict)
 
         clone = copy.deepcopy(self)
-        clone.nodes = [n.clone(memoize) for n in self.nodes]
+        clone.nodes = [n.clone(memo) for n in self.nodes]
         return clone
 
 
@@ -548,13 +548,13 @@ class Complement(Region):
             surfaces = region.get_surfaces(surfaces)
         return surfaces
 
-    def clone(self, memoize=None):
+    def clone(self, memo=None):
         """Create a copy of this region - each of the surfaces in the
         complement's node will be cloned and will have new unique IDs.
 
         Parameters
         ----------
-        memoize : defaultdict(dict) or None
+        memo : defaultdict(dict) or None
             A nested dictionary of previously cloned objects. This parameter
             is used internally and should not be specified by the user.
 
@@ -565,9 +565,9 @@ class Complement(Region):
 
         """
 
-        if memoize is None:
-            memoize = defaultdict(dict)
+        if memo is None:
+            memo = defaultdict(dict)
 
         clone = copy.deepcopy(self)
-        clone.node = self.node.clone(memoize)
+        clone.node = self.node.clone(memo)
         return clone

--- a/openmc/region.py
+++ b/openmc/region.py
@@ -1,5 +1,5 @@
 from abc import ABCMeta, abstractmethod
-from collections import Iterable, OrderedDict, defaultdict
+from collections import Iterable, OrderedDict
 from copy import deepcopy
 
 from six import add_metaclass
@@ -229,7 +229,7 @@ class Region(object):
 
         Parameters
         ----------
-        memo : defaultdict(dict) or None
+        memo : dict or None
             A nested dictionary of previously cloned objects. This parameter
             is used internally and should not be specified by the user.
 
@@ -332,7 +332,7 @@ class Intersection(Region):
 
         Parameters
         ----------
-        memo : defaultdict(dict) or None
+        memo : dict or None
             A nested dictionary of previously cloned objects. This parameter
             is used internally and should not be specified by the user.
 
@@ -344,7 +344,7 @@ class Intersection(Region):
         """
 
         if memo is None:
-            memo = defaultdict(dict)
+            memo = {}
 
         clone = deepcopy(self)
         clone.nodes = [n.clone(memo) for n in self.nodes]
@@ -433,7 +433,7 @@ class Union(Region):
 
         Parameters
         ----------
-        memo : defaultdict(dict) or None
+        memo : dict or None
             A nested dictionary of previously cloned objects. This parameter
             is used internally and should not be specified by the user.
 
@@ -445,7 +445,7 @@ class Union(Region):
         """
 
         if memo is None:
-            memo = defaultdict(dict)
+            memo = {}
 
         clone = copy.deepcopy(self)
         clone.nodes = [n.clone(memo) for n in self.nodes]
@@ -554,7 +554,7 @@ class Complement(Region):
 
         Parameters
         ----------
-        memo : defaultdict(dict) or None
+        memo : dict or None
             A nested dictionary of previously cloned objects. This parameter
             is used internally and should not be specified by the user.
 
@@ -566,7 +566,7 @@ class Complement(Region):
         """
 
         if memo is None:
-            memo = defaultdict(dict)
+            memo = {}
 
         clone = copy.deepcopy(self)
         clone.node = self.node.clone(memo)

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -172,12 +172,12 @@ class Surface(object):
         return (np.array([-np.inf, -np.inf, -np.inf]),
                 np.array([np.inf, np.inf, np.inf]))
 
-    def clone(self, memoize=None):
+    def clone(self, memo=None):
         """Create a copy of this surface with a new unique ID.
 
         Parameters
         ----------
-        memoize : defaultdict(dict) or None
+        memo : defaultdict(dict) or None
             A nested dictionary of previously cloned objects. This parameter
             is used internally and should not be specified by the user.
 
@@ -188,18 +188,18 @@ class Surface(object):
 
         """
 
-        if memoize is None:
-            memoize = defaultdict(dict)
+        if memo is None:
+            memo = defaultdict(dict)
 
         # If no nemoize'd clone exists, instantiate one
-        if self.id not in memoize['surfaces']:
+        if self.id not in memo['surfaces']:
             clone = deepcopy(self)
             clone.id = None
 
             # Memoize the clone
-            memoize['surfaces'][self.id] = clone
+            memo['surfaces'][self.id] = clone
 
-        return memoize['surfaces'][self.id]
+        return memo['surfaces'][self.id]
 
     def to_xml_element(self):
         """Return XML representation of the surface
@@ -1932,13 +1932,13 @@ class Halfspace(Region):
         surfaces[self.surface.id] = self.surface
         return surfaces
 
-    def clone(self, memoize=None):
+    def clone(self, memo=None):
         """Create a copy of this halfspace, with a cloned surface with a
         unique ID.
 
         Parameters
         ----------
-        memoize : defaultdict(dict) or None
+        memo : defaultdict(dict) or None
             A nested dictionary of previously cloned objects. This parameter
             is used internally and should not be specified by the user.
 
@@ -1949,11 +1949,11 @@ class Halfspace(Region):
 
         """
 
-        if memoize is None:
-            memoize = defaultdict(dict)
+        if memo is None:
+            memo = defaultdict(dict)
 
         clone = deepcopy(self)
-        clone.surface = self.surface.clone(memoize)
+        clone.surface = self.surface.clone(memo)
         return clone
 
 

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -1,5 +1,5 @@
 from abc import ABCMeta
-from collections import Iterable, OrderedDict, defaultdict
+from collections import Iterable, OrderedDict
 from copy import deepcopy
 from numbers import Real, Integral
 from xml.etree import ElementTree as ET
@@ -82,6 +82,9 @@ class Surface(object):
 
     def __pos__(self):
         return Halfspace(self, '+')
+
+    def __hash__(self):
+        return hash(repr(self))
 
     def __repr__(self):
         string = 'Surface\n'
@@ -177,7 +180,7 @@ class Surface(object):
 
         Parameters
         ----------
-        memo : defaultdict(dict) or None
+        memo : dict or None
             A nested dictionary of previously cloned objects. This parameter
             is used internally and should not be specified by the user.
 
@@ -189,17 +192,17 @@ class Surface(object):
         """
 
         if memo is None:
-            memo = defaultdict(dict)
+            memo = {}
 
         # If no nemoize'd clone exists, instantiate one
-        if self.id not in memo['surfaces']:
+        if self not in memo:
             clone = deepcopy(self)
             clone.id = None
 
             # Memoize the clone
-            memo['surfaces'][self.id] = clone
+            memo[self] = clone
 
-        return memo['surfaces'][self.id]
+        return memo[self]
 
     def to_xml_element(self):
         """Return XML representation of the surface
@@ -1938,7 +1941,7 @@ class Halfspace(Region):
 
         Parameters
         ----------
-        memo : defaultdict(dict) or None
+        memo : dict or None
             A nested dictionary of previously cloned objects. This parameter
             is used internally and should not be specified by the user.
 
@@ -1950,7 +1953,7 @@ class Halfspace(Region):
         """
 
         if memo is None:
-            memo = defaultdict(dict)
+            memo = dict
 
         clone = deepcopy(self)
         clone.surface = self.surface.clone(memo)

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -1,5 +1,6 @@
 from abc import ABCMeta
 from collections import Iterable, OrderedDict
+from copy import deepcopy
 from numbers import Real, Integral
 from xml.etree import ElementTree as ET
 from math import sqrt
@@ -174,7 +175,7 @@ class Surface(object):
     def clone(self):
         """Create a copy of this surface with a new unique ID."""
 
-        clone = copy.deepcopy(self)
+        clone = deepcopy(self)
         clone.id = None
         return clone
 
@@ -1828,15 +1829,6 @@ class Halfspace(Region):
     def __init__(self, surface, side):
         self.surface = surface
         self.side = side
-
-    @abstractmethod
-    def clone(self):
-        """Create a copy of this halfspace, with a cloned surface with a
-        unique ID."""
-
-        clone = copy.deepcopy(self)
-        clone.surface = self.surface.clone()
-        return clone
         
     def __and__(self, other):
         if isinstance(other, Intersection):
@@ -1917,6 +1909,14 @@ class Halfspace(Region):
         
         surfaces[self.surface.id] = self.surface
         return surfaces
+
+    def clone(self):
+        """Create a copy of this halfspace, with a cloned surface with a
+        unique ID."""
+
+        clone = deepcopy(self)
+        clone.surface = self.surface.clone()
+        return clone
 
 
 def get_rectangular_prism(width, height, axis='z', origin=(0., 0.),

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -171,6 +171,13 @@ class Surface(object):
         return (np.array([-np.inf, -np.inf, -np.inf]),
                 np.array([np.inf, np.inf, np.inf]))
 
+    def clone(self):
+        """Create a copy of this surface with a new unique ID."""
+
+        clone = copy.deepcopy(self)
+        clone.id = None
+        return clone
+
     def to_xml_element(self):
         """Return XML representation of the surface
 
@@ -1822,6 +1829,15 @@ class Halfspace(Region):
         self.surface = surface
         self.side = side
 
+    @abstractmethod
+    def clone(self):
+        """Create a copy of this halfspace, with a cloned surface with a
+        unique ID."""
+
+        clone = copy.deepcopy(self)
+        clone.surface = self.surface.clone()
+        return clone
+        
     def __and__(self, other):
         if isinstance(other, Intersection):
             return Intersection(self, *other.nodes)

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -173,7 +173,20 @@ class Surface(object):
                 np.array([np.inf, np.inf, np.inf]))
 
     def clone(self, memoize=None):
-        """Create a copy of this surface with a new unique ID."""
+        """Create a copy of this surface with a new unique ID.
+
+        Parameters
+        ----------
+        memoize : defaultdict(dict) or None
+            A nested dictionary of previously cloned objects. This parameter
+            is used internally and should not be specified by the user.
+
+        Returns
+        -------
+        clone : openmc.Surface
+            The clone of this surface
+
+        """
 
         if memoize is None:
             memoize = defaultdict(dict)
@@ -1921,7 +1934,20 @@ class Halfspace(Region):
 
     def clone(self, memoize=None):
         """Create a copy of this halfspace, with a cloned surface with a
-        unique ID."""
+        unique ID.
+
+        Parameters
+        ----------
+        memoize : defaultdict(dict) or None
+            A nested dictionary of previously cloned objects. This parameter
+            is used internally and should not be specified by the user.
+
+        Returns
+        -------
+        clone : openmc.Halfspace
+            The clone of this halfspace
+
+        """
 
         if memoize is None:
             memoize = defaultdict(dict)

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -517,13 +517,13 @@ class Universe(object):
 
         return universes
 
-    def clone(self, memoize=None):
+    def clone(self, memo=None):
         """Create a copy of this universe with a new unique ID, and clones
         all cells within this universe.
 
         Parameters
         ----------
-        memoize : defaultdict(dict) or None
+        memo : defaultdict(dict) or None
             A nested dictionary of previously cloned objects. This parameter
             is used internally and should not be specified by the user.
 
@@ -534,20 +534,23 @@ class Universe(object):
 
         """
 
-        if memoize is None:
-            memoize = defaultdict(dict)
+        if memo is None:
+            memo = defaultdict(dict)
 
         # If no nemoize'd clone exists, instantiate one
-        if self.id not in memoize['universes']:
-            memoize['universes'][self.id] = deepcopy(self)
-            memoize['universes'][self.id].id = None
+        if self.id not in memo['universes']:
+            clone = deepcopy(self)
+            clone.id = None
 
             # Clone all cells for the universe clone
-            memoize['universes'][self.id]._cells = OrderedDict()
+            clone._cells = OrderedDict()
             for cell in self._cells.values():
-                memoize['universes'][self.id].add_cell(cell.clone(memoize))
+                clone.add_cell(cell.clone(memo))
 
-        return memoize['universes'][self.id]
+            # Memoize the clone
+            memo['universes'][self.id] = clone
+
+        return memo['universes'][self.id]
 
     def create_xml_subelement(self, xml_element):
         # Iterate over all Cells

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -1,5 +1,5 @@
 from __future__ import division
-from collections import OrderedDict, Iterable, defaultdict
+from collections import OrderedDict, Iterable
 from copy import copy, deepcopy
 from numbers import Integral, Real
 import random
@@ -523,7 +523,7 @@ class Universe(object):
 
         Parameters
         ----------
-        memo : defaultdict(dict) or None
+        memo : dict or None
             A nested dictionary of previously cloned objects. This parameter
             is used internally and should not be specified by the user.
 
@@ -535,10 +535,10 @@ class Universe(object):
         """
 
         if memo is None:
-            memo = defaultdict(dict)
+            memo = {}
 
         # If no nemoize'd clone exists, instantiate one
-        if self.id not in memo['universes']:
+        if self not in memo:
             clone = deepcopy(self)
             clone.id = None
 
@@ -548,9 +548,9 @@ class Universe(object):
                 clone.add_cell(cell.clone(memo))
 
             # Memoize the clone
-            memo['universes'][self.id] = clone
+            memo[self] = clone
 
-        return memo['universes'][self.id]
+        return memo[self]
 
     def create_xml_subelement(self, xml_element):
         # Iterate over all Cells

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -519,7 +519,20 @@ class Universe(object):
 
     def clone(self, memoize=None):
         """Create a copy of this universe with a new unique ID, and clones
-        all cells within this universe."""
+        all cells within this universe.
+
+        Parameters
+        ----------
+        memoize : defaultdict(dict) or None
+            A nested dictionary of previously cloned objects. This parameter
+            is used internally and should not be specified by the user.
+
+        Returns
+        -------
+        clone : openmc.Universe
+            The clone of this universe
+
+        """
 
         if memoize is None:
             memoize = defaultdict(dict)

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -1,5 +1,5 @@
 from __future__ import division
-from collections import OrderedDict, Iterable
+from collections import OrderedDict, Iterable, defaultdict
 from copy import copy, deepcopy
 from numbers import Integral, Real
 import random
@@ -517,19 +517,24 @@ class Universe(object):
 
         return universes
 
-    def clone(self):
+    def clone(self, memoize=None):
         """Create a copy of this universe with a new unique ID, and clones
         all cells within this universe."""
 
-        clone = deepcopy(self)
-        clone.id = None
+        if memoize is None:
+            memoize = defaultdict(dict)
 
-        # Clone all cells for the universe clone
-        clone._cells = OrderedDict()
-        for cell in self._cells.values():
-            clone.add_cell(cell.clone())
+        # If no nemoize'd clone exists, instantiate one
+        if self.id not in memoize['universes']:
+            memoize['universes'][self.id] = deepcopy(self)
+            memoize['universes'][self.id].id = None
 
-        return clone
+            # Clone all cells for the universe clone
+            memoize['universes'][self.id]._cells = OrderedDict()
+            for cell in self._cells.values():
+                memoize['universes'][self.id].add_cell(cell.clone(memoize))
+
+        return memoize['universes'][self.id]
 
     def create_xml_subelement(self, xml_element):
         # Iterate over all Cells

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -1,6 +1,6 @@
 from __future__ import division
-from copy import copy
 from collections import OrderedDict, Iterable
+from copy import copy, deepcopy
 from numbers import Integral, Real
 import random
 import sys
@@ -521,7 +521,7 @@ class Universe(object):
         """Create a copy of this universe with a new unique ID, and clones
         all cells within this universe."""
 
-        clone = copy.deepcopy(self)
+        clone = deepcopy(self)
         clone.id = None
 
         # Clone all cells for the universe clone

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -517,6 +517,20 @@ class Universe(object):
 
         return universes
 
+    def clone(self):
+        """Create a copy of this universe with a new unique ID, and clones
+        all cells within this universe."""
+
+        clone = copy.deepcopy(self)
+        clone.id = None
+
+        # Clone all cells for the universe clone
+        clone._cells = OrderedDict()
+        for cell in self._cells.values():
+            clone.add_cell(cell.clone())
+
+        return clone
+
     def create_xml_subelement(self, xml_element):
         # Iterate over all Cells
         for cell_id, cell in self._cells.items():


### PR DESCRIPTION
This PR introduces new `clone()` methods to the `Material`, `Surface`, `Cell`, `Universe`, `Lattice` and `Geometry` classes. These new methods are essentially a wrapper around the `__deepcopy__()` method, except they assign a unique ID to the clone (whereas `__deepcopy__()` retains the original ID). Furthermore, any portion of the CSG tree below the clone is also cloned, and hence has unique IDs. 

This feature is intended to support @GiudGiud and @tjlaboss with their research. Based on their use cases, I think this could be a more broadly useful feature. Of course @paulromano will note that we have previously discussed on at least one occasion whether the `__deepcopy__()` methods should assign unique IDs as the new `clone()` methods do. I still stand by my original view that `__deepcopy__()` should return a genuine deep copy, but of course I won't be surprised if this PR re-opens this conversation :-)