### PR TITLE
Allow determine_paths() to be called only to get number of instances

### DIFF
--- a/openmc/cell.py
+++ b/openmc/cell.py
@@ -103,7 +103,7 @@ class Cell(object):
         self._rotation_matrix = None
         self._temperature = None
         self._translation = None
-        self._paths = []
+        self._paths = None
         self._num_instances = None
         self._volume = None
         self._atoms = None
@@ -215,7 +215,7 @@ class Cell(object):
 
     @property
     def paths(self):
-        if not self._paths:
+        if self._paths is None:
             raise ValueError('Cell instance paths have not been determined. '
                              'Call the Geometry.determine_paths() method.')
         return self._paths
@@ -230,6 +230,10 @@ class Cell(object):
 
     @property
     def num_instances(self):
+        if self._num_instances is None:
+            raise ValueError(
+                'Number of cell instances have not been determined. Call the '
+                'Geometry.determine_paths() method.')
         return self._num_instances
 
     @id.setter

--- a/openmc/cell.py
+++ b/openmc/cell.py
@@ -104,6 +104,7 @@ class Cell(object):
         self._temperature = None
         self._translation = None
         self._paths = []
+        self._num_instances = None
         self._volume = None
         self._atoms = None
 
@@ -229,7 +230,7 @@ class Cell(object):
 
     @property
     def num_instances(self):
-        return len(self.paths)
+        return self._num_instances
 
     @id.setter
     def id(self, cell_id):
@@ -528,11 +529,12 @@ class Cell(object):
         # If no nemoize'd clone exists, instantiate one
         if self not in memo:
             # Temporarily remove paths
-            paths = self.paths
+            paths = self._paths
             self._paths = None
 
             clone = deepcopy(self)
             clone.id = None
+            clone._num_instances = None
 
             # Restore paths on original instance
             self._paths = paths

--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -258,7 +258,7 @@ class Geometry(object):
                     lattices[cell.fill.id] = cell.fill
 
         return lattices
-    
+
     def get_all_surfaces(self):
         """
         Return all surfaces used in the geometry
@@ -270,11 +270,11 @@ class Geometry(object):
 
         """
         surfaces = OrderedDict()
-        
+
         for cell in self.get_all_cells().values():
             surfaces = cell.region.get_surfaces(surfaces)
         return surfaces
-                
+
     def get_materials_by_name(self, name, case_sensitive=False, matching=False):
         """Return a list of materials with matching names.
 
@@ -482,22 +482,30 @@ class Geometry(object):
         lattices.sort(key=lambda x: x.id)
         return lattices
 
-    def determine_paths(self):
+    def determine_paths(self, instances_only=False):
         """Determine paths through CSG tree for cells and materials.
 
         This method recursively traverses the CSG tree to determine each unique
         path that reaches every cell and material. The paths are stored in the
         :attr:`Cell.paths` and :attr:`Material.paths` attributes.
 
+        Parameters
+        ----------
+        instances_only : bool
+            If true, this method will only determine the number of instances of
+            each cell and material.
+
         """
         # (Re-)initialize all cell instances to 0
         for cell in self.get_all_cells().values():
             cell._paths = []
+            cell._num_instances = 0
         for material in self.get_all_materials().values():
             material._paths = []
+            material._num_instances = 0
 
         # Recursively traverse the CSG tree to count all cell instances
-        self.root_universe._determine_paths()
+        self.root_universe._determine_paths(instances_only=instances_only)
 
     def clone(self):
         """Create a copy of this geometry with new unique IDs for all of its

--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -491,7 +491,7 @@ class Geometry(object):
 
         Parameters
         ----------
-        instances_only : bool
+        instances_only : bool, optional
             If true, this method will only determine the number of instances of
             each cell and material.
 

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -97,7 +97,7 @@ class Material(object):
         self._density = None
         self._density_units = ''
         self._depletable = False
-        self._paths = []
+        self._paths = None
         self._num_instances = None
         self._volume = None
         self._atoms = {}
@@ -210,13 +210,17 @@ class Material(object):
 
     @property
     def paths(self):
-        if not self._paths:
+        if self._paths is None:
             raise ValueError('Material instance paths have not been determined. '
                              'Call the Geometry.determine_paths() method.')
         return self._paths
 
     @property
     def num_instances(self):
+        if self._num_instances is None:
+            raise ValueError(
+                'Number of material instances have not been determined. Call '
+                'the Geometry.determine_paths() method.')
         return self._num_instances
 
     @property

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -98,6 +98,7 @@ class Material(object):
         self._density_units = ''
         self._depletable = False
         self._paths = []
+        self._num_instances = None
         self._volume = None
         self._atoms = {}
 
@@ -216,7 +217,7 @@ class Material(object):
 
     @property
     def num_instances(self):
-        return len(self.paths)
+        return self._num_instances
 
     @property
     def elements(self):
@@ -297,11 +298,6 @@ class Material(object):
         if volume is not None:
             cv.check_type('material volume', volume, Real)
         self._volume = volume
-
-    @num_instances.setter
-    def num_instances(self, num_instances):
-        cv.check_type('num_instances', num_instances, Integral)
-        self._num_instances = num_instances
 
     @classmethod
     def from_hdf5(cls, group):
@@ -823,11 +819,12 @@ class Material(object):
             # Temporarily remove paths -- this is done so that when the clone is
             # made, it doesn't create a copy of the paths (which are specific to
             # an instance)
-            paths = self.paths
+            paths = self._paths
             self._paths = None
 
             clone = deepcopy(self)
             clone.id = None
+            clone._num_instances = None
 
             # Restore paths on original instance
             self._paths = paths


### PR DESCRIPTION
This PR adds an `instances_only` argument to `Geometry.determine_paths()` that allows a user to get only the number of instances of each cell and material in the geometry (no path strings are generated). This is a second attempt to address memory concerns for reactor models brought up by @cjosey.