### PR TITLE
Fix Multipole module

### DIFF
--- a/openmc/data/multipole.py
+++ b/openmc/data/multipole.py
@@ -1,8 +1,8 @@
 from numbers import Integral, Real
+from math import exp, erf, pi, sqrt
 
 import h5py
 import numpy as np
-from math import exp, erf, pi
 from six import string_types
 
 from . import WMP_VERSION
@@ -102,7 +102,7 @@ def _broaden_wmp_polynomials(E, dopp, n):
         The value of each Doppler-broadened curvefit polynomial term.
 
     """
-    sqrtE = np.sqrt(E)
+    sqrtE = sqrt(E)
     beta = sqrtE * dopp
     half_inv_dopp2 = 0.5 / dopp**2
     quarter_inv_dopp4 = half_inv_dopp2**2
@@ -124,7 +124,7 @@ def _broaden_wmp_polynomials(E, dopp, n):
     factors[0] = erf_beta / E
     factors[1] = 1.0 / sqrtE
     factors[2] = (factors[0] * (half_inv_dopp2 + E)
-                  + exp_m_beta2 / (beta * np.sqrt(pi)))
+                  + exp_m_beta2 / (beta * sqrt(pi)))
 
     # Perform recursive broadening of high order components. range(1, n-2)
     # replaces a do i = 1, n-3.  All indices are reduced by one due to the
@@ -528,8 +528,8 @@ class WindowedMultipole(EqualityMixin):
         # Bookkeeping
 
         # Define some frequently used variables.
-        sqrtkT = np.sqrt(K_BOLTZMANN * T)
-        sqrtE = np.sqrt(E)
+        sqrtkT = sqrt(K_BOLTZMANN * T)
+        sqrtE = sqrt(E)
         invE = 1.0 / E
         dopp = self.sqrtAWR / sqrtkT
 
@@ -537,7 +537,7 @@ class WindowedMultipole(EqualityMixin):
         # the 1-based vs. 0-based indexing.  Similarly startw needs to be
         # decreased by 1.  endw does not need to be decreased because
         # range(startw, endw) does not include endw.
-        i_window = int(np.floor((sqrtE - np.sqrt(self.start_E)) / self.spacing))
+        i_window = int(np.floor((sqrtE - sqrt(self.start_E)) / self.spacing))
         startw = self.w_start[i_window] - 1
         endw = self.w_end[i_window]
 
@@ -621,7 +621,7 @@ class WindowedMultipole(EqualityMixin):
             # At temperature, use Faddeeva function-based form.
             for i_pole in range(startw, endw):
                 Z = (sqrtE - self.data[i_pole, _MP_EA]) * dopp
-                w_val = _faddeeva(Z) * dopp * invE * np.sqrt(pi)
+                w_val = _faddeeva(Z) * dopp * invE * sqrt(pi)
                 if self.formalism == 'MLBW':
                     sigT += ((self.data[i_pole, _MLBW_RT] *
                               sigT_factor[self.l_value[i_pole]-1] +

--- a/openmc/data/multipole.py
+++ b/openmc/data/multipole.py
@@ -2,6 +2,7 @@ from numbers import Integral, Real
 
 import h5py
 import numpy as np
+from math import exp, erf, pi
 from six import string_types
 
 from . import WMP_VERSION
@@ -112,9 +113,8 @@ def _broaden_wmp_polynomials(E, dopp, n):
         erf_beta = 1.0
         exp_m_beta2 = 0.0
     else:
-        from scipy.special import erf
         erf_beta = erf(beta)
-        exp_m_beta2 = np.exp(-beta**2)
+        exp_m_beta2 = exp(-beta**2)
 
     # Assume that, for sure, we'll use a second order (1/E, 1/V, const)
     # fit, and no less.
@@ -124,7 +124,7 @@ def _broaden_wmp_polynomials(E, dopp, n):
     factors[0] = erf_beta / E
     factors[1] = 1.0 / sqrtE
     factors[2] = (factors[0] * (half_inv_dopp2 + E)
-                  + exp_m_beta2 / (beta * np.sqrt(np.pi)))
+                  + exp_m_beta2 / (beta * np.sqrt(pi)))
 
     # Perform recursive broadening of high order components. range(1, n-2)
     # replaces a do i = 1, n-3.  All indices are reduced by one due to the
@@ -435,7 +435,7 @@ class WindowedMultipole(EqualityMixin):
             h5file = h5py.File(group_or_filename, 'r')
             try:
                 version = h5file['version'].value.decode()
-            except:
+            except AttributeError:
                 version = h5file['version'].value[0].decode()
             if version != WMP_VERSION:
                 raise ValueError('The given WMP data uses version '
@@ -621,7 +621,7 @@ class WindowedMultipole(EqualityMixin):
             # At temperature, use Faddeeva function-based form.
             for i_pole in range(startw, endw):
                 Z = (sqrtE - self.data[i_pole, _MP_EA]) * dopp
-                w_val = _faddeeva(Z) * dopp * invE * np.sqrt(np.pi)
+                w_val = _faddeeva(Z) * dopp * invE * np.sqrt(pi)
                 if self.formalism == 'MLBW':
                     sigT += ((self.data[i_pole, _MLBW_RT] *
                               sigT_factor[self.l_value[i_pole]-1] +

--- a/openmc/data/multipole.py
+++ b/openmc/data/multipole.py
@@ -77,7 +77,7 @@ def _faddeeva(z):
     if np.angle(z) > 0:
         return wofz(z)
     else:
-        return -np.conj(wofz(np.conj(z)))
+        return -np.conj(wofz(z.conjugate()))
 
 
 def _broaden_wmp_polynomials(E, dopp, n):
@@ -126,16 +126,14 @@ def _broaden_wmp_polynomials(E, dopp, n):
     factors[2] = (factors[0] * (half_inv_dopp2 + E)
                   + exp_m_beta2 / (beta * np.sqrt(np.pi)))
 
-    # Perform recursive broadening of high order components.  range(1, n-4)
-    # replaces a do i = 1, n=3.  All indices are reduced by one due to the
+    # Perform recursive broadening of high order components. range(1, n-2)
+    # replaces a do i = 1, n-3.  All indices are reduced by one due to the
     # 1-based vs. 0-based indexing.
     for i in range(1, n-2):
         if i != 1:
             factors[i+2] = (-factors[i-2] * (i - 1.0) * i * quarter_inv_dopp4
                 + factors[i] * (E + (1.0 + 2.0 * i) * half_inv_dopp2))
         else:
-            # Although it's mathematically identical, factors[0] will contain
-            # nothing, and we don't want to have to worry about memory.
             factors[i+2] = factors[i]*(E + (1.0 + 2.0 * i) * half_inv_dopp2)
 
     return factors
@@ -408,7 +406,7 @@ class WindowedMultipole(EqualityMixin):
                 raise ValueError('Multipole curvefit arrays must be 3D')
             if curvefit.shape[2] not in (2, 3):  # sigT, sigA (and maybe sigF)
                 raise ValueError('The third dimension of multipole curvefit'
-                                 ' arrays must have a length of 2 or 2 or 3')
+                                 ' arrays must have a length of 2 or 3')
             if not np.issubdtype(curvefit.dtype, float):
                 raise TypeError('Multipole curvefit arrays must be float dtype')
         self._curvefit = curvefit

--- a/src/cross_section.F90
+++ b/src/cross_section.F90
@@ -649,15 +649,19 @@ contains
              * broadened_polynomials(i_poly)
         sigA = sigA + multipole % curvefit(FIT_A, i_poly, i_window) &
              * broadened_polynomials(i_poly)
-        sigF = sigF + multipole % curvefit(FIT_F, i_poly, i_window) &
-             * broadened_polynomials(i_poly)
+        if (multipole % fissionable) then
+          sigF = sigF + multipole % curvefit(FIT_F, i_poly, i_window) &
+               * broadened_polynomials(i_poly)
+        end if
       end do
     else ! Evaluate as if it were a polynomial
       temp = invE
       do i_poly = 1, multipole % fit_order+1
         sigT = sigT + multipole % curvefit(FIT_T, i_poly, i_window) * temp
         sigA = sigA + multipole % curvefit(FIT_A, i_poly, i_window) * temp
-        sigF = sigF + multipole % curvefit(FIT_F, i_poly, i_window) * temp
+        if (multipole % fissionable) then
+          sigF = sigF + multipole % curvefit(FIT_F, i_poly, i_window) * temp
+        end if
         temp = temp * sqrtE
       end do
     end if
@@ -675,12 +679,16 @@ contains
                              sigT_factor(multipole % l_value(i_pole))) &
                       + real(multipole % data(MLBW_RX, i_pole) * c_temp)
           sigA = sigA + real(multipole % data(MLBW_RA, i_pole) * c_temp)
-          sigF = sigF + real(multipole % data(MLBW_RF, i_pole) * c_temp)
+          if (multipole % fissionable) then
+            sigF = sigF + real(multipole % data(MLBW_RF, i_pole) * c_temp)
+          end if
         else if (multipole % formalism == FORM_RM) then
           sigT = sigT + real(multipole % data(RM_RT, i_pole) * c_temp * &
                              sigT_factor(multipole % l_value(i_pole)))
           sigA = sigA + real(multipole % data(RM_RA, i_pole) * c_temp)
-          sigF = sigF + real(multipole % data(RM_RF, i_pole) * c_temp)
+          if (multipole % fissionable) then
+            sigF = sigF + real(multipole % data(RM_RF, i_pole) * c_temp)
+          end if
         end if
       end do
     else
@@ -694,12 +702,16 @@ contains
                           sigT_factor(multipole % l_value(i_pole)) + &
                           multipole % data(MLBW_RX, i_pole)) * w_val)
             sigA = sigA + real(multipole % data(MLBW_RA, i_pole) * w_val)
-            sigF = sigF + real(multipole % data(MLBW_RF, i_pole) * w_val)
+            if (multipole % fissionable) then
+              sigF = sigF + real(multipole % data(MLBW_RF, i_pole) * w_val)
+            end if
           else if (multipole % formalism == FORM_RM) then
             sigT = sigT + real(multipole % data(RM_RT, i_pole) * w_val * &
                                sigT_factor(multipole % l_value(i_pole)))
             sigA = sigA + real(multipole % data(RM_RA, i_pole) * w_val)
-            sigF = sigF + real(multipole % data(RM_RF, i_pole) * w_val)
+            if (multipole % fissionable) then
+              sigF = sigF + real(multipole % data(RM_RF, i_pole) * w_val)
+            end if
           end if
         end do
       end if
@@ -780,12 +792,16 @@ contains
                         sigT_factor(multipole%l_value(i_pole)) + &
                         multipole % data(MLBW_RX, i_pole)) * w_val)
           sigA = sigA + real(multipole % data(MLBW_RA, i_pole) * w_val)
-          sigF = sigF + real(multipole % data(MLBW_RF, i_pole) * w_val)
+          if (multipole % fissionable) then
+            sigF = sigF + real(multipole % data(MLBW_RF, i_pole) * w_val)
+          end if
         else if (multipole % formalism == FORM_RM) then
           sigT = sigT + real(multipole % data(RM_RT, i_pole) * w_val * &
                              sigT_factor(multipole % l_value(i_pole)))
           sigA = sigA + real(multipole % data(RM_RA, i_pole) * w_val)
-          sigF = sigF + real(multipole % data(RM_RF, i_pole) * w_val)
+          if (multipole % fissionable) then
+            sigF = sigF + real(multipole % data(RM_RF, i_pole) * w_val)
+          end if
         end if
       end do
       sigT = -HALF*multipole % sqrtAWR / sqrt(K_BOLTZMANN) * T**(-1.5) * sigT


### PR DESCRIPTION
The multipole python api module has several bugs that affect the loading of wmp library or xs evaluation from multipole data.
```python
import openmc.data
nuc_wmp = openmc.data.WindowedMultipole.from_hdf5("./wmp/092235.h5")

(sigT, sigA, SigF) = nuc_wmp(E=0.001, T=300)
AttributeError: module 'numpy' has no attribute 'erf'

(sigT, sigA, SigF) = nuc_wmp(E=2240, T=300)
sigT, sigA, SigF
(array(-4954886358.87597),
 array(-171244680.68258008),
 array(-1001055628.4242938))
```
For the second example where the xs are nonsense, it was found the python code to evaluate xs has inconsistencies with the Fortran code.

Another fix is for reading or evaluating non-fissionable multiple data for both fortran and python codes. If processing a nonfissionable nuclide, the code is likely crashing since residues and curvefit data for fission xs do not exist. That didn't happen because currently all the nuclides in our wmp library are fissionable (fissionable = 1, even though they are actually not!). I've been generating more wmp libraries which are mostly non-fissionable, these modifications have been verified using those libraries.