### PR TITLE
Hotfix for MGXSLibrary import issue

### DIFF
--- a/openmc/mgxs_library.py
+++ b/openmc/mgxs_library.py
@@ -9,7 +9,7 @@ import h5py
 import openmc
 import openmc.mgxs
 from openmc.checkvalue import check_type, check_value, check_greater_than, \
-    check_iterable_type, check_less_than
+    check_iterable_type, check_less_than, check_filetype_version
 
 
 # Supported incoming particle MGXS angular treatment representations
@@ -2561,8 +2561,8 @@ class MGXSLibrary(object):
         file = h5py.File(filename, 'r')
 
         # Check filetype and version
-        cv.check_filetype_version(file, _FILETYPE_MGXS_LIBRARY,
-                                  _VERSION_MGXS_LIBRARY)
+        check_filetype_version(file, _FILETYPE_MGXS_LIBRARY,
+                               _VERSION_MGXS_LIBRARY)
 
         group_structure = file.attrs['group structure']
         num_delayed_groups = file.attrs['delayed_groups']


### PR DESCRIPTION
I just ran the MGXSLibrary.from_hdf5 method and found an issue with imports.
This PR fixes the issue.