### PR TITLE
Don't copy paths when cloning Cell or Material

### DIFF
--- a/openmc/cell.py
+++ b/openmc/cell.py
@@ -527,8 +527,16 @@ class Cell(object):
 
         # If no nemoize'd clone exists, instantiate one
         if self not in memo:
+            # Temporarily remove paths
+            paths = self.paths
+            self._paths = None
+
             clone = deepcopy(self)
             clone.id = None
+
+            # Restore paths on original instance
+            self._paths = paths
+
             if self.region is not None:
                 clone.region = self.region.clone(memo)
             if self.fill is not None:
@@ -542,7 +550,7 @@ class Cell(object):
             memo[self] = clone
 
         return memo[self]
-    
+
     def create_xml_subelement(self, xml_element):
         element = ET.Element("cell")
         element.set("id", str(self.id))

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -820,8 +820,17 @@ class Material(object):
 
         # If no nemoize'd clone exists, instantiate one
         if self not in memo:
+            # Temporarily remove paths -- this is done so that when the clone is
+            # made, it doesn't create a copy of the paths (which are specific to
+            # an instance)
+            paths = self.paths
+            self._paths = None
+
             clone = deepcopy(self)
             clone.id = None
+
+            # Restore paths on original instance
+            self._paths = paths
 
             # Memoize the clone
             memo[self] = clone


### PR DESCRIPTION
When you call `cell.clone()` or `material.clone()` right now, if `geometry.determine_paths()` was used to calculate cell/material paths, those paths get copied to the new clone (even though they don't make sense). This PR simply prevents paths from being copied to clones. It might seem like a trivial thing, but it actually has big implications if you are creating a geometry with a material that gets cloned many times (for depletion purposes). @cjosey ran into this with an SMR model where the fact that material paths were getting copied resulted in 100s of GB of memory being used.