### PR TITLE
Fix for OpenMOC compatibility for generic planar surfaces

### DIFF
--- a/openmc/lattice.py
+++ b/openmc/lattice.py
@@ -56,11 +56,11 @@ class Lattice(object):
             return False
         elif self.name != other.name:
             return False
-        elif self.pitch != other.pitch:
+        elif np.any(self.pitch != other.pitch):
             return False
         elif self.outer != other.outer:
             return False
-        elif self.universes != other.universes:
+        elif np.any(self.universes != other.universes):
             return False
         else:
             return True
@@ -533,7 +533,7 @@ class RectLattice(Lattice):
             return False
         elif self.shape != other.shape:
             return False
-        elif self.lower_left != other.lower_left:
+        elif np.any(self.lower_left != other.lower_left):
             return False
         else:
             return True

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -76,10 +76,17 @@ class Universe(object):
             return False
         elif self.name != other.name:
             return False
-        elif self.cells != other.cells:
+        elif len(self.cells) != len(other.cells):
             return False
-        else:
-            return True
+
+        # Check each cell
+        for cell_id in self.cells:
+            if cell_id not in other.cells:
+                return False
+            if self.cells[cell_id] != other.cells[cell_id]:
+                return False
+
+        return True
 
     def __ne__(self, other):
         return not self == other

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -76,17 +76,10 @@ class Universe(object):
             return False
         elif self.name != other.name:
             return False
-        elif len(self.cells) != len(other.cells):
+        elif dict.__eq__(self.cells, other.cells):
             return False
-
-        # Check each cell
-        for cell_id in self.cells:
-            if cell_id not in other.cells:
-                return False
-            if self.cells[cell_id] != other.cells[cell_id]:
-                return False
-
-        return True
+        else:
+            return True
 
     def __ne__(self, other):
         return not self == other

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -76,7 +76,7 @@ class Universe(object):
             return False
         elif self.name != other.name:
             return False
-        elif dict.__eq__(self.cells, other.cells):
+        elif dict.__ne__(self.cells, other.cells):
             return False
         else:
             return True


### PR DESCRIPTION
This short PR fixes two issues that I discovered in the OpenMOC compatibility module while helping @tjlaboss convert an OpenMC model of the TREAT reactor for modeling with OpenMOC. The primary issue is that the halfspace convention used for generic planar surfaces differs between OpenMC and OpenMOC. The second bug fix included in this PR fixes an issue when converting a rectangular lattice from OpenMOC into OpenMC. @paulromano do you have time for a speedy review of this code?