### PR TITLE
Fix typos and links in example notebooks and userguide/geometry

### DIFF
--- a/docs/source/usersguide/geometry.rst
+++ b/docs/source/usersguide/geometry.rst
@@ -19,7 +19,7 @@ surface is a locus of zeros of a function of Cartesian coordinates
 :math:`x,y,z`, e.g.
 
 - A plane perpendicular to the :math:`x` axis: :math:`x - x_0 = 0`
-- A cylinder perpendicular to the :math:`z` axis: :math:`(x - x_0)^2 + (y -
+- A cylinder parallel to the :math:`z` axis: :math:`(x - x_0)^2 + (y -
   y_0)^2 - R^2 = 0`
 - A sphere: :math:`(x - x_0)^2 + (y - y_0)^2 + (z - z_0)^2 - R^2 = 0`
 

--- a/examples/jupyter/pandas-dataframes.ipynb
+++ b/examples/jupyter/pandas-dataframes.ipynb
@@ -281,7 +281,7 @@
     "plot.origin = [0, 0, 0]\n",
     "plot.width = [21.5, 21.5]\n",
     "plot.pixels = [250, 250]\n",
-    "plot.color = 'mat'\n",
+    "plot.color_by = 'material'\n",
     "\n",
     "# Instantiate a Plots collection and export to \"plots.xml\"\n",
     "plot_file = openmc.Plots([plot])\n",
@@ -1350,7 +1350,7 @@
     "df = tally.get_pandas_dataframe()\n",
     "\n",
     "# Print the first twenty rows in the dataframe\n",
-    "df.head(100)"
+    "df.head(20)"
    ]
   },
   {
@@ -1955,7 +1955,7 @@
     "absorption[['mean', 'std. dev.']].dropna().describe()\n",
     "\n",
     "# Note that the maximum standard deviation does indeed\n",
-    "# meet the 5e-4 threshold set by the tally trigger"
+    "# meet the 5e-5 threshold set by the tally trigger"
    ]
   },
   {
@@ -1981,7 +1981,7 @@
     }
    ],
    "source": [
-    "# Extract tally data from pins in the pins divided along y=x diagonal \n",
+    "# Extract tally data from pins in the pins divided along y=-x diagonal \n",
     "multi_index = ('level 2', 'lat',)\n",
     "lower = df[df[multi_index + ('x',)] + df[multi_index + ('y',)] < 16]\n",
     "upper = df[df[multi_index + ('x',)] + df[multi_index + ('y',)] > 16]\n",
@@ -1998,7 +1998,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that the symmetry implied by the y=x diagonal ensures that the two sampling distributions are identical. Indeed, as illustrated by the test above, for any reasonable significance level (*e.g.*, $\\alpha$=0.05) one would **not reject** the null hypothesis that the two sampling distributions are identical.\n",
+    "Note that the symmetry implied by the y=-x diagonal ensures that the two sampling distributions are identical. Indeed, as illustrated by the test above, for any reasonable significance level (*e.g.*, $\\alpha$=0.05) one would **not reject** the null hypothesis that the two sampling distributions are identical.\n",
     "\n",
     "Next, perform the same test but with two groupings of pins which are not symmetrically identical to one another."
    ]
@@ -2019,7 +2019,7 @@
     }
    ],
    "source": [
-    "# Extract tally data from pins in the pins divided along y=-x diagonal\n",
+    "# Extract tally data from pins in the pins divided along y=x diagonal\n",
     "multi_index = ('level 2', 'lat',)\n",
     "lower = df[df[multi_index + ('x',)] > df[multi_index + ('y',)]]\n",
     "upper = df[df[multi_index + ('x',)] < df[multi_index + ('y',)]]\n",
@@ -2036,7 +2036,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that the asymmetry implied by the y=-x diagonal ensures that the two sampling distributions are *not* identical. Indeed, as illustrated by the test above, for any reasonable significance level (*e.g.*, $\\alpha$=0.05) one would **reject** the null hypothesis that the two sampling distributions are identical."
+    "Note that the asymmetry implied by the y=x diagonal ensures that the two sampling distributions are *not* identical. Indeed, as illustrated by the test above, for any reasonable significance level (*e.g.*, $\\alpha$=0.05) one would **reject** the null hypothesis that the two sampling distributions are identical."
    ]
   },
   {

--- a/examples/jupyter/pandas-dataframes.ipynb
+++ b/examples/jupyter/pandas-dataframes.ipynb
@@ -10,9 +10,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import glob\n",
@@ -44,9 +42,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# 1.6 enriched fuel\n",
@@ -79,9 +75,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Instantiate a Materials collection\n",
@@ -101,9 +95,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Create cylinders for the fuel and clad\n",
@@ -130,9 +122,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Create fuel Cell\n",
@@ -163,9 +153,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Create fuel assembly Lattice\n",
@@ -185,9 +173,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Create root Cell\n",
@@ -211,9 +197,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Create Geometry and export to \"geometry.xml\"\n",
@@ -270,9 +254,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Instantiate a Plot\n",
@@ -298,9 +280,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -321,13 +301,11 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPoAAAD6AgMAAAD1grKuAAAABGdBTUEAALGPC/xhBQAAACBjSFJN\nAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAADFBMVEX////pgJFyEhJNv8RV\nUZDeAAAAAWJLR0QAiAUdSAAAAAd0SU1FB+EEDRUXN7H1XJgAAAPZSURBVGje7Zs7buMwEIZ9iey5\n0gyNjQpXKTYudIScgkdQYTfut1idwkdQkQNsYQO2Qj0sPiVK+mlQDmwgwIcgg8Cc4fCTSK5W4OeF\nkM8rHv+2I/rgxPZEPZgR7XtQxKdXYuUXJSUnBQ/9WCgo4vOSJ+WFUvF7E08mlia+rn7VcKXP8sRs\nzFX8b2MdX2y6v1Tw6MZUw4H4ojfIjD8mvn/qRL5p4+vvlMqvp2EhR8WBzfiz20hXORmP9fi/bM9E\neUFvV5H/0yRkeSbiGRfFJErxD9ENdz7Mbhig/h89fvtFdMiI/ePUIXV4lXju8K3DKv9NThOZ3q2K\nmUy6grxFES8rjeyic+FFQav+ncg3fXjH+Ts+/iibztFqOiZuZP/Z3OafPX40NGgST2r+uvQkXXp6\ncKvmr+r0e1Eef5um3+JHP3IFF1D/seNZJgaDmvY0Gav1s+2f1fqpIcublfKGt6apotG/NVx3SInW\ntLX+7Vg/Pv1YqOsnun6JSVdOXT/X7vk75f938QP+8OmSBs0fXtymMhJbf8qlPynYmpKCh7OB1fzN\nalOj1sl0ZAruHLiA+RM73pDe/VjMVP89+aTXwjyc/x5n+u991895/utrJTy8/06TXh0r/5JOa2Jm\nYmqi4r/vUm/H4wLmT+z4anhr05X+q6KUXhtzr/9qSff5L5uMT//V/NdU4YuBTPa/8P67l/6r44ds\n+hYuoP5jx9ciy6XTWlibBrmx8V/TdMfjkP+6pOsu/lvM9N90sf7r+f6m/65n+S8p/itN15v0UkW3\n/+48+PRfJX6S9Joo4g+G/1qYG9KroqP/WypcuvyXPf13wH89/hHef7MB6R3Cqn55U4rv4kfH3zaS\ngQuYP7HjVf89tXrbO+hfLdr+Ozv/SP1dgtQ/Ov8C+i/3+q/Zf2D/HWi6bjT6rym9I/v/03/b+LHS\n4cTg/utTsV7/net/Afzz4f0XGX84/2j9xZ4/sePR/of2X7D/o+vPo/sv6h9B/Bfxr9j1Hz2eN/hO\n8/wfff4A848+f/1A/530/I0+/8PvH9D3H9HnT+R49P0b+v4PfP/4E/wXfP8Mvf9G37/D/ovuP8Se\nP7Hj0f0vdP8tqP9O339cyv7p3P1fdP8Z3v9G999j13/seMax8x/o+ZN7+O+E8zdP/8XOf8Hnz9Dz\nb7HnT+x49PxlCp7/BM+fOv13wvnXBfivt2lMvD8TyH/Hnb+Gz3+j589jz5/Y8ej9h4D+W7qQmf57\nefqv239n3T+C7z+h969i13/seMax+3/o/cMcu/8Y2H9n3p+J6r98pv8m4fwXuH+M3n+OO3++AX9c\nlR+4PhbRAAAAJXRFWHRkYXRlOmNyZWF0ZQAyMDE3LTA0LTEzVDE3OjIzOjU1LTA0OjAwSGKjuQAA\nACV0RVh0ZGF0ZTptb2RpZnkAMjAxNy0wNC0xM1QxNzoyMzo1NS0wNDowMDk/GwUAAAAASUVORK5C\nYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPoAAAD6AgMAAAD1grKuAAAABGdBTUEAALGPC/xhBQAAAAFzUkdC\nAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAxQTFRF\n////chIS6YCRTb/E6kGE+wAAAAFiS0dEAIgFHUgAAAAJcEhZcwAAAEgAAABIAEbJaz4AAAPZSURB\nVGje7Zs7buMwEIZ9iey50gyNjQpXKTYudIScgkdQYTfut1idwkdQkQNsYQO2Qj0sPiVK+mlQDmwg\nwIcgg8Cc4fCTSK5W4OeFkM8rHv+2I/rgxPZEPZgR7XtQxKdXYuUXJSUnBQ/9WCgo4vOSJ+WFUvF7\nE08mlia+rn7VcKXP8sRszFX8b2MdX2y6v1Tw6MZUw4H4ojfIjD8mvn/qRL5p4+vvlMqvp2EhR8WB\nzfiz20hXORmP9fi/bM9EeUFvV5H/0yRkeSbiGRfFJErxD9ENdz7Mbhig/h89fvtFdMiI/ePUIXV4\nlXju8K3DKv9NThOZ3q2KmUy6grxFES8rjeyic+FFQav+ncg3fXjH+Ts+/iibztFqOiZuZP/Z3Oaf\nPX40NGgST2r+uvQkXXp6cKvmr+r0e1Eef5um3+JHP3IFF1D/seNZJgaDmvY0Gav1s+2f1fqpIcub\nlfKGt6apotG/NVx3SInWtLX+7Vg/Pv1YqOsnun6JSVdOXT/X7vk75f938QP+8OmSBs0fXtymMhJb\nf8qlPynYmpKCh7OB1fzNalOj1sl0ZAruHLiA+RM73pDe/VjMVP89+aTXwjyc/x5n+u991895/utr\nJTy8/06TXh0r/5JOa2JmYmqi4r/vUm/H4wLmT+z4anhr05X+q6KUXhtzr/9qSff5L5uMT//V/NdU\n4YuBTPa/8P67l/6r44ds+hYuoP5jx9ciy6XTWlibBrmx8V/TdMfjkP+6pOsu/lvM9N90sf7r+f6m\n/65n+S8p/itN15v0UkW3/+48+PRfJX6S9Joo4g+G/1qYG9KroqP/WypcuvyXPf13wH89/hHef7MB\n6R3Cqn55U4rv4kfH3zaSgQuYP7HjVf89tXrbO+hfLdr+Ozv/SP1dgtQ/Ov8C+i/3+q/Zf2D/HWi6\nbjT6rym9I/v/03/b+LHS4cTg/utTsV7/net/Afzz4f0XGX84/2j9xZ4/sePR/of2X7D/o+vPo/sv\n6h9B/Bfxr9j1Hz2eN/hO8/wfff4A848+f/1A/530/I0+/8PvH9D3H9HnT+R49P0b+v4PfP/4E/wX\nfP8Mvf9G37/D/ovuP8SeP7Hj0f0vdP8tqP9O339cyv7p3P1fdP8Z3v9G999j13/seMax8x/o+ZN7\n+O+E8zdP/8XOf8Hnz9Dzb7HnT+x49PxlCp7/BM+fOv13wvnXBfivt2lMvD8TyH/Hnb+Gz3+j589j\nz5/Y8ej9h4D+W7qQmf57efqv239n3T+C7z+h969i13/seMax+3/o/cMcu/8Y2H9n3p+J6r98pv8m\n4fwXuH+M3n+OO3++AX9clR+4PhbRAAAAJXRFWHRkYXRlOmNyZWF0ZQAyMDE3LTA2LTA3VDEzOjE4\nOjQ5LTA0OjAwxfC/BgAAACV0RVh0ZGF0ZTptb2RpZnkAMjAxNy0wNi0wN1QxMzoxODo0OS0wNDow\nMLStB7oAAAAASUVORK5CYII=\n",
       "text/plain": [
        "<IPython.core.display.Image object>"
       ]
@@ -374,9 +352,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Instantiate a tally Mesh\n",
@@ -411,9 +387,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Instantiate tally Filter\n",
@@ -439,9 +413,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Instantiate tally Filter\n",
@@ -483,9 +455,7 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -519,22 +489,22 @@
       "                   | The OpenMC Monte Carlo Code\n",
       "         Copyright | 2011-2017 Massachusetts Institute of Technology\n",
       "           License | http://openmc.readthedocs.io/en/latest/license.html\n",
-      "           Version | 0.8.0\n",
-      "          Git SHA1 | bc4683be1c853fe6d0e31bccad416ef219e3efaf\n",
-      "         Date/Time | 2017-04-13 17:23:58\n",
+      "           Version | 0.9.0\n",
+      "          Git SHA1 | 897db1389dec7871026442bae96d9410ade85192\n",
+      "         Date/Time | 2017-06-07 13:18:50\n",
       "     MPI Processes | 1\n",
-      "    OpenMP Threads | 1\n",
+      "    OpenMP Threads | 12\n",
       "\n",
       " Reading settings XML file...\n",
       " Reading geometry XML file...\n",
       " Reading materials XML file...\n",
       " Reading cross sections XML file...\n",
-      " Reading U235 from /home/smharper/openmc/data/nndc_hdf5/U235.h5\n",
-      " Reading U238 from /home/smharper/openmc/data/nndc_hdf5/U238.h5\n",
-      " Reading O16 from /home/smharper/openmc/data/nndc_hdf5/O16.h5\n",
-      " Reading H1 from /home/smharper/openmc/data/nndc_hdf5/H1.h5\n",
-      " Reading B10 from /home/smharper/openmc/data/nndc_hdf5/B10.h5\n",
-      " Reading Zr90 from /home/smharper/openmc/data/nndc_hdf5/Zr90.h5\n",
+      " Reading U235 from /home/johnny/Github/openmc/scripts/nndc_hdf5/U235.h5\n",
+      " Reading U238 from /home/johnny/Github/openmc/scripts/nndc_hdf5/U238.h5\n",
+      " Reading O16 from /home/johnny/Github/openmc/scripts/nndc_hdf5/O16.h5\n",
+      " Reading H1 from /home/johnny/Github/openmc/scripts/nndc_hdf5/H1.h5\n",
+      " Reading B10 from /home/johnny/Github/openmc/scripts/nndc_hdf5/B10.h5\n",
+      " Reading Zr90 from /home/johnny/Github/openmc/scripts/nndc_hdf5/Zr90.h5\n",
       " Maximum neutron transport energy: 2.00000E+07 eV for U235\n",
       " Reading tallies XML file...\n",
       " Building neighboring cells lists for each surface...\n",
@@ -578,20 +548,20 @@
       "\n",
       " =======================>     TIMING STATISTICS     <=======================\n",
       "\n",
-      " Total time for initialization     =  2.4022E-01 seconds\n",
-      "   Reading cross sections          =  1.9056E-01 seconds\n",
-      " Total time in simulation          =  7.5438E+00 seconds\n",
-      "   Time in transport only          =  7.5290E+00 seconds\n",
-      "   Time in inactive batches        =  1.0482E+00 seconds\n",
-      "   Time in active batches          =  6.4956E+00 seconds\n",
-      "   Time synchronizing fission bank =  2.3117E-03 seconds\n",
-      "     Sampling source sites         =  1.3344E-03 seconds\n",
-      "     SEND/RECV source sites        =  6.8338E-04 seconds\n",
-      "   Time accumulating tallies       =  3.9461E-04 seconds\n",
-      " Total time for finalization       =  1.3648E-05 seconds\n",
-      " Total time elapsed                =  7.7964E+00 seconds\n",
-      " Calculation Rate (inactive)       =  11925.2 neutrons/second\n",
-      " Calculation Rate (active)         =  5773.18 neutrons/second\n",
+      " Total time for initialization     =  3.6433E-01 seconds\n",
+      "   Reading cross sections          =  2.7963E-01 seconds\n",
+      " Total time in simulation          =  1.4715E+00 seconds\n",
+      "   Time in transport only          =  1.3171E+00 seconds\n",
+      "   Time in inactive batches        =  2.2329E-01 seconds\n",
+      "   Time in active batches          =  1.2482E+00 seconds\n",
+      "   Time synchronizing fission bank =  2.3145E-03 seconds\n",
+      "     Sampling source sites         =  1.4054E-03 seconds\n",
+      "     SEND/RECV source sites        =  7.6241E-04 seconds\n",
+      "   Time accumulating tallies       =  5.8822E-04 seconds\n",
+      " Total time for finalization       =  5.0159E-05 seconds\n",
+      " Total time elapsed                =  1.8511E+00 seconds\n",
+      " Calculation Rate (inactive)       =  55980.8 neutrons/second\n",
+      " Calculation Rate (active)         =  30044.0 neutrons/second\n",
       "\n",
       " ============================>     RESULTS     <============================\n",
       "\n",
@@ -632,9 +602,7 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# We do not know how many batches were needed to satisfy the \n",
@@ -655,9 +623,7 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -692,21 +658,19 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[[[ 0.22614381]]\n",
+      "[[[ 0.17581417]]\n",
       "\n",
-      " [[ 0.3789572 ]]\n",
+      " [[ 0.30578219]]\n",
       "\n",
-      " [[ 0.05763899]]\n",
+      " [[ 0.06842901]]\n",
       "\n",
-      " [[ 0.14265074]]]\n"
+      " [[ 0.12436752]]]\n"
      ]
     }
    ],
@@ -723,14 +687,25 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
        "<div>\n",
+       "<style>\n",
+       "    .dataframe thead tr:only-child th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "</style>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr>\n",
@@ -763,8 +738,8 @@
        "      <td>0.00e+00</td>\n",
        "      <td>6.25e-01</td>\n",
        "      <td>fission</td>\n",
-       "      <td>2.28e-04</td>\n",
-       "      <td>5.15e-05</td>\n",
+       "      <td>2.24e-04</td>\n",
+       "      <td>3.94e-05</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
@@ -774,8 +749,8 @@
        "      <td>0.00e+00</td>\n",
        "      <td>6.25e-01</td>\n",
        "      <td>nu-fission</td>\n",
-       "      <td>5.55e-04</td>\n",
-       "      <td>1.26e-04</td>\n",
+       "      <td>5.46e-04</td>\n",
+       "      <td>9.59e-05</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
@@ -785,8 +760,8 @@
        "      <td>6.25e-01</td>\n",
        "      <td>2.00e+07</td>\n",
        "      <td>fission</td>\n",
-       "      <td>8.65e-05</td>\n",
-       "      <td>9.06e-06</td>\n",
+       "      <td>8.42e-05</td>\n",
+       "      <td>6.79e-06</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
@@ -796,8 +771,8 @@
        "      <td>6.25e-01</td>\n",
        "      <td>2.00e+07</td>\n",
        "      <td>nu-fission</td>\n",
-       "      <td>2.28e-04</td>\n",
-       "      <td>2.19e-05</td>\n",
+       "      <td>2.22e-04</td>\n",
+       "      <td>1.65e-05</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
@@ -807,8 +782,8 @@
        "      <td>0.00e+00</td>\n",
        "      <td>6.25e-01</td>\n",
        "      <td>fission</td>\n",
-       "      <td>1.83e-04</td>\n",
-       "      <td>3.54e-05</td>\n",
+       "      <td>1.85e-04</td>\n",
+       "      <td>2.70e-05</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
@@ -818,8 +793,8 @@
        "      <td>0.00e+00</td>\n",
        "      <td>6.25e-01</td>\n",
        "      <td>nu-fission</td>\n",
-       "      <td>4.47e-04</td>\n",
-       "      <td>8.62e-05</td>\n",
+       "      <td>4.52e-04</td>\n",
+       "      <td>6.58e-05</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
@@ -829,8 +804,8 @@
        "      <td>6.25e-01</td>\n",
        "      <td>2.00e+07</td>\n",
        "      <td>fission</td>\n",
-       "      <td>6.91e-05</td>\n",
-       "      <td>6.94e-06</td>\n",
+       "      <td>6.82e-05</td>\n",
+       "      <td>5.29e-06</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>7</th>\n",
@@ -841,7 +816,7 @@
        "      <td>2.00e+07</td>\n",
        "      <td>nu-fission</td>\n",
        "      <td>1.81e-04</td>\n",
-       "      <td>1.77e-05</td>\n",
+       "      <td>1.35e-05</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>8</th>\n",
@@ -851,8 +826,8 @@
        "      <td>0.00e+00</td>\n",
        "      <td>6.25e-01</td>\n",
        "      <td>fission</td>\n",
-       "      <td>1.98e-04</td>\n",
-       "      <td>2.55e-05</td>\n",
+       "      <td>2.05e-04</td>\n",
+       "      <td>2.25e-05</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>9</th>\n",
@@ -862,8 +837,8 @@
        "      <td>0.00e+00</td>\n",
        "      <td>6.25e-01</td>\n",
        "      <td>nu-fission</td>\n",
-       "      <td>4.82e-04</td>\n",
-       "      <td>6.20e-05</td>\n",
+       "      <td>5.00e-04</td>\n",
+       "      <td>5.49e-05</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>10</th>\n",
@@ -873,8 +848,8 @@
        "      <td>6.25e-01</td>\n",
        "      <td>2.00e+07</td>\n",
        "      <td>fission</td>\n",
-       "      <td>7.76e-05</td>\n",
-       "      <td>9.73e-06</td>\n",
+       "      <td>7.53e-05</td>\n",
+       "      <td>7.06e-06</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>11</th>\n",
@@ -884,8 +859,8 @@
        "      <td>6.25e-01</td>\n",
        "      <td>2.00e+07</td>\n",
        "      <td>nu-fission</td>\n",
-       "      <td>2.05e-04</td>\n",
-       "      <td>2.48e-05</td>\n",
+       "      <td>1.99e-04</td>\n",
+       "      <td>1.81e-05</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>12</th>\n",
@@ -895,8 +870,8 @@
        "      <td>0.00e+00</td>\n",
        "      <td>6.25e-01</td>\n",
        "      <td>fission</td>\n",
-       "      <td>2.32e-04</td>\n",
-       "      <td>3.38e-05</td>\n",
+       "      <td>2.06e-04</td>\n",
+       "      <td>2.79e-05</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>13</th>\n",
@@ -906,8 +881,8 @@
        "      <td>0.00e+00</td>\n",
        "      <td>6.25e-01</td>\n",
        "      <td>nu-fission</td>\n",
-       "      <td>5.66e-04</td>\n",
-       "      <td>8.23e-05</td>\n",
+       "      <td>5.03e-04</td>\n",
+       "      <td>6.80e-05</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>14</th>\n",
@@ -917,8 +892,8 @@
        "      <td>6.25e-01</td>\n",
        "      <td>2.00e+07</td>\n",
        "      <td>fission</td>\n",
-       "      <td>6.54e-05</td>\n",
-       "      <td>4.61e-06</td>\n",
+       "      <td>6.65e-05</td>\n",
+       "      <td>3.91e-06</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>15</th>\n",
@@ -928,8 +903,8 @@
        "      <td>6.25e-01</td>\n",
        "      <td>2.00e+07</td>\n",
        "      <td>nu-fission</td>\n",
-       "      <td>1.73e-04</td>\n",
-       "      <td>1.23e-05</td>\n",
+       "      <td>1.75e-04</td>\n",
+       "      <td>1.04e-05</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>16</th>\n",
@@ -939,8 +914,8 @@
        "      <td>0.00e+00</td>\n",
        "      <td>6.25e-01</td>\n",
        "      <td>fission</td>\n",
-       "      <td>2.18e-04</td>\n",
-       "      <td>3.68e-05</td>\n",
+       "      <td>2.03e-04</td>\n",
+       "      <td>2.78e-05</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>17</th>\n",
@@ -950,8 +925,8 @@
        "      <td>0.00e+00</td>\n",
        "      <td>6.25e-01</td>\n",
        "      <td>nu-fission</td>\n",
-       "      <td>5.32e-04</td>\n",
-       "      <td>8.97e-05</td>\n",
+       "      <td>4.94e-04</td>\n",
+       "      <td>6.78e-05</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>18</th>\n",
@@ -961,8 +936,8 @@
        "      <td>6.25e-01</td>\n",
        "      <td>2.00e+07</td>\n",
        "      <td>fission</td>\n",
-       "      <td>5.92e-05</td>\n",
-       "      <td>6.63e-06</td>\n",
+       "      <td>6.26e-05</td>\n",
+       "      <td>5.71e-06</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>19</th>\n",
@@ -972,8 +947,8 @@
        "      <td>6.25e-01</td>\n",
        "      <td>2.00e+07</td>\n",
        "      <td>nu-fission</td>\n",
-       "      <td>1.56e-04</td>\n",
-       "      <td>1.82e-05</td>\n",
+       "      <td>1.64e-04</td>\n",
+       "      <td>1.53e-05</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -982,49 +957,49 @@
       "text/plain": [
        "   mesh 1       energy low [eV] energy high [eV]       score     mean  \\\n",
        "        x  y  z                                                         \n",
-       "0       1  1  1        0.00e+00         6.25e-01     fission 2.28e-04   \n",
-       "1       1  1  1        0.00e+00         6.25e-01  nu-fission 5.55e-04   \n",
-       "2       1  1  1        6.25e-01         2.00e+07     fission 8.65e-05   \n",
-       "3       1  1  1        6.25e-01         2.00e+07  nu-fission 2.28e-04   \n",
-       "4       1  2  1        0.00e+00         6.25e-01     fission 1.83e-04   \n",
-       "5       1  2  1        0.00e+00         6.25e-01  nu-fission 4.47e-04   \n",
-       "6       1  2  1        6.25e-01         2.00e+07     fission 6.91e-05   \n",
+       "0       1  1  1        0.00e+00         6.25e-01     fission 2.24e-04   \n",
+       "1       1  1  1        0.00e+00         6.25e-01  nu-fission 5.46e-04   \n",
+       "2       1  1  1        6.25e-01         2.00e+07     fission 8.42e-05   \n",
+       "3       1  1  1        6.25e-01         2.00e+07  nu-fission 2.22e-04   \n",
+       "4       1  2  1        0.00e+00         6.25e-01     fission 1.85e-04   \n",
+       "5       1  2  1        0.00e+00         6.25e-01  nu-fission 4.52e-04   \n",
+       "6       1  2  1        6.25e-01         2.00e+07     fission 6.82e-05   \n",
        "7       1  2  1        6.25e-01         2.00e+07  nu-fission 1.81e-04   \n",
-       "8       1  3  1        0.00e+00         6.25e-01     fission 1.98e-04   \n",
-       "9       1  3  1        0.00e+00         6.25e-01  nu-fission 4.82e-04   \n",
-       "10      1  3  1        6.25e-01         2.00e+07     fission 7.76e-05   \n",
-       "11      1  3  1        6.25e-01         2.00e+07  nu-fission 2.05e-04   \n",
-       "12      1  4  1        0.00e+00         6.25e-01     fission 2.32e-04   \n",
-       "13      1  4  1        0.00e+00         6.25e-01  nu-fission 5.66e-04   \n",
-       "14      1  4  1        6.25e-01         2.00e+07     fission 6.54e-05   \n",
-       "15      1  4  1        6.25e-01         2.00e+07  nu-fission 1.73e-04   \n",
-       "16      1  5  1        0.00e+00         6.25e-01     fission 2.18e-04   \n",
-       "17      1  5  1        0.00e+00         6.25e-01  nu-fission 5.32e-04   \n",
-       "18      1  5  1        6.25e-01         2.00e+07     fission 5.92e-05   \n",
-       "19      1  5  1        6.25e-01         2.00e+07  nu-fission 1.56e-04   \n",
+       "8       1  3  1        0.00e+00         6.25e-01     fission 2.05e-04   \n",
+       "9       1  3  1        0.00e+00         6.25e-01  nu-fission 5.00e-04   \n",
+       "10      1  3  1        6.25e-01         2.00e+07     fission 7.53e-05   \n",
+       "11      1  3  1        6.25e-01         2.00e+07  nu-fission 1.99e-04   \n",
+       "12      1  4  1        0.00e+00         6.25e-01     fission 2.06e-04   \n",
+       "13      1  4  1        0.00e+00         6.25e-01  nu-fission 5.03e-04   \n",
+       "14      1  4  1        6.25e-01         2.00e+07     fission 6.65e-05   \n",
+       "15      1  4  1        6.25e-01         2.00e+07  nu-fission 1.75e-04   \n",
+       "16      1  5  1        0.00e+00         6.25e-01     fission 2.03e-04   \n",
+       "17      1  5  1        0.00e+00         6.25e-01  nu-fission 4.94e-04   \n",
+       "18      1  5  1        6.25e-01         2.00e+07     fission 6.26e-05   \n",
+       "19      1  5  1        6.25e-01         2.00e+07  nu-fission 1.64e-04   \n",
        "\n",
        "   std. dev.  \n",
        "              \n",
-       "0   5.15e-05  \n",
-       "1   1.26e-04  \n",
-       "2   9.06e-06  \n",
-       "3   2.19e-05  \n",
-       "4   3.54e-05  \n",
-       "5   8.62e-05  \n",
-       "6   6.94e-06  \n",
-       "7   1.77e-05  \n",
-       "8   2.55e-05  \n",
-       "9   6.20e-05  \n",
-       "10  9.73e-06  \n",
-       "11  2.48e-05  \n",
-       "12  3.38e-05  \n",
-       "13  8.23e-05  \n",
-       "14  4.61e-06  \n",
-       "15  1.23e-05  \n",
-       "16  3.68e-05  \n",
-       "17  8.97e-05  \n",
-       "18  6.63e-06  \n",
-       "19  1.82e-05  "
+       "0   3.94e-05  \n",
+       "1   9.59e-05  \n",
+       "2   6.79e-06  \n",
+       "3   1.65e-05  \n",
+       "4   2.70e-05  \n",
+       "5   6.58e-05  \n",
+       "6   5.29e-06  \n",
+       "7   1.35e-05  \n",
+       "8   2.25e-05  \n",
+       "9   5.49e-05  \n",
+       "10  7.06e-06  \n",
+       "11  1.81e-05  \n",
+       "12  2.79e-05  \n",
+       "13  6.80e-05  \n",
+       "14  3.91e-06  \n",
+       "15  1.04e-05  \n",
+       "16  2.78e-05  \n",
+       "17  6.78e-05  \n",
+       "18  5.71e-06  \n",
+       "19  1.53e-05  "
       ]
      },
      "execution_count": 22,
@@ -1046,15 +1021,13 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAikAAAGICAYAAACEO3DIAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAAPYQAAD2EBqD+naQAAIABJREFUeJzs3XuYXGWZ7/3vzwCSVg462ZOAGJABc0CRpAVpZM+MuAlD\n1ILRYN5odjBBGMYkMPDuhHdESScMbhPkGGAkGM3OIB1wO4aDGxPBYUMgCdoNUUw3huEQERKJOJw6\nEQj3+8dazayudHV3VQ6ruur3ua66OvWsez11P9150nfWetZaigjMzMzMqs078k7AzMzMrCcuUszM\nzKwquUgxMzOzquQixczMzKqSixQzMzOrSi5SzMzMrCq5SDEzM7Oq5CLFzMzMqpKLFDMzM6tKLlLM\n6oCkOZIeyTuPgUTSW5IKvWz/N0lX7smczOqNixSz3UTS99JfdF2vLZLulvThnFLq9zMwJB2a5nz0\n7kzIzKw3LlLMdq+7gaHAMOAk4E3gzlwz6h9RRlFTVsfSOyRpd/Rt5ZG0V945mPXGRYrZ7vWniHgh\nIn4fEb8Evgm8X9KfdQVI+pCkeyV1pkdbbpT0rnTbOyU9JunGTPxfSHpZ0pfS92dK+qOk0yT9RtJW\nST+RdEippJS4RNJvJW2T9IikUzIhT6ZfH02PqPysl74Kmc+9V9KUdJ/9i/L7jKRfA9vS70GvOUj6\nq2w/adtH0rbh5Yw93d6abn8i/dx3ZLYfIen+dPtjkv5bqfEW2UvSQkn/IekFSfMyfX5d0q96+H49\nKmluie/lgZK+L+n36d+HxyWdmdn+Pkktkv4g6VVJD0s6NrP979Px/UlSu6TJRf2/JelcSbdLehX4\natr+IUn/R9IrkjZJWpr9O2qWm4jwyy+/dsML+B7wr5n37wa+DXRk2hqA3wG3AaOAvwb+HfhuJuYj\nJL/YP0PyH4vVwA8y288E/gSsBY4DxgBrgAcyMXOAtsz7C4A/AmcAR5IUT38C/iLd/lHgrTSfPwcO\nLDHGw9L9vpn283ngt8B2YP+i/B4Ajk/j9u1HDn+V7SfzvdgODC9j7P8V+A9gMnAo8Mn0e/z1dLuA\nXwErgQ8BJwKt6ecUevn5/hvwMnBlmv8k4FXgrHT7+4A3gMbMPmNIjqYdWqLP69LPHgMMJzn69ql0\n27vSvO8DmoDDgQnAx9Ltf5t+L/4OOCL9/r4B/FWm/7eA59Pv22HAIcABwGbg0nQcHwF+AtyT9xzy\ny6/cE/DLr1p9kRQpbwCvpK+3gGeBYzIxZwNbgH0zbaem+/2XTNv/C/weuDbt4z2ZbWemv1A/mmkb\nkX7eR9P3xUXKs8BFRfmuBRamfz403f/oPsb4P4F1RW2XsmORsh34UFFcXzn0t0jpa+w/7eFzvgj8\nLv3zuPSX+9DM9lPSPvoqUh7r4fvxWOb9j4HrMu+vBe7tpc/bge+U2HYOSbF1QIntq4B/Lmq7Fbgz\n8/4t4FtFMRcDdxe1HZLGHpH3PPKrvl8+3WO2e/0MOJrkl+uxwArgJ5Len24fSfJLfltmnweBQSS/\nbLtcCfwGmA5MjYg/Fn3OmxHxi643EfE4yS+0UcUJSdoPOBh4qGjTgz3F92EE8POitod7iHs9Ih7b\nTTn0NfaPAJekpzJekfQKcBMwVNK+JD+D30bE5kyfq/v52WuK3q8GjsysubkJmCRpH0l7kxxtWdxL\nf/+cxj8iab6kpsy2jwCPRMRLJfYdRf++n61F7z8CnFT0/WknWZP0F73karbbedGU2e71WkQ81fVG\n0tnASyRHUC4po5+hwAdJjhp8kOTowECytYJ93kq/ZhfZ7l1BP+8m+V7/aw/b/lRBf+W4M/2MvyU5\nOrYX8MNSwRHxk3S9zXjgZOBeSddFxGwq+x725LWi9+8G7gBm0/17DcmpIbPc+EiK2Z73FjA4/XM7\n8BFJgzPbTyQpRh7PtH0X+CXJ6Y0FkrJHWSBZwPnRrjfp9gOB9cUfHhGvAM8BHy/a9PFM/Ovp10F9\njOVxkvUrWcf1sU9/c3iB5JfmQZntY3rorq+xtwEjIuLJHl5B8jN4v6ShmT6b6N/VTR8ret8EbEj7\nJSK2A0uBacBUYFlE9FoYRcQfIuJfImIK8A8kp3kg+fkfI+nAEru20/v3s5Q24CjgmR6+P7uqMDKr\nTN7nm/zyq1ZfJGtSfkxyFGQoyWmF60kWTv5lGjOYZG3GbSS/KD4BPAEszvQzHfgDcHD6/vskh+z3\nSt93LR5dTVIgNJIc9l+V6aN4Tcr5JItWP09yZOabJItzuxatDiL5H/c/kiyc3b/EGA9L98sunN1I\nUmTtl8nvxR727SuHvYBngGUkC0E/RfKLuKeFs72NvWvNySXA6PTnMBG4NN0u4DGSU3FHkyy0/Tn9\nWzj7EvCtNP9JJGuPvlwUdwTJUZTXgWP7+DszFyiQnGY5iuQIx0Pptr2BDpKFsycAHwA+y38unD0t\n/f6dm37mheln/tdM/zussyEpAjeR/B38KMmC3FNICmPlPY/8qu9X7gn45VetvkiKlO2Z13+QrGE4\nvSjuKOCetCh4gWRdQkO6bQTJFSOfz8QfADwN/M/0/ZnAi8DpJAVOJ8nVGYdk9ikuUgR8naSg2Eby\nv+mTi/Kaln7OG8DPehnnp0mOqHQC95L8z387sE82vx72608OTcCj6ffmvvSXcnGR0uvY07iTSa4u\nepWkMFpNehVOuv0I4P+SnFJpT+P7KlJ+BiwkKTz/g2QB9LwSsf8X+GU//s5cTFIwvZr+XfhXMlcC\nAe9Pi4k/khREa+m+aPjvgA3p97Md+EJR/z2OiaQo+t8kxfCrwK+BK/KeQ375pYj+HNE0s2qV3kfj\nqoh4b965AEi6GDgnIg7dA59VVWMvRdIGkqt8rsk7F7OBxAtnzWynSPp7ktMjfyBZT/M/SC61rXuS\nhpCcBhoKLMk3G7OBx0WKme2sI4GvAe8hOXVzOcn6EkvubfMCcHaUvnTYzErw6R4zMzOrSr4E2cx2\nO0nN6XNjjpR0c/qsm993PetG0vslLZf0kqTnJV1YtP8+kuZK2pA+52djerOzfYripip5ftDmNO7X\nks7tIZ+nJd0h6eOS1qbP7Pl3Sf99934nzKwcLlLMbE/oOmR7a/r1IpIrnS6W9A8kz815luSGYhuA\nyyWdCMnDEEluinYhyW3jZwA/Ink2zbKizzmX5Iqky9L4jcAN6bqZ4nyOBH6QfvaFJFcJfU9SuXe8\nNbPdxKd7zGy3kzSH5DLob0fEV9K2d5AUFAcD/19EfCttP4DkRm+3RsS09Em+3yO5t8zqTJ/nkFyu\n/fGIWJO2vTOKbpYm6W6SZ9AcmWl7iuQBfv81Ih5K24aQPBxxYSR3eDWznPlIipntKUHmuTUR8Rbw\nC5L7pXw30/4SyX1XDk+bJpDc8+M3kv6s60VyMzWR3ACva9+3CxRJ+6dx9wOHp88LylrfVaCk+24p\n+lwzy5mv7jGzPWlj0fuXgG0R8WIP7V33PjmS5C6xL/TQX5DcERcASR8nuWvr8UBDUdwBJDdAK5UL\nJDdJe0/vQzCzPcVFipntSdv72Qb/+bC7dwC/IlmDUvwAPEhO0SDpcJI797ansb8luS38p0iegVN8\n5LivzzWznLlIMbNq9+/A0RHxb33EfQbYB/hMRPyuq1HSJ3dncma2+3hNiplVu9uAQySdXbxB0r6S\nuk7rdB0ZeUdm+wHAl3Z7hma2W/hIiplVu38heVLyP0v6BPAgyVOaRwFnkDzluI3kUuI3gLsk3Qjs\nB3wZ2AwMyyFvM9tJLlLMLG+l7oMQABERkk4jWWcyheSJx53Ak8BVwG/SuN9I+hzwTyS35t8E3EDy\nTKHFPfTd6+eaWf58nxQzMzOrShWtSZE0XdJT6a2k10g6to/4MyS1p/HrJJ3aQ8w8Sc9J6pT0U0lH\nlOhrH0mPprfYPjrTfmjaln1tl3RcJWM0MzOzfJVdpEiaCFxBcvfIMcA6YEV6t8ae4k8AbgFuAo4h\nua31ckmjMzEXkdzq+hzgOOC1tM99duyRBSS3z+7pEFAAJ5Gcfx4GHAS0ljtGMzMzy1/Zp3skrQHW\nRsT56XuR3I/g2ohY0EP8MqAhIgqZttXAI5nbYz8HXB4RV6Xv9ydZ7HZmRNyW2e9U4FvA54D1wDER\n8ct026HAU9k2MzMzG7jKOpIiaW+gEbi3qy2SKuceoKnEbk3p9qwVXfHpDZiGFfX5MrA226ekocAi\nYDKwtZc070ifgPqApM/0b2RmZmZWbco93TOE5NK/zUXtvV3iN6yP+KEkp2n66vN7wA0R8UiJz3mV\n5EmmZwDjgVUkp5U+XSLezMzMqtiAuARZ0nnAu4H5XU3FMRHxB+DqTFOrpIOBWcBdJfr9M+AUkiex\nbtuFKZuZmVlp+wKHASvS3989KrdI2UJyV8ehRe1DSe5J0JNNfcRvIik6htL9aMpQoOuoySdITv38\nKVkC87ZfSPp+REwt8dlrgf9WYhskBcr3e9luZmZmu88XSS6u6VFZRUpEvCGpFfgkcAe8vXD2k8C1\nJXZb3cP2k9N2IuIpSZvSmK5FsPsDHwOuT+NnAhdn9j+YZF3L54GHe0l5DPB8L9ufBrj55psZNWpU\nL2E2UF1wwQVcddVVeadhZhXw/K1d7e3tTJ48GdLfw6VUcrrnSmBJWqw8THIXyAZgCYCkpcCzEfHV\nNP4a4D5JFwI/BiaRLL7NPofjauBrkp5IE76U5DLj2wEi4tlsApJeIzn68mREPJe2TSF54mnX0ZfP\nkTyz46xexrINYNSoUYwdO7aMb4ENFAcccIB/tmYDlOdvXeh1qUXZRUpE3JbeE2UeySmZR4FTIuKF\nNOQQ4M1M/GpJXwAuS18bgNMiYn0mZkH6kLAbgQOBB4BTI+L13lLpoe3rwPD08zuAz0fEj8odo5mZ\nmeWvooWzEXEDyTMxetp2Ug9tPwR+2EefzUBzPz//GZKrjLJtS4Gl/dnf6seLL76YdwpmViHPX6vo\ntvhmA8UTTzyRdwpmViHPX3ORYjXtm9/8Zt4pmFmFPH/NRYrVtC996Ut5p2BmFfL8NRcpZmZmVpVc\npJiZWVVqaWnJOwXLmYsUq2mzZs3KOwUzq9DXv/71vFOwnLlIsZo2fPjwvFMwswoNHjw47xQsZy5S\nrKbNnDkz7xTMrEIf+MAH8k7BcjYgnoJsZma1r6Wlpds6lDvvvJNCofD2+0mTJjFp0qQ8UrOcuEgx\nM7OqUFyEFAoF7rjjjhwzsrz5dI/VtI6OjrxTMLMKvfLKK3mnYDlzkWI1bfbs2XmnYGYVam9vzzsF\ny5mLFKtp1113Xd4pmFmFLr744rxTsJy5SLGa5kuQzQYuX51nLlLMzMysKrlIMTMzs6rkIsVq2vz5\n8/NOwcwq5PlrLlKspnV2duadgplVyPPXXKRYTZs7d27eKZhZhTx/zUWKmZmZVSUXKWZmVpWyz/Gx\n+uQixWrali1b8k7BzCq0ZMmSvFOwnFVUpEiaLukpSVslrZF0bB/xZ0hqT+PXSTq1h5h5kp6T1Cnp\np5KOKNHXPpIelfSWpKOLth0t6f70c56RNKuS8VntmDZtWt4pmFmF1q5dm3cKlrOyixRJE4ErgDnA\nGGAdsELSkBLxJwC3ADcBxwC3A8sljc7EXATMAM4BjgNeS/vcp4cuFwDPAlH0OfsBK4CngLHALKBZ\n0pfLHaPVjubm5rxTMLMKDRo0KO8ULGd7VbDPBcCNEbEUQNK5wKeAaSQFRLHzgLsj4sr0/SWSTiYp\nSr6Stp0PXBoRd6V9TgE2A6cDt3V1lB6BORn4HDC+6HMmA3sDZ0XEm0C7pDHAhcB3Khin1YCxY8fm\nnYKZ9VNLS0u3dSgvvvgihULh7feTJk1i0qRJeaRmOSmrSJG0N9AIfKOrLSJC0j1AU4ndmkiOvGSt\nAE5L+zwcGAbcm+nzZUlr031vS+OGAouAArC1h885Hrg/LVCynzNb0gER8VJ/x2lmZntecRHyzne+\nkzvuuCPHjCxv5R5JGQIMIjnKkbUZGFFin2El4oelfx5KcuqmtxiA7wE3RMQjkg4t8TlP9tBH1zYX\nKWZmVaz4SMrrr7/uIyl1rpLTPXucpPOAdwNd90hWjunYALJ48WLOOuusvNMws34oLkIk+UhKnSt3\n4ewWYDvJ0Y+socCmEvts6iN+E0nR0VvMJ0hO/fxJ0hvAhrT9F5K+18fndG0rafz48RQKhW6vpqYm\nli9f3i1u5cqV3ar6LtOnT2fx4sXd2tra2igUCjtcAjtnzpwdnkexceNGCoUCHR0d3doXLlzIrFnd\nL1Dq7OykUCiwatWqbu0tLS1MnTp1h9wmTpxY1+Noa2uriXF08Tg8jloeR1NTE8cee+zb/w4DHH/8\n8QwbNoxCodDtKEs1j6NWfh67ahyLFi3q9vt1xIgRTJgwYYc+eqKI6Dsqu4O0BlgbEeen7wVsBK6N\niMt7iF8GDI6I0zJtDwLrIuIr6fvngMsj4qr0/f4kp2qmRMQPJB0C7J/p9mCS9SafAx6OiOfSBbz/\nBAyNiO1pP98ATo+I0fRA0ligtbW11QsszcyqjCTK/R1lA0NbWxuNjY0AjRHRViquktM9VwJLJLUC\nD5Nc7dMALAGQtBR4NiK+msZfA9wn6ULgx8AkksW3Z2f6vBr4mqQngKeBS0kuM74dICKezSYg6TWS\noy9PRsRzafMtwCXAdyXNBz5McmXR+RWM0czM9rDiNSmA16TUubKLlIi4Lb0nyjyS0ymPAqdExAtp\nyCHAm5n41ZK+AFyWvjYAp0XE+kzMAkkNwI3AgcADwKkR8XpvqRTl9bKkccD1wC9ITk01R8TinnY2\nMzOz6lbRwtmIuAG4ocS2k3po+yHwwz76bAaa+/n5z5BcZVTc/hjwV/3pw8zMzKrbgLi6x6xShULB\nVweYDRC+useK+QGDVtNmzJiRdwpmZlYhFylW08aNG5d3CmZmViEXKWZmVpX8gEFzkWJmZlVh5syZ\nDBs27O3X9u3bu72fOXNm3inaHuaFs1bTli9fzumnn553GmbWDyeccALPPPPM2+/vvPNOjjvuuG7b\nrb64SLGa1tLS4iLFbIAovrpn0KBBvrqnzrlIsZp266235p2CmRXp7Ozc4VkzPRk0aNDbz9/qzciR\nI2loaNgVqVmVcZFiZmZ7VEdHR9dzW/rUnzg/f612uUgxM7M9auTIkbS2tvYa094Okyf/hJtv/htG\njeq7P6tNLlLMzGyPamho6OeRj7GMGgU+SFK/fAmy1bSpU6fmnYKZVczzt965SLGa5jvOmg1Mo0bB\nggXj+jzVY7XNp3uspmUvZzSzgWPwYJg1y/O33vlIipmZmVUlFylmZmZWlVykWE1btWpV3imYWYU8\nf81FitW0BQsW5J2CmVXI89dcpFhNW7ZsWd4pmFmFPH/NRYrVND/Pw2zg8vw1FylmZlZ1nn8empuT\nr1a/XKSYmVnVef55mDvXRUq9c5FiNW3WrFl5p2BmFfP8rXcVFSmSpkt6StJWSWskHdtH/BmS2tP4\ndZJO7SFmnqTnJHVK+qmkI4q23y7pmbSP5yQtlXRQZvuhkt4qem2XdFwlY7TaMHz48LxTMLOKef7W\nu7KLFEkTgSuAOcAYYB2wQtKQEvEnALcANwHHALcDyyWNzsRcBMwAzgGOA15L+9wn09XPgDOADwKf\nBf4C+EHRxwVwEjAsfR0E9P48cKtpM2fOzDsFM6uY52+9q+RIygXAjRGxNCI6gHOBTmBaifjzgLsj\n4sqIeDwiLgHaSIqSLucDl0bEXRHxGDAFOBg4vSsgIq6JiIcj4rcRsQb4JnC8pEGZfgS8GBG/z7y2\nVzBGMzMzy1lZRYqkvYFG4N6utogI4B6gqcRuTen2rBVd8ZIOJznqke3zZWBtqT4lvRf4IvBgD0XI\nHZI2S3pA0mf6OTQzMzOrMuUeSRkCDAI2F7VvJik0ejKsj/ihJKdp+uxT0jclvQpsAd5P5kgL8Cpw\nIckpofHAKpLTSp/ufUhWyzo6OvJOwcwq5vlb7wba1T0LSNa1nAxsB/6la0NE/CEiro6In0dEa0T8\nI3Az/VgePn78eAqFQrdXU1MTy5cv7xa3cuVKCoXCDvtPnz6dxYsXd2tra2ujUCiwZcuWbu1z5sxh\n/vz53do2btxIoVDY4RfqwoULd7g6pbOzk0KhsMMzLVpaWpg6deoOuU2cOLGuxzF79uyaGEcXj8Pj\nqJdx7LsvvPvds2ltHdjj6DLQfx47M45FixZ1+/06YsQIJkyYsEMfPVFytqZ/0tM9ncDnIuKOTPsS\n4ICI+Nse9nkGuCIirs20NQOnRcQYSR8A/h04JiJ+mYm5D3gkIi4okcv7gN8CTRGxtkTMV4CLI+J9\nJbaPBVpbW1sZO3Zsr2O3gWnjxo2+wsdsgPL8rV1tbW00NjYCNEZEW6m4so6kRMQbJFfLfLKrTZLS\n9w+V2G11Nj51ctpORDwFbCrqc3/gY730CclpJ4B39hIzBvCtgOqY/4EzG7g8f22vCva5ElgiqRV4\nmORqnwZgCYCkpcCzEfHVNP4a4D5JFwI/BiaRLL49O9Pn1cDXJD0BPA1cCjxLcrky6b1OjiVZZ/JH\n4AhgHrCBtNiRNAV4HXgk7fNzwJeAsyoYo5mZmeWs7CIlIm5L74kyj2TR66PAKRHxQhpyCPBmJn61\npC8Al6WvDSSnetZnYhZIagBuBA4EHgBOjYjX05BOknujNAPvIjk6cjdwWXp0p8vXSe7+8ybJiqvP\nR8SPyh2jmZmZ5a+sNSm1xmtSat/8+fO56KKL8k7DzCrg+Vu7dsuaFLOBprOzM+8UzKxCnr/mIsVq\n2ty5c/NOwcwq5PlrLlLMzMysKrlIMTOzqrN+PRx1VPLV6peLFKtpxXdsNLOBYds2WL9+C9u25Z2J\n5clFitW0adNKPZzbzKqf52+9c5FiNa25uTnvFMysYs15J2A5c5FiNc33vzEbyDx/652LFDMzM6tK\nLlLMzMysKrlIsZq2ePHivFMws4p5/tY7FylW09raSj4Swsyq2EEHwUc/2sZBB+WdieWp7Kcgmw0k\n119/fd4pmFkFDjoIfv5zz9965yMpZmZmVpVcpJiZmVlVcpFiZmZmVclFitW0QqGQdwpmViHPX3OR\nYjVtxowZeadgZhXy/DUXKVbTxo0bl3cKZlYhz19zkWJmZlVn61b49a+Tr1a/XKSYmVnVaW+HD30o\n+Wr1y0WK1bTly5fnnYKZVczzt95VVKRImi7pKUlbJa2RdGwf8WdIak/j10k6tYeYeZKek9Qp6aeS\njijafrukZ9I+npO0VNJBRTFHS7o/jXlG0qxKxme1o6WlJe8UzKxinr/1ruwiRdJE4ApgDjAGWAes\nkDSkRPwJwC3ATcAxwO3AckmjMzEXATOAc4DjgNfSPvfJdPUz4Azgg8Bngb8AfpDpYz9gBfAUMBaY\nBTRL+nK5Y7Taceutt+adgplVzPO33lVyJOUC4MaIWBoRHcC5QCcwrUT8ecDdEXFlRDweEZcAbSRF\nSZfzgUsj4q6IeAyYAhwMnN4VEBHXRMTDEfHbiFgDfBM4XtKgNGQysDdwVkS0R8RtwLXAhRWM0czM\nzHJWVpEiaW+gEbi3qy0iArgHaCqxW1O6PWtFV7ykw4FhRX2+DKwt1aek9wJfBB6MiO1p8/HA/RHx\nZtHnjJB0QH/GZ2ZmZtWj3CMpQ4BBwOai9s0khUZPhvURPxSI/vQp6ZuSXgW2AO8nc6Sll8/p2mZm\nZmYDyEC7umcBybqWk4HtwL/km45Vu6lTp+adgplVzPO33pVbpGwhKQ6GFrUPBTaV2GdTH/GbAPWn\nz4h4MSKeiIh7gUnAeEkf6+NzuraVNH78eAqFQrdXU1PTDpevrly5ssdnSUyfPp3Fixd3a2tra6NQ\nKLBly5Zu7XPmzGH+/Pnd2jZu3EihUKCjo6Nb+8KFC5k1q/sFSp2dnRQKBVatWtWtvaWlpcdfyBMn\nTqzrcXTdsXKgj6OLx+Fx1Ms4Ro2CBQvG8bvfDexxdBnoP4+dGceiRYu6/X4dMWIEEyZM2KGPnihZ\nUtJ/ktYAayPi/PS9gI3AtRFxeQ/xy4DBEXFapu1BYF1EfCV9/xxweURclb7fn+RUzZSI+EFxn2nM\ncOBp4K8j4n5J5wL/BAztWqci6RvA6RExukQfY4HW1tZWxo4dW9b3wczMzCrT1tZGY2MjQGNEtJWK\nq+R0z5XA2ZKmSBoJfBtoAJYApPcv+UYm/hrgbyRdKGmEpGaSxbfXZWKuBr4m6TOSPgwsBZ4luVwZ\nScel92b5iKThkk4iuax5A7A67eMW4HXgu5JGp5dKn0dyubSZmZkNMHuVu0NE3JbeE2UeyemUR4FT\nIuKFNOQQ4M1M/GpJXwAuS18bgNMiYn0mZoGkBuBG4EDgAeDUiHg9DekkuTdKM/Au4HngbuCyiHgj\n7eNlSeOA64FfkJyaao6I7sefzMzMbEAo+3RPLfHpntq3atUqTjzxxLzTMLMKeP7Wrt15usdswFiw\nYEHeKZhZhTx/zUWK1bRly5blnYKZVcjz11ykWE1raGjIOwUzq5Dnr7lIMTOzqvP889DcnHy1+uUi\nxczMqs7zz8PcuS5S6p2LFKtpxXdcNLOBxPO33rlIsZo2fPjwvFMws4p5/tY7FylW02bOnJl3CmZW\nMc/feucixczMzKqSixQzMzOrSi5SrKYVP77czAYSz9965yLFatrs2bPzTsHMKrDvvvDud89m333z\nzsTyVPZTkM0Gkuuuuy7vFMysAqNHw69/fR2+QK+++UiK1TRfgmw2cHn+mosUMzMzq0ouUszMzKwq\nuUixmjZ//vy8UzCzCnn+mosUq2mdnZ15p2BmFfL8NRcpVtPmzp2bdwpmViHPX3ORYmZmZlXJRYqZ\nmVWd9evhqKOSr1a/XKRYTduyZUveKZhZBbZtg/Xrt7BtW96ZWJ4qKlIkTZf0lKStktZIOraP+DMk\ntafx6ySd2kPMPEnPSeqU9FNJR2S2HSrpO5KeTLdvkNQsae+imLeKXtslHVfJGK02TJs2Le8UzKxi\nnr/1ruwiRdJE4ApgDjAGWAeskDSkRPwJwC3ATcAxwO3AckmjMzEXATOAc4DjgNfSPvdJQ0YCAs4G\nRgMXAOdh38QUAAAgAElEQVQClxV9XAAnAcPS10FAa7ljtNrR3NycdwpmVrHmvBOwnFVyJOUC4MaI\nWBoRHSTFQielS97zgLsj4sqIeDwiLgHaSIqSLucDl0bEXRHxGDAFOBg4HSAiVkTEWRFxb0Q8HRF3\nAd8CPlv0WQJejIjfZ17bKxij1YixY8fmnYKZVczzt96VVaSkp1cagXu72iIigHuAphK7NaXbs1Z0\nxUs6nOSoR7bPl4G1vfQJcCDwYg/td0jaLOkBSZ/pdUBmZmZWtco9kjIEGARsLmrfTFJo9GRYH/FD\nSU7T9LvPdL3KDODbmeZXgQuBM4DxwCqS00qfLpGXmZmZVbEBd3WPpPcBdwO3RsR3u9oj4g8RcXVE\n/DwiWiPiH4GbgVl55Wr5W7x4cd4pmFnFPH/rXblFyhZgO8nRj6yhwKYS+2zqI34TyVqSPvuUdDDw\nM2BVRPxdP/JdCxzRV9D48eMpFArdXk1NTSxfvrxb3MqVKykUCjvsP3369B1+Gba1tVEoFHa4BHbO\nnDk7PI9i48aNFAoFOjo6urUvXLiQWbO611idnZ0UCgVWrVrVrb2lpYWpU6fukNvEiRPrehxtbW01\nMY4uHofHUS/jOOgg+OhH23j88YE9ji4D/eexM+NYtGhRt9+vI0aMYMKECTv00RMlS0r6T9IaYG1E\nnJ++F7ARuDYiLu8hfhkwOCJOy7Q9CKyLiK+k758DLo+Iq9L3+5Oc7pkSET9I295HUqD8HPjv0Y/E\nJd0EjImIj5bYPhZobW1t9QJLMzOzPaStrY3GxkaAxohoKxW3VwV9XwkskdQKPExytU8DsARA0lLg\n2Yj4ahp/DXCfpAuBHwOTSBbfnp3p82rga5KeAJ4GLgWeJblcuesIyn3AU8Bs4M+T2ggiYnMaMwV4\nHXgk7fNzwJeAsyoYo5mZmeWs7CIlIm5L74kyj+SUzKPAKRHxQhpyCPBmJn61pC+Q3NPkMmADcFpE\nrM/ELJDUANxIctXOA8CpEfF6GnIycHj6+m3aJpIFt4My6X0dGJ5+fgfw+Yj4UbljNDMzs/yVfbqn\nlvh0j5mZ2Z7X39M9A+7qHrNy9LTAy8wGBs9fc5FiNW3GjBl9B5lZVfL8NRcpVtPGjRuXdwpmViHP\nX3ORYmZmVWfrVvj1r5OvVr9cpJiZWdVpb4cPfSj5avXLRYrVtOK7JZrZQOL5W+9cpFhNa2lpyTsF\nM6uY52+9c5FiNe3WW2/NOwUzq5jnb71zkWJmZmZVyUWKmZmZVSUXKWZmZlaVXKRYTZs6dWreKZhZ\nxTx/652LFKtpvmOl2cA0ahQsWDCOUaPyzsTytFfeCZjtTpMmTco7BTOrwODBMGuW52+985EUMzMz\nq0ouUszMzKwquUixmrZq1aq8UzCzCnn+mosUq2kLFizIOwUzq5Dnr7lIsZq2bNmyvFMwswp5/pqL\nFKtpDQ0NeadgZhXy/DUXKWZmVnWefx6am5OvVr9cpJiZWdV5/nmYO9dFSr1zkWI1bdasWXmnYGYV\n8/ytdxUVKZKmS3pK0lZJayQd20f8GZLa0/h1kk7tIWaepOckdUr6qaQjMtsOlfQdSU+m2zdIapa0\nd1EfR0u6P/2cZyT5b3idGz58eN4pmFnFPH/rXdlFiqSJwBXAHGAMsA5YIWlIifgTgFuAm4BjgNuB\n5ZJGZ2IuAmYA5wDHAa+lfe6ThowEBJwNjAYuAM4FLsv0sR+wAngKGEtSgjdL+nK5Y7TaMXPmzLxT\nMLOKef7Wu0qOpFwA3BgRSyOig6RY6ASmlYg/D7g7Iq6MiMcj4hKgjaQo6XI+cGlE3BURjwFTgIOB\n0wEiYkVEnBUR90bE0xFxF/At4LOZPiYDewNnRUR7RNwGXAtcWMEYzczMLGdlFSnp6ZVG4N6utogI\n4B6gqcRuTen2rBVd8ZIOB4YV9fkysLaXPgEOBF7MvD8euD8i3iz6nBGSDuilHzMzM6tC5R5JGQIM\nAjYXtW8mKTR6MqyP+KFAlNNnul5lBvDtfnxO1zarQx0dHXmnYGYV8/ytdwPu6h5J7wPuBm6NiO/u\nij7Hjx9PoVDo9mpqamL58uXd4lauXEmhUNhh/+nTp7N48eJubW1tbRQKBbZs2dKtfc6cOcyfP79b\n28aNGykUCjv8Ql24cOEOV6d0dnZSKBR2eKZFS0sLU6dO3SG3iRMn1vU4Zs+eXRPj6OJxeBz1Mo59\n94V3v3s2ra0DexxdBvrPY2fGsWjRom6/X0eMGMGECRN26KMnSs7W9E96uqcT+FxE3JFpXwIcEBF/\n28M+zwBXRMS1mbZm4LSIGCPpA8C/A8dExC8zMfcBj0TEBZm2g4F/Ax6KiG7fUUn/C9gvIj6baftr\nktNI742Il3rIbSzQ2traytixY/v9fbCBY+PGjb7Cx2yA8vytXW1tbTQ2NgI0RkRbqbiyjqRExBtA\nK/DJrjZJSt8/VGK31dn41MlpOxHxFLCpqM/9gY9l+0yPoPwb8HN6XqS7GvhLSYMybeOAx3sqUKw+\n+B84s4HL89cqOd1zJXC2pCmSRpKsC2kAlgBIWirpG5n4a4C/kXShpBHpUZRG4LpMzNXA1yR9RtKH\ngaXAsySXK3cdQbkPeAaYDfy5pKGShmb6uAV4HfiupNHppdLnkVwubWZmZgPMXuXuEBG3pfdEmUey\n6PVR4JSIeCENOQR4MxO/WtIXSO5pchmwgeRUz/pMzAJJDcCNJFftPACcGhGvpyEnA4enr9+mbSJZ\ncDso7eNlSeOA64FfAFuA5ojofpLMzMzMBoSKFs5GxA0RcVhEDI6Ipoj4RWbbSRExrSj+hxExMo0/\nOiJW9NBnc0QcHBENEXFKRDyR2fa/ImJQ0esdETGoqI/HIuKv0j6GR8S3Khmf1Y7iRWZmNnB4/tqA\nu7rHrBydnZ15p2BmFfL8NRcpVtPmzp2bdwpmViHPX3ORYmZmZlXJRYqZmVWd9evhqKOSr1a/XKRY\nTSu+Y6OZDQzbtsH69VvYti3vTCxPLlKspk2bVurh3GZW/Tx/652LFKtpxx9/fN4pmFnFmvNOwHLm\nIsVq2po1a/JOwcwq5meq1TsXKWZmZlaVXKSYmZlZVSr72T1m1aylpYWWlpa33995550UCoW330+a\nNIlJkyblkZpZ3diwAV55Zef6aG8HWEx7+1k7nc9++8GRR+50N5YDFylWU4qLkA984APccccdOWZk\nVl82bIAPfnBX9dbG5Mk7X6QA/OY3LlQGIhcpVtM+/OEP552CWV3pOoJy880watTO9nb9znZAeztM\nnrzzR3YsHy5SrKb96le/yjsFs7o0ahSM9cU5tpO8cNZq2ubNm/NOwczMKuQixWran/70p7xTMDOz\nCrlIsZr21ltv5Z2CmVUoe2We1ScXKVZTZs6cybBhw95+Ad3ez5w5M+cMzay/ZsyYkXcKljMvnLWa\ncsIJJ/DMM8+8/f7OO+/kuOOO67bdzAaGcePG5Z2C5cxFitWUhx56iIcffrhbW/b9oYce6pu5mZkN\nEC5SrKb4SIqZWe1wkWI1pfiOs5J8x1mzAWr58uWcfvrpeadhOapo4ayk6ZKekrRV0hpJx/YRf4ak\n9jR+naRTe4iZJ+k5SZ2SfirpiKLtX5X0oKTXJL1Y4nPeKnptl/T5SsZo1a2zs5O2trYdXk1NTeyz\nzz5vv4Bu75uamnrcr7OzM+cRmVmx7HO4rD6VfSRF0kTgCuAc4GHgAmCFpA9GxJYe4k8AbgEuAn4M\nfBFYLmlMRKxPYy4CZgBTgKeBf0r7HBURr6dd7Q3cBqwGpvWS4pnATwCl7/+j3DFa9evo6KCxsbFf\nsW+88cbbf16zZk2P+7W2tjLWt8c0qyq33npr3ilYzio53XMBcGNELAWQdC7wKZLCYUEP8ecBd0fE\nlen7SySdTFKUfCVtOx+4NCLuSvucAmwGTicpTIiIuem2M/vI76WIeKGCcdkAMnLkSFpbW3uNSZ7Z\ncRw33/xwn88QGTly5C7MzszMdoWyihRJewONwDe62iIiJN0DNJXYrYnkyEvWCuC0tM/DgWHAvZk+\nX5a0Nt33tnJyBK6XtBh4Evh2RHyvzP1tAGhoaOjnkY9BjBo11s8QMTMbgMo9kjIEGERylCNrMzCi\nxD7DSsQPS/88FIg+Yvrr68DPgE5gHHCDpHdFxHVl9mM146/zTsDMzCpUU3ecjYjLImJ1RKyLiMtJ\nTj/Nyjsvy9PBeSdgZhWaOnVq3ilYzsotUrYA20mOfmQNBTaV2GdTH/GbSBa5ltNnf60FDklPU5U0\nfvx4CoVCt1dTUxPLly/vFrdy5coenyUxffp0Fi9e3K2tra2NQqHAli3d1xLPmTOH+fPnd2vbuHEj\nhUKBjo6Obu0LFy5k1qzuNVZnZyeFQoFVq1Z1a29paelxQk+cOLHOxzGuRsaBx+Fx1N04xo0bt0vG\nAXNYssQ/j7zGsWjRom6/X0eMGMGECRN26KMnioh+Bb69g7QGWBsR56fvBWwErk2PXhTHLwMGR8Rp\nmbYHgXUR8ZX0/XPA5RFxVfp+f5LTPVMi4gdF/Z0JXBUR7+1HrhcDF0TEkBLbxwKtvrKjNrW1QWMj\ntLbiNSlme0i1zbtqy8cSbW1tXVdaNkZEW6m4Sq7uuRJYIqmV/7wEuQFYAiBpKfBsRHw1jb8GuE/S\nhSSXIE8iWXx7dqbPq4GvSXqC5BLkS4Fngdu7AiS9H3gvcCgwSNJH0k1PRMRrkj5NcvRlDbCN5L/Q\n/0jPVxxZHTjoIJgzJ/lqZmYDT9lFSkTcJmkIMI+kKHgUOCVz2e8hwJuZ+NWSvgBclr42AKd13SMl\njVkgqQG4ETgQeAA4NXOPFNLPm5J531V5fQK4H3gDmE5SRAl4AviHiPhOuWO02nDQQdDcnHcWZmZW\nqYpuix8RNwA3lNh2Ug9tPwR+2EefzUBzL9unAiVXUUXECpJLm83etmrVKk488cS80zCzCnj+Wk1d\n3WNWbMECn+0zG6g8f81FitW0ZcuW5Z2CmVXI89dcpFhNa2hoyDsFM6uQ56+5SDEzM7Oq5CLFzMzM\nqpKLFKtZW7fC1Kmz2Lo170zMrBLFd0y1+uMixWpWezssWTKc9va8MzGzSgwfPjzvFCxnLlKsxs3M\nOwEzq9DMmZ6/9c5FipmZmVUlFylmZmZWlVykWI3r6DvEzKpSR4fnb71zkWI1bnbeCZhZhWbP9vyt\ndy5SrMZdl3cCZlah667z/K13LlKsxvkSRrOBypcg2155J2C2u4waBY89BocfnncmZmZWCRcpVrMG\nD4ajjso7CzMzq5RP91hNmz9/ft4pmFmFPH/NRYrVtM7OzrxTMLMKef6aixSraXPnzs07BTOrkOev\nuUgxMzOzquQixczMzKqSixSraVu2bMk7BTOrkOevVVSkSJou6SlJWyWtkXRsH/FnSGpP49dJOrWH\nmHmSnpPUKemnko4o2v5VSQ9Kek3SiyU+5/2SfpzGbJK0QJILsTr1/PPw8Y9P4/nn887EzCoxbdq0\nvFOwnJX9C1zSROAKYA4wBlgHrJA0pET8CcAtwE3AMcDtwHJJozMxFwEzgHOA44DX0j73yXS1N3Ab\n8M8lPucdwP8huffL8cCZwJeAeeWO0WrD88/Db37T7CLFbIBqbm7OOwXLWSVHGS4AboyIpRHRAZwL\ndAKlSt7zgLsj4sqIeDwiLgHaSIqSLucDl0bEXRHxGDAFOBg4vSsgIuZGxDXAr0p8zinASOCLEfGr\niFgBfB2YLsk3ratbY/NOwMwqNHas52+9K6tIkbQ30Ajc29UWEQHcAzSV2K0p3Z61oite0uHAsKI+\nXwbW9tJnT44HfhUR2ZOYK4ADAN931MzMbIAp90jKEGAQsLmofTNJodGTYX3EDwWizD7L+ZyubWZm\nZjaAeFGp1bjFeSdgZhVavNjzt96VW6RsAbaTHP3IGgpsKrHPpj7iNwEqs89yPqdrW0njx4+nUCh0\nezU1NbF8+fJucStXrqRQKOyw//Tp03eYTG1tbRQKhR0uoZszZ84Oz6PYuHEjhUKBjo6Obu0LFy5k\n1qxZ3do6OzspFAqsWrWqW3tLSwtTp07dIbeJEyfW+TjaamQceBweR92No62tbZeMA+awZIl/HnmN\nY9GiRd1+v44YMYIJEybs0EdPlCwp6T9Ja4C1EXF++l7ARuDaiLi8h/hlwOCIOC3T9iCwLiK+kr5/\nDrg8Iq5K3+9PcqpmSkT8oKi/M4GrIuK9Re1/A9wJHNS1LkXSOcB84M8j4o0echsLtLa2tnqBVg1q\na4PGRmhtBf94zfaMapt31ZaPJdra2mhsbARojIi2UnGVXPVyJbBEUivwMMnVPg3AEgBJS4FnI+Kr\nafw1wH2SLgR+DEwiWXx7dqbPq4GvSXoCeBq4FHiW5HJl0n7fD7wXOBQYJOkj6aYnIuI1YCWwHviX\n9JLmg9J+ruupQLHat+++MHp08tXMzAaesouUiLgtvSfKPJLTKY8Cp0TEC2nIIcCbmfjVkr4AXJa+\nNgCnRcT6TMwCSQ3AjcCBwAPAqRHxeuaj55Fcmtylq/L6BHB/RLwl6dMk91F5iOReK0tI7udidWj0\naPj1r/POwszMKlXR/UMi4gbghhLbTuqh7YfAD/vosxlo7mX7VGDHk2bdY34LfLq3GDMzMxsYfHWP\n1bSeFniZ2cDg+WsuUqymzZgxo+8gM6tKnr/mIsVq2rhx4/JOwcwq5PlrLlLMzMysKrlIMTMzs6rk\nIsVqWvHdEs1s4PD8NRcpVrPWr4czz2xh/fq+Y82s+rS0tOSdguXMRYrVrG3b4OWXb2XbtrwzMbNK\n3HrrrXmnYDlzkWJmZmZVyUWKmZmZVSUXKWZmZlaVXKRYjev1cU9mVsWmTvX8rXcVPWDQbODwHSvN\n9iRt7WQMHQxu3/m+xh15JLS19R3Yi8HtMAbQ1pFAw84nZXuUixSrShs2wCuv7Fwf7e0Ak9KvO2e/\n/eDII3e+H7Nat+/THbTRCJN3vq9JABdfvFN9jALagPanW+HjY3c+KdujXKRY1dmwAT74wV3X3+Rd\n8I8lwG9+40LFrC/bDhvJWFr5/s0walTe2ST/WfniZFh82Mi8U7EKuEixqtN1BOXmKvpHbvLknT+y\nY1YPYnADjzCWraOAKjhwsRV4BIjBeWdilXCRYlVr1CgYu5P/yK1atYoTTzxx1yRkZnuU56/56h6r\naQsWLMg7BTOrkOevuUixmrZs2bK8UzCzCnn+mosUq2kNDb7k0Gyg8vw1FylmZmZWlVykmJmZWVVy\nkWI1bdasWXmnYGYV8vy1iooUSdMlPSVpq6Q1ko7tI/4MSe1p/DpJp/YQM0/Sc5I6Jf1U0hFF298j\n6fuSXpL0R0nfkfSuzPZDJb1V9Nou6bhKxmi1Yfjw4XmnYGYV8vy1sosUSROBK4A5JI9EWAeskDSk\nRPwJwC3ATcAxwO3AckmjMzEXATOAc4DjgNfSPvfJdHULyR2OPwl8CvhL4MaijwvgJGBY+joIaC13\njFY7Zs6cmXcKZlYhz1+r5EjKBcCNEbE0IjqAc4FOYFqJ+POAuyPiyoh4PCIuIXmUwoxMzPnApRFx\nV0Q8BkwBDgZOB5A0CjgFOCsifhERDwEzgf9H0rBMPwJejIjfZ17bKxijmZmZ5aysIkXS3kAjcG9X\nW0QEcA/QVGK3pnR71oqueEmHkxz1yPb5MrA20+fxwB8j4pFMH/eQHDn5WFHfd0jaLOkBSZ/p/+jM\nzMysmpR7JGUIMAjYXNS+maTQ6MmwPuKHkhQbvcUMA36f3ZgeIXkxE/MqcCFwBjAeWEVyWunTvY7I\nalpHR0feKZhZhTx/rWau7omIP0TE1RHx84hojYh/BG4G+lwePn78eAqFQrdXU1MTy5cv7xa3cuVK\nCoXCDvtPnz6dxYsXd2tra2ujUCiwZcuWbu1z5sxh/vz53do2btxIoVDYYUIuXLhwh9XtnZ2dFAoF\nVq1a1a29paWFqVOn7pDbxIkTB9w4mpt33Thmz569y8axbFl9/jw8Do8jr3HMnj17l4wD5rBkiX8e\neY1j0aJF3X6/jhgxggkTJuzQR48iot8vYG/gDaBQ1L4E+FGJfZ4BzitqawYeSf/8AeAt4OiimPuA\nq9I/TwX+ULR9UJrLab3k+xXgd71sHwtEa2trWPVobY2A5OvOeuaZZ6oqH7Na5/lr/dHa2hokZ1HG\nRi91R1lHUiLiDZKrZT7Z1SZJ6fuHSuy2OhufOjltJyKeAjYV9bk/yVqThzJ9HChpTKaPT5IslF3b\nS8pjgOd7HZTVNF/CaDZwef7aXhXscyWwRFIr8DDJ1T4NJEdTkLQUeDYivprGXwPcJ+lC4MfAJJLF\nt2dn+rwa+JqkJ4CngUuBZ0kuVyYiOiStAG6S9PfAPsBCoCUiNqWfOwV4HehaXPs54EvAWRWM0czM\nzHJWdpESEbel90SZR7Lo9VHglIh4IQ05BHgzE79a0heAy9LXBpJTNOszMQskNZDc9+RA4AHg1Ih4\nPfPRXwCuI7mq5y3gf5Ncupz1dWB4+vkdwOcj4kfljtHMzMzyV9HC2Yi4ISIOi4jBEdEUEb/IbDsp\nIqYVxf8wIkam8UdHxIoe+myOiIMjoiEiTomIJ4q2/0dETI6IAyLiPRFxdkR0ZrYvjYijImK/dHuT\nCxQrXmRmZgOH56/VzNU9Zj3p7OzsO8jMqpLnr7lIsZo2d+7cvFMwswp5/lolC2fNzMx61HXwo60t\n3zy6tLfnnYHtDBcpZma2y3TdU+zss3uP29P22y/vDKwSLlKspm3ZsoUhQ3p8QLeZ7Qann558HTkS\nGhoq76e9HSZP3sLNNw9h1Kidy2m//eDII3euD8uHixSradOmTeOOO+7IOw2zujFkCHz5y7uqt2mM\nGnUHY8fuqv5soPHCWatpzc3NeadgZhVrzjsBy5mPpFjV0dZOxtDB4F2w4G0s7PQKvsHtyfMVtHUk\nyc2VzWzP8CGUeucixarOvk930EYjTM47k8QooA1of7oVPu5/NM3M9hQXKVZ1th02krG08v2b2ekF\nc7tCezt8cTIsPmxk3qmYmdUVFylWdWJwA48wlq2j2OmjvYsXL+ass3buGZNbSZ5aGYN3LhczK9di\n/IzY+uaFs1bT2qrljlJmVpZ994X3vKeNfffNOxPLk4+kWE27/vrr807BzCowejS8+KLnb73zkRQz\nMzOrSi5SzMzMrCq5SDEzM7Oq5CLFalqhUMg7BTOrkOeveeGsVZ1d+aj3U06ZsdP9+FHvZvmYMWNG\n3ilYzlykWNXZtY96H7crOgH8qHezPW3cuF03f21gcpFiVWfXPuodbt4Fd671o97NzPY8FylWdXbt\no96TAsWPejcbWNavhzPOgB/8ILlnitUnL5y1Grc87wTMrALbtsH69cvZti3vTCxPFRUpkqZLekrS\nVklrJB3bR/wZktrT+HWSTu0hZp6k5yR1SvqppCOKtr9H0vclvSTpj5K+I+ldRTFHS7o//ZxnJM2q\nZHxWS+bnnYCZVczzt96VXaRImghcAcwBxgDrgBWShpSIPwG4BbgJOAa4HVguaXQm5iJgBnAOcBzw\nWtrnPpmubgFGAZ8EPgX8JXBjpo/9gBXAUySPpZsFNEvahScObOD5L3knYGYV8/ytd5WsSbkAuDEi\nlgJIOpekaJgGLOgh/jzg7oi4Mn1/iaSTSYqSr6Rt5wOXRsRdaZ9TgM3A6cBtkkYBpwCNEfFIGjMT\n+LGk/xERm4DJwN7AWRHxJtAuaQxwIfCdCsZpZma7QWdnJx1dl/GVkFz6/xLt7X3fQ2DkyJE07Mwq\ne6taZRUpkvYGGoFvdLVFREi6B2gqsVsTyZGXrBXAaWmfhwPDgHszfb4saW26723A8cAfuwqU1D1A\nAB8jOTpzPHB/WqBkP2e2pAMi4qVyxmpmZrtHR0cHjY2N/YqdPLnvuNbWVsZ6dXxNKvdIyhBgEMlR\njqzNwIgS+wwrET8s/fNQkmKjt5hhwO+zGyNiu6QXi2Ke7KGPrm0uUmpIf/4n9uST0NDwEk8+6f+J\nmVWTkSNH0tra2mfcBRdcwFVXXdWv/qw21fslyPsCtPuWogNOe3s7kydP7lfsGWf0/T+xm2++mVE7\nezMVM9ulHn/88X7F9fUfFqs+md+7+/YWV26RsgXYTnL0I2sosKnEPpv6iN8EKG3bXBTzSCbmz7Md\nSBoEvBd4vo/P6drWk8OAfv+ys9rlvwNm1am/p4VswDoMeKjUxrKKlIh4Q1IryRU2dwBIUvr+2hK7\nre5h+8lpOxHxlKRNacwv0z73J1lrcn2mjwMljcmsS/kkSXHzcCbmnyQNiojtads44PFe1qOsAL4I\nPA34anwzM7M94/9v7+6DrK7qOI6/P2OQOIKMOY6aiJk2IGqB6fgIEyRqzmQm4xiTVj40mqkDUwoM\nBoQ5KqmDmjo2q4Wjk0RajmQsPlTIkIqRyEMCgsyqFBDypKDIfvvjnKs/r7ssyy67v10+r5k73Ps7\n53d+97fsufu953FvUoAyY0eZFBHNKlXSBcBvgCtIAcIIYBjQJyLWSJoCvBkRY3L+k4G/AqOB6cB3\ngFHAgIhYlPNcB1wPfJ8UMEwE+gH9IuKDnOfPpNaUK4GuwAPAixFxUU7vAfwbmEmaXH8sUANcGxE1\nzbpJMzMza3fNHpMSEVPzmig/J3Wn/As4MyLW5CyHAh8W8s+RNBz4RX4sBc6tBCg5z62S9iGte9IT\nmAWcXQlQsuHA3aRZPfXANNLU5UoZGyUNJbW+zCV1TY13gGJmZtYxNbslxczMzKwteO8eMzMzKyUH\nKVYqku6X9D9J9ZLWSbq96bOaLPNBSY+1xvszs5aT9C1JSyVtk3S7pO/lda9aWu4gSdvzGEXrBNzd\nY6Uh6SzStsWDSHsw1QNbIuLdFpbbnfS7vrHl79LMWirP6KwhzfrcTBrH2D0i1raw3M8A+0fE6iYz\nW4ewpy/mZuVyJLAqIl5ozUIjYlNrlmdmu07SvqSZmrURUVwb6/2Wlp23RXGA0om4u8dKQdKDpG9V\nh0yW/VUAAAc0SURBVOWunuWSnit290j6kaQlkrZI+o+kqYW0YZLmS3pP0lpJtZK6VcoudvdI6irp\nTkn/zWXNkvTVQvqg/B4GS3pJ0ruSZks6qm1+GmblkOvgZEm35G7YVZLG5bTeuZ4cV8i/Xz42sJHy\nBgEbSVuhPJe7Zgbm7p53CvmOk/SspI2SNuR6OCCnHSbpidwdvFnSq7kVtlh3exTKOl/SAklbJa2Q\nNLLqPa2QNFpSTb7eSkmXt+KP0VrAQYqVxTXAz4A3SVPbTygm5iBiMjAW+BJpV+y/57SDgEdIu133\nIXUXPUZa7K8hk4DzgIuA/sAyYIaknlX5biStA3Q8qTn6gZbcoFkHdTGpS+ZE4DrSTvZDclpzxwvM\nJu3zJlIdPJiPVxstlvUwUEeqewOAm4FtOe0e0lpZpwHHkNbY2lw496NyJB0PPEr6fDgGGAdMlHRx\n1fsaCbwEfCWXf6+/lJSDu3usFCJik6RNwPbKmjtpMeOP9CJ9EE3PY1TqgFdy2sGkjS8fj4i6fGxh\nQ9fJ6/FcAVwcEbX52OWkVZAv5eMduwMYExHP5zw3A09K6lq1fo9ZZzc/Iibm569L+jFpxe9lNP5F\noEER8aGkSnfMO5WxI1V1HeAw4NaIWFq5biGtFzCtsNbWGzu45Ajg6Yi4Kb9eJqkf8FNgSiHf9Ii4\nLz+/RdII4Gukdb2sHbklxTqKmcBKYIWkKZKGV7pzSMHKM8ACSVMlXdZAq0jFF0nB+Ud7ReR+7BeB\n6h0GXy08r+wRdSBme5b5Va9XsZP1IHezbMqP6c245u1AjaSZkq6XdEQh7U7gBknPSxov6dgdlNOX\n1HpTNBs4Sp+MjF6tyvOp/eKsfThIsQ4hIjaTmn0vBN4GJgCvSOoREfURMRQ4i9SCcjXwmqTeLbzs\ntsLzShOy64ztabZVvQ5SPajPr4t/7LtU5T0b+HJ+XLazF4yICcDRwJPAYGChpHNzWg3wBVJLyDHA\nXElX7WzZjWjsHq2d+T/BOowcjDwbEaNIH3qHkz7AKulz8odbf+ADUp93tddJH0inVg7kaYsn0EgX\nkZk1qLIVysGFY/0pjAmJiLqIWJ4fq2iGiFgWEZMj4kzgceAHhbS3IuL+iBhG6qJtbKDrYgp1PTsN\nWBJef6ND8JgU6xAknQMcQRos+w5wDukb3GuSTiT1kdeSph+eBBwALKouJyLek3QvMCnPJqgjDQbs\nxicHxjbU196s/nezziwitkr6BzBK0hukAe8Td3xW0yTtTRrcPo20XlIv0peI3+f0O4CngCXA/qSx\nI8W6XqyntwEvShpLGkB7CnAVaVyadQAOUqzMit901gPfJo3O35s0oO3CiFgsqQ8wkLThZA/S2JWR\nlYGxDRhF+iCbAnQnbUg5NCI2NHLtHR0z68ya+p2/hDSrbi7wGingb6ze7Wy524HPAb8lBT5rgT8A\n43P6XqTNZg8lTWd+ijQ751NlR8Q8SReQNsQdSxpPMzYiHmrivbiul4RXnDUzM7NS8pgUMzMzKyUH\nKWZmZlZKDlLMzMyslBykmJmZWSk5SDEzM7NScpBiZmZmpeQgxczMzErJQYqZmZmVkoMUMzMzKyUH\nKWZmZlZKDlLMrFOT1KW934OZ7RoHKWbWLiQNkzRf0nuS1kqqldQtp10iaYGkrZLeknRn4bxekv4k\naZOkDZIelXRgIX2cpHmSLpW0HNiSj0vSaEnL8zXnSTq/zW/czHaad0E2szYn6SDgEeAnwB9Ju1Gf\nnpJ0JXAbaUfdvwD7Aafm8wQ8Qdr99nSgC3AP8DtgcOESR5J2zT6PtKsuwBhgOPBDYBlp5+yHJK2O\niFm7617NbNd5F2Qza3OS+gNzgcMjoq4q7U2gJiLGNXDeGcD0fN7b+VhfYCFwQkS8LGkcMBo4JCLW\n5TxdgXXAkIh4oVDer4FuEfHd3XGfZtYybkkxs/bwCvAMsEDSDKAWmEZqGTkEeLaR8/oAdZUABSAi\nFktaD/QFXs6HV1YClOxIYB9gZm6NqegCzGuF+zGz3cBBipm1uYioB4ZKOhkYClwN3Ah8vZUu8W7V\n633zv98A3q5Ke7+VrmlmrcwDZ82s3UTEnIiYAPQHtgFnACuAIY2cshjoJenzlQOSjgZ6krp8GrOI\nFIz0jojlVY+3WuNezKz1uSXFzNqcpBNJgUgtsBo4CTiAFExMAO6TtAZ4CugBnBIRd0fE05IWAA9L\nGkHqrvkV8FxENNptExGbJf0SuEPSXsDzfDwgd0NEPLS77tXMdp2DFDNrDxtJs2uuJQUhK4GRETED\nQNJngRHAJGAtabxKxTeBu4C/AfWkQOaapi4YETdIWg2MAo4A1gP/BG5qnVsys9bm2T1mZmZWSh6T\nYmZmZqXkIMXMzMxKyUGKmZmZlZKDFDMzMyslBylmZmZWSg5SzMzMrJQcpJiZmVkpOUgxMzOzUnKQ\nYmZmZqXkIMXMzMxKyUGKmZmZlZKDFDMzMyul/wPM2EbRBd7KbAAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY8AAAEcCAYAAAA/aDgKAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAHTpJREFUeJzt3X+cVnWd9/HXuwEdA1dUkhAIKKkYFzJ20vaxa/fgr4RK\ndi1Xsc1kvWMxpTY1gtg7190o02573BLILRsqW2rutq7cgUklk1lZYKj4e1nDQEkzFR2g4sfn/uN8\nxz1cDTPXF2bmYmbez8fjPLiuc77fc77nzOG8r/M95zqXIgIzM7Mcr6t1A8zMrOdxeJiZWTaHh5mZ\nZXN4mJlZNoeHmZllc3iYmVk2h4cd8CTdKOnztW5HrbW3HSSdL+ne7m6T9V0OD6uapA2StktqkfSS\npOWSRtS6XWWSQtIxtW6HWW/n8LBcH4iIgcBQ4Dlgfo3b02VU8P+RTiaprtZtsP3n/xi2TyLit8C/\nAQ2t4yQdJmmppF9LelrS37cefCVdJ+lbpbJfkvT9dIBukrRJ0mclvZDOcD68t2VL+pik9ZJelLRM\n0tFp/D2pyIPp7OjsNurWSfrfaTm/kHRxOlvpl6Y3S5on6UfANuDNko5Oy3kxLfdjpfnt0ZXUui6l\n9xskzZH0aDpbu0FSfWn6+yU9IOllST+WNL407Z2Sfi7pVUnfBF6rt/dNo69K2iLpcUknp5FnSbq/\nouAlku7Yy0zOl/RUWu4vyn+LtO0fS9MelTQhjR+btt3Lkh6RdEbFNrpO0gpJW4GJkg6W9GVJv5T0\nnKRFkg7pYP3sQBIRHjxUNQAbgFPS69cDNwFLS9OXAncAhwKjgCeBC0rlnwTOB04EXgCGp2lNwE7g\nGuBg4H8AW4G3pek3Ap9Pr09KdSeksvOBe0ptCOCYdtZhBvAoMBw4HPheqtMvTW8GfgkcC/QD+gP3\nAAspDt7HAb8GTqpsW2ldNlVss4eBEcARwI9K6/JO4HngBKAO+GgqfzBwEPA08KnUhg8BO8rLqliv\n89M2bC1/NrAlLfNg4EVgbKn8WuCDbcxnAPBKadsPBY5Nr88CngHeBQg4BhiZlrce+Gxq90nAqxV/\nvy3An1F8YK0HvgIsS+07FPh/wBdrvY97yDge1LoBHnrOkA5sLcDL6UD2LDAuTasDfg80lMr/LdBc\nen9COog9DUwtjW9KB74BpXG3Af8rvX7tAA18DbiqVG5gasuo9L6j8Lgb+NvS+1P4w/D4x9L0EcAu\n4NDSuC8CN1a2rbQuleExo/R+MvBf6fV1wD9VtO8JivB8T9q+Kk37Me2HR2X5nwEfKS1rXnp9LPAS\ncHAb8xmQ/r4fBA6pmHYX8Mk26pwI/Ap4XWncLcA/lLZR+UOGKD4cvKU07k+BX9R6H/dQ/eBuK8v1\nFxExiOLT48XADyS9ERhM8Qn06VLZp4FhrW8i4qfAUxQHj9sq5vtSRGytqHt0G8s/uryMiGgBflNe\nTgeOBjaW3m9so0x53NHAixHxakXbql1e5fzK6zUSuDR19bws6WWKsDo6Dc9EOrKW6ranrfKty7oJ\nOFeSgI8At0XE7ypnkP4GZ1OcoW1ON0W8PU0eAfxXG8s9GtgYEbsrll3eRuVt8AaKM9H7S+v9nTTe\negiHh+2TiNgVEf9O8an8zym6knZQHBBbvYmimwMASRdRdKE8C8yqmOXhkgZU1H22jUU/W15GqnNk\neTkd2EzRZdWqrbvFygfgZ4EjJB1a0bbW5W2lOBC2emMb8ysvo7xeGynOBgaVhtdHxC2pncPSwb5c\ntz1tlX8WICLuozgzPBE4F/iXvc0kIu6KiFMpuqweBxaX2vuWNqo8C4youLlgj789e27TF4DtFN1h\nret9WBQ3YlgP4fCwfZIudE+huG7wWETsojibmCfpUEkjgUuAr6fybwU+D/w1xSffWZKOq5jtFZIO\nknQi8H7gX9tY9C3ANEnHSToY+ALw04jYkKY/B7y5nabfBnxS0jBJg4DPtLeeEbGRorvoi5Lq0wXt\nC1rXC3gAmCzpiHQG9ndtzOYiScMlHQHMBb6Zxi8GZkg6IW3PAZLel4LqJxRdeZ+Q1F/SmcDx7bUV\nOKpU/ixgLLCiNH0p8FVgR0S0+Z0QSUMkTUmh/DuKbsrWM4p/Bi6T9Cepvcekv/NPKW4umJWW3QR8\nALi1rWWkM5TFwFckHZWWO0zSeztYPzuQ1LrfzEPPGSj677dTHFBepbgQ/OHS9MMpDqq/pviU+jmK\nDyj9KPrfZ5fKXgisozgTaQI2URxYX6C4YP2RUtkb2fO6wgyK7pMXgW+TLryXpm2m6Lf/qzbWoR/F\nxdrfAL+guMC8g3StgOKax/+sqDM8LefFtNzyNYx6ijB4BXgoza/ymscciov0L1N0H72+NP10YHWa\ntpkiMA9N0xopLmy/mpbxTdq/5vEjinDYQnFzwmkVZd5EEQRXtPM3Hgr8IM3j5bQ9Giq27xNpH3gY\neGcaf2yp3qPAX+7t71fabl+g6MZ8BXgM+ESt93EP1Q81b4AHD1RcZO7mZU8Cnm5n+gbg0ykYtlJc\nsB8C3JkO6t8DDk9l301xlvIy8GBarw0UF+WnpQPkq+mAWb5o30QRnpdS3H21GZjWBet6SFr+mFr/\nzT30/MHdVtanSDpE0mRJ/SQNAy4Hbu+g2geBU4G3UnTH3ElxW+obKM6sPpHmtZyia+4I4DLgW/x3\n1/DzFF1xf0QRJF9p/Y5E8kbgMIqLzBcACyQdvp+rW+lCYHVE/Gcnz9f6oH61boBZNxNwBUUX0HaK\nA/7nOqgzPyKeA5D0Q+D5iFib3t8OnExxLWdFRLReY/iupDUU30chIpaX5vcDSSspLl7/PI3bQXGL\n8E5ghaQW4G3Affuzsq0kbaBY97/ojPmZOTys5iKimT3vgOrKZW2j+JJbjudKr7e38X4gxR1gZ0n6\nQGlaf4rvcXxP0iSKs5y3UpyNvJ7imk+r36TgaLUtzbdTRMSozpqXGTg8zDrLRuBfIuJjlRPSXWHf\nAs4D7oiIHZL+g+JMwKxH8jUPs87xdeADkt6r4vlZ9SqeczWc4pEdB1PchbYznYWcVsvGmu0vh4dZ\nJ4ji+yBTKC6kt96q/GmKR3a8CnyC4jsmL1F8SW9ZjZpq1ila7203MzOrms88zMwsm8PDzMyyOTzM\nzCybw8PMzLI5PMzMLFuP+pLg4MGDY9SoUbVuRq+zdetWBgwY0HFBswOE99muc//9978QER3+MFeP\nCo9Ro0axZs2aWjej12lubqapqanWzTCrmvfZriOpo1+sBNxtZWZm+8DhYWZm2RweZmaWzeFhZmbZ\nHB5mZpbN4WFmPcbMmTOpr69n4sSJ1NfXM3PmzFo3qc/qUbfqmlnfNXPmTBYsWMDrXld85t25cycL\nFiwAYP78+bVsWp/kMw8z6xEWLlyIJK666iruvPNOrrrqKiSxcOHCWjetT3J4mFmPsHv3bubNm8cl\nl1xCfX09l1xyCfPmzWP37t21blqf5PAwM7NsvuZhZj1CXV0dc+fO5aCDDqKhoYFrrrmGuXPnUldX\nV+um9UkODzPrES688EIWLFjArFmz2LVrF3V1dUQEH//4x2vdtD7J3VZm1iPMnz+fU0899bVrHLt3\n7+bUU0/1nVY14vAwsx7hlltuYe3atYwcORJJjBw5krVr13LLLbfUuml9UlXhIel0SU9IWi9pdhvT\nJenaNP0hSRMy6l4qKSQN3r9VMbPebNasWdTV1bFkyRJWrlzJkiVLqKurY9asWbVuWp/UYXhIqgMW\nAJOABmCqpIaKYpOAMWmYDlxXTV1JI4DTgF/u95qYWa+2adMmli5dysSJE+nXrx8TJ05k6dKlbNq0\nqdZN65OqOfM4HlgfEU9FxO+BW4EpFWWmAEujcB8wSNLQKup+BZgFxP6uiJmZdZ9q7rYaBmwsvd8E\nnFBFmWHt1ZU0BXgmIh6UtNeFS5pOcTbDkCFDaG5urqLJlqOlpcXb1Q54gwcP5swzz2TAgAE8//zz\nHHXUUWzdupXBgwd7/62BmtyqK+n1wGcpuqzaFRHXA9cDNDY2hn96svP5Jz2tJzjnnHNYuHAhAwcO\nRBKS2LZtG+eff7733xqoptvqGWBE6f3wNK6aMnsb/xZgNPCgpA1p/M8lvTGn8WbWd6xatYo5c+Zw\n5JFHAnDkkUcyZ84cVq1aVeOW9U2KaP9yg6R+wJPAyRQH/tXAuRHxSKnM+4CLgckU3VLXRsTx1dRN\n9TcAjRHxQnttaWxsjDVr1mStoHXMZx7WE9TV1fHb3/6W/v37v7bP7tixg/r6enbt2lXr5vUaku6P\niMaOynV45hEROymC4S7gMeC2iHhE0gxJM1KxFcBTwHpgMfDx9uruw/qYWR83duxY7r333j3G3Xvv\nvYwdO7ZGLerbqrrmERErKAKiPG5R6XUAF1Vbt40yo6pph5n1XXPnzuWCCy7ga1/7Grt27WLVqlVc\ncMEFzJs3r9ZN65P8bCszO2C1dSfmSSedtMf7c889l3PPPXePcR11x9v+8+NJzOyAFRFtDiM/8+29\nTnNwdA+Hh5mZZXN4mJlZNoeHmZllc3iYmVk2h4eZmWVzeJiZWTaHh5mZZXN4mJlZNoeHmZllc3iY\nmVk2h4eZmWVzeJiZWTaHh5mZZXN4mJlZNoeHmZllc3iYmVk2h4eZmWVzeJiZWTaHh5mZZXN4mJlZ\nNoeHmZllc3iYmVk2h4eZmWVzeJiZWTaHh5mZZXN4mJlZNoeHmZllc3iYmVk2h4eZmWVzeJiZWTaH\nh5mZZXN4mJlZNoeHmZllc3iYmVk2h4eZmWWrKjwknS7pCUnrJc1uY7okXZumPyRpQkd1Jf1TKvuA\npJWSju6cVTIzs67WYXhIqgMWAJOABmCqpIaKYpOAMWmYDlxXRd2rI2J8RBwHfBv43P6vjpmZdYdq\nzjyOB9ZHxFMR8XvgVmBKRZkpwNIo3AcMkjS0vboR8Uqp/gAg9nNdzMysm/SroswwYGPp/SbghCrK\nDOuorqR5wHnAFmBi1a02M7OaqiY8ukxEzAXmSpoDXAxcXllG0nSKrjCGDBlCc3Nzt7axL2hpafF2\ntR7H+2xtVRMezwAjSu+Hp3HVlOlfRV2AbwAraCM8IuJ64HqAxsbGaGpqqqLJlqO5uRlvV+tRvrPc\n+2yNVXPNYzUwRtJoSQcB5wDLKsosA85Ld129G9gSEZvbqytpTKn+FODx/VwXMzPrJh2eeUTETkkX\nA3cBdcCSiHhE0ow0fRHFWcNkYD2wDZjWXt006yslvQ3YDTwNzOjUNTMzsy5T1TWPiFhBERDlcYtK\nrwO4qNq6afwHs1pqZmYHDH/D3MzMsjk8zMwsm8PDzMyyOTzMzCybw8PMzLI5PMzMLJvDw8zMsjk8\nzMwsm8PDzMyyOTzMzCybw8PMzLI5PMzMLJvDw8zMsjk8zMwsm8PDzMyyOTzMzCybw8PMzLI5PMzM\nLJvDw8zMsjk8zMwsm8PDzMyyOTzMzCybw8PMzLI5PMzMLJvDw8zMsjk8zMwsm8PDzMyyOTzMzCyb\nw8PMzLI5PMzMLJvDw8zMsjk8zMwsm8PDzMyyOTzMzCybw8PMzLI5PMzMLJvDw8zMsjk8zMwsW1Xh\nIel0SU9IWi9pdhvTJenaNP0hSRM6qivpakmPp/K3SxrUOatkZmZdrcPwkFQHLAAmAQ3AVEkNFcUm\nAWPSMB24roq63wX+OCLGA08Cc/Z7bczMrFtUc+ZxPLA+Ip6KiN8DtwJTKspMAZZG4T5gkKSh7dWN\niJURsTPVvw8Y3gnrY2Zm3aCa8BgGbCy935TGVVOmmroAfwPcWUVbzMzsANCv1g2QNBfYCXxjL9On\nU3SFMWTIEJqbm7uvcX1ES0uLt6v1ON5na6ua8HgGGFF6PzyNq6ZM//bqSjofeD9wckREWwuPiOuB\n6wEaGxujqampiiZbjubmZrxdrUf5znLvszVWTbfVamCMpNGSDgLOAZZVlFkGnJfuuno3sCUiNrdX\nV9LpwCzgjIjY1knrY2Zm3aDDM4+I2CnpYuAuoA5YEhGPSJqRpi8CVgCTgfXANmBae3XTrL8KHAx8\nVxLAfRExozNXzszMukZV1zwiYgVFQJTHLSq9DuCiauum8cdktdTMzA4Y/oa5mZllc3iYmVk2h4eZ\nmWVzeJiZWTaHh5mZZav5N8ytdsaPH8+6deteez9u3DgeeuihGrbI+qJ3XLGSLdt3ZNcbNXt5VvnD\nDunPg5eflr0ca5vDo49qDY4zzjiDadOmccMNN7Bs2TLGjx/vALFutWX7DjZc+b6sOvvyVITcsLH2\nuduqj2oNjjvuuINBgwZxxx13cMYZZ+xxJmJmtjcOjz5s8ODB1NfXM3HiROrr6xk8eHCtm2RmPYS7\nrfqwG264gS9/+cs0NDTw6KOPctlll9W6SWbWQzg8+ihJRASXX345LS0tDBw4kIggPWfMzKxd7rbq\noyKCuro6WlpagOI3Perq6tjLk/HNzPbg8OijJDF9+nQiglWrVhERTJ8+3WceZlYVd1v1URHB4sWL\nOeaYY2hoaOCaa65h8eLFPvMws6o4PPqQyrOKnTt3cumll3ZYzoFiZpXcbdWHRMRrw80338zo0aO5\n++67edNl/8Hdd9/N6NGjufnmm/co5+Aws7b4zKOPmjp1KgAzZ87kl48+xsw7xzJv3rzXxpuZtcfh\n0YdNnTqVqVOnMmr2ch7OfDyEmfVt7rYyM7NsDg8zM8vm8DAzs2wODzMzy+bwMDOzbA4PMzPL5vAw\nM7NsDg8zM8vm8DAzs2wODzMzy+bwMDOzbA4PMzPL5vAwM7NsDg8zM8vm8DAzs2wODzMzy+bwMDOz\nbA4PMzPL5vAwM7NsDg8zM8tWVXhIOl3SE5LWS5rdxnRJujZNf0jShI7qSjpL0iOSdktq7JzVMTOz\n7tBheEiqAxYAk4AGYKqkhopik4AxaZgOXFdF3YeBM4F79n81zMysO1Vz5nE8sD4inoqI3wO3AlMq\nykwBlkbhPmCQpKHt1Y2IxyLiiU5bEzMz6zbVhMcwYGPp/aY0rpoy1dQ1M7Mepl+tG9ARSdMpusIY\nMmQIzc3NtW1QL+XtarWUu/+1tLTs0z7r/bzzVBMezwAjSu+Hp3HVlOlfRd12RcT1wPUAjY2N0dTU\nlFPdqvGd5Xi7Ws3sw/7X3Nycv896P+9U1XRbrQbGSBot6SDgHGBZRZllwHnprqt3A1siYnOVdc3M\nrIfp8MwjInZKuhi4C6gDlkTEI5JmpOmLgBXAZGA9sA2Y1l5dAEl/CcwH3gAsl/RARLy3s1fQzMw6\nX1XXPCJiBUVAlMctKr0O4KJq66bxtwO35zTWzMwODP6GuZmZZXN4mJlZNoeHmZllc3iYmVk2h4eZ\nmWVzeJiZWTaHh5mZZVPxFY2eobGxMdasWVPrZhzQ3nHFSrZs39HlyznskP48ePlpXb4c6/3G3TSu\n25a17qPrum1ZPZWk+yOiw99YOuAfjGh5tmzfwYYr35dVZ1+eEzRq9vKs8mZ78+pjV3qf7YHcbWVm\nZtkcHmZmls3hYWZm2RweZmaWzeFhZmbZHB5mZpbN4WFmZtkcHmZmls3hYWZm2RweZmaWzeFhZmbZ\nHB5mZpbN4WFmZtkcHmZmls3hYWZm2fx7HmZWc/v0Wxvfyatz2CH985dhe+XwMLOayv0hKCjCZl/q\nWedxt5WZmWVzeJiZWTZ3W/Uyh46dzbibZudXvCl3OQDuNjDrqxwevcyrj12Z3Rfc3NxMU1NTVp19\nusBpZr2Gu63MzCybw8PMzLI5PMzMLJvDw8zMsjk8zMwsm++26oX8qAcz62oOj17Gj3ows+7gbisz\nM8tWVXhIOl3SE5LWS/qDry+rcG2a/pCkCR3VlXSEpO9K+s/07+Gds0pmZtbVOgwPSXXAAmAS0ABM\nldRQUWwSMCYN04Hrqqg7G/h+RIwBvp/em5lZD1DNNY/jgfUR8RSApFuBKcCjpTJTgKUREcB9kgZJ\nGgqMaqfuFKAp1b8JaAY+s5/rY2a9iKS9T/vS3usVhyLrStV0Ww0DNpbeb0rjqinTXt0hEbE5vf4V\nMKTKNts+ktTm8PSX3r/Xae395zXrahHR5rBq1aq9TnNwdI8D4m6riAhJbf7FJU2n6ApjyJAhNDc3\nd2fTepVVq1a1Ob6lpYWBAwfutZ63uR1oWlpavF/WWDXh8QwwovR+eBpXTZn+7dR9TtLQiNicurie\nb2vhEXE9cD1AY2Nj5D791Tq2L0/VNasl77O1V0231WpgjKTRkg4CzgGWVZRZBpyX7rp6N7AldUm1\nV3cZ8NH0+qPAHfu5LmZm1k06PPOIiJ2SLgbuAuqAJRHxiKQZafoiYAUwGVgPbAOmtVc3zfpK4DZJ\nFwBPA3/VqWtmZmZdpqprHhGxgiIgyuMWlV4HcFG1ddP43wAn5zTWzMwODP6GuZmZZXN4mJlZNoeH\nmZllc3iYmVk29aRvY0r6NcWdWda5BgMv1LoRZhm8z3adkRHxho4K9ajwsK4haU1ENNa6HWbV8j5b\ne+62MjOzbA4PMzPL5vAwSM8OM+tBvM/WmK95mJlZNp95mJlZNodHLyHpE5Iek/RSW78zX0X9H3dF\nu8z2laS3S3pA0lpJb9mXfVTSP0o6pSva19e526qXkPQ4cEpEbKp1W8w6Q/oQ1C8iPl/rttgf8plH\nLyBpEfBm4E5Jn5L01TT+LEkPS3pQ0j1p3LGSfpY+0T0kaUwa35L+laSrU711ks5O45skNUv6N0mP\nS/qG/Bu11g5Jo9LZ8GJJj0haKemQtB81pjKDJW1oo+5k4O+ACyWtSuNa99Ghku5J+/DDkk6UVCfp\nxtJ++6lU9kZJH0qvT05nMeskLZF0cBq/QdIVkn6epr29WzZQD+fw6AUiYgbwLDAReKk06XPAeyPi\nHcAZadwM4P9ExHFAI8XvypedCRwHvAM4Bbg6/dIjwDsp/kM3UITVn3X+2lgvMwZYEBHHAi8DH6ym\nUvoph0XAVyJiYsXkc4G70j78DuABin12WET8cUSMA24oV5BUD9wInJ2m9wMuLBV5ISImANcBl+Wt\nYt/k8OjdfgTcKOljFD/GBfAT4LOSPkPxGILtFXX+HLglInZFxHPAD4B3pWk/i4hNEbGb4j/sqC5f\nA+vpfhERD6TX99M5+8xqYJqkfwDGRcSrwFPAmyXNl3Q68EpFnbeltjyZ3t8EvKc0/d87uY29nsOj\nF0tnJH9P8Tvy90s6MiJupjgL2Q6skHRSxix/V3q9iyp/TMz6tLb2mZ3897GnvnWipBtSV9Qf/Hhc\nWUTcQ3Hgf4biw9F5EfESxVlIM8XZ9T/vYzu9X1fJ4dGLSXpLRPw0Ij4H/BoYIenNwFMRcS3F78aP\nr6j2Q+Ds1If8Bor/pD/r1oZbb7cB+JP0+kOtIyNiWkQcFxGT26ssaSTwXEQspgiJCZIGA6+LiG9R\nfGCaUFHtCWCUpGPS+49QnFXbPnLC9m5XpwviAr4PPAh8BviIpB3Ar4AvVNS5HfjTVDaAWRHxK19E\ntE70ZeA2SdOB5ftQvwn4dNqHW4DzgGHADZJaPxDPKVeIiN9Kmgb8q6R+FF1fi7B95lt1zcwsm7ut\nzMwsm8PDzMyyOTzMzCybw8PMzLI5PMzMLJvDw8zMsjk8zGogfdfArMdyeJhVSdIAScvTU4oflnS2\npHdJ+nEa9zNJh0qqT4/aWJee4jox1T9f0jJJd1N8aRNJn5a0Oj3h+IqarqBZBn/6Mave6cCzEfE+\nAEmHAWspntS6WtIfUTwz7JNARMS49M38lZLemuYxARgfES9KOo3iqbPHUzwFYJmk96RnN5kd0Hzm\nYVa9dcCpkr4k6UTgTcDmiFgNEBGvRMROiicTfz2Nexx4GmgNj+9GxIvp9WlpWAv8HHg7RZiYHfB8\n5mFWpYh4UtIEYDLweeDufZjN1tJrAV+MiP/bGe0z604+8zCrkqSjgW0R8XXgauAEYKikd6Xph6YL\n4T8EPpzGvZXiDOWJNmZ5F/A3kgamssMkHdX1a2K2/3zmYVa9cRRPKt4N7KD4JToB8yUdQnG94xRg\nIXCdpHUUv11xfkT8rvJXeyNipaSxwE/StBbgr4Hnu2l9zPaZn6prZmbZ3G1lZmbZHB5mZpbN4WFm\nZtkcHmZmls3hYWZm2RweZmaWzeFhZmbZHB5mZpbt/wMI6HZ6IKRFegAAAABJRU5ErkJggg==\n",
       "text/plain": [
-       "<matplotlib.figure.Figure at 0x7f7d809cea90>"
+       "<matplotlib.figure.Figure at 0x7f6ef4813b00>"
       ]
      },
      "metadata": {},
@@ -1070,14 +1043,12 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.colorbar.Colorbar at 0x7f7d7dd40a20>"
+       "<matplotlib.colorbar.Colorbar at 0x7f6eee52de80>"
       ]
      },
      "execution_count": 24,
@@ -1086,9 +1057,9 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAdIAAAGHCAYAAAAEI9NyAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAAPYQAAD2EBqD+naQAAIABJREFUeJzt3XmYXVWZ7/Hvj0qEDlOUtBXDIGBshCsIRsZ2QEaxEXBA\nDHJpBUFaEDo8It02Qgxyr+JlvJiWVhmikm40V0AwREZBBKKEKU2CoAkSIYEQIEAQkqr3/rH2gZND\nnWmffWo45/d5nv2E2nvt96xdKfLWWnsNigjMzMwsn3WGugJmZmYjmROpmZlZC5xIzczMWuBEamZm\n1gInUjMzsxY4kZqZmbXAidTMzKwFTqRmZmYtcCI1MzNrgROpDTuS3ifpDkkvSuqTtIOkqZL62/BZ\nn5PUL2mLomObWXcYNdQVMCsnaRTwM2AV8M/Zn48BARSeSLO4I3adTEn/CjwUEVcPdV3MupW81q4N\nJ5K2ARYAR0fEpWXn1wFGRcSrBX+egNFFxx0skl4AfhoRRw11Xcy6lbt2bbjpzf58vvxkRPS3I9lF\nMiySqJJ1h7oeZtYcJ1IbNiRdCtxK6mr9Wfbu8ubs2hvekUraV9Ltkp6V9IKkhZLOqijzZUnzJb0k\naYWk30n6TNn1Ad+RSvpSdt9fJf1F0kWSNq4oc6ukByRtK+mW7DOWSDqlweftl3ShpMMlzQf+Cuyf\nXftK9p54uaRVkn4v6ZOV9wNjgNIz9Eu6pOz6BEmXSFqaPcd8SZ9vpG5m1ji/I7Xh5HvAEuDfgAuA\n3wHLsmtrvcuUtB3wC+A+4OvAK8BEYI+yMsdkca4EzgfWA3YAdgX+c6C42X1TgdOBXwHTgW2ALwHv\nk/T3EdFXdu9bgNnA/8tifgr4lqQHImJOA8+8N/Bp4CJgObA4O38icDXwY+BNwGeAKyUdGBGzszJH\nAD8E7gb+Izv3x+wZ3pqd7wMuzGIfAPxQ0oYRcWEDdTOzRkSEDx/D5gA+RBpU9ImK82cAfWVfn0RK\nEm+uEevnwAN1Pu8fszhbZF+PI7UMf1lR7ktZuX8sO3dLdu7wsnOjgSeAKxt41n5gNbDNANfWrfi6\nB3gAuKHi/AvAJQPc/wPSLyVjK85fAayojO/Dh4/8h7t2baR6Lvvz49mAoWplNpP0vibi7kNKhudX\nnP8+KWn9Q8X5FyPiitIXEbEamAts3eDn3RoRD1eejIhXSv8taSzwZuB24L0Nxv0EqcXeI2mT0kFq\nZW/cRBwzq8OJ1Eaq/wLuICW4ZZJmSjq0Iql+G3gRmCvpD9l7zj0GClbm7dmffyg/mSXIP5VdL1ky\nQIxnSYmvEYsHOinpQEl3SnqZ1IJ8CvgnUhKsSdLfAmOBY4GnK47SO9S3Nlg/M6vD70htRIqIvwIf\nlPRhUivxI8BhwE2S9otkYTad5sDs+ieAL0n6RkR8o6Cq9FU5X62VXOnlN9wofYD0fvRWUvJ8ktQF\nfBQwuYGYpV+QfwxcXqXMAw3Wz8zqcCK1ES0ibiG9q/xKtjjBN4EPAzdn118Gfgr8NFvs4efAv0n6\n3zHwtJfHsj+3oay1KGk0sBVwQ5sepdwnSAl2/4hYU1aHowcoO9BE8KdJ3dA9EXFze6poZiXu2rUR\nSdJAXaf3k1qC62Zl3lJ+MUtKC7Iyo6uEvpHU+jux4vwXgI2Aa/PXumF9pAT52i+6krYEDh6g7Euk\nbtzXREQ/MAv4pKT/UXmDpHEF1tWs67lFaiPV6ZI+CFxHakX2krpB/wz8JivzK0lLSe9SlwHbAccD\n10bESwMFjYjlkv53Fv964BrgXVnsucBP2vdIr7kOOBmYI+kK0rN9CXiENH2n3D3APpKmkEYLL4qI\nucC/AHsCd0v6PvAQaarOJGAv0uhkMyuAE6kNR9XWrSw/fzVp4M/nSUlhOemd4tSIeCEr8z3gs8AU\nYAPSwKDzgbUWbXjDh0R8Q9JTwAnAuaTBPt8D/i1en0PaTF2rftRA5SLiFklHkZLhecAi4KukruXK\nRHoycDFwJvA3pHeicyPiKUm7kObDfpz0i8AzwH9nscysIF5r18zMrAV+R2pmZtYCJ1IzM7MWOJGa\nmZm1wInUzMysBU6kZmZmLejI6S/Z4tz7k1am+evQ1sbMrBDrAVsCcyLimaKDZ3vytjK/eHlE/Lmo\n+owkHZlISUl0MCbOm5kNts+StsMrjKQtRsNjq1sLs0rStt2YTDs1kS5Of/yYtChNNVNI891reaKQ\nCiXrFRTnLfWLNKSoxvp/N1Dmu6RFheppZsezWu4qKE61NenzGFNQnJUNlPkhMNDSvOVeqXO9URsV\nFAeKq9PjBcUZcAGsCteT9kRot+Wk/eMH3jGoReNWk3alz7Mt0FPAz9IP+DjS6mJdpVMTaZYh3kXt\nbRfH1rkOxSUtKO4f0qJ2wHrDxiM5NfJ77AbA3zVQrqhtMovq+VpTv0jDNiwozooGyowB3lGnTFF/\n/0X+P1JUnYpaaKaRX1rWA95W0Oc1pG2vqyYAm+a4r1MTSaNG1GAjScdLWiTpZUl3Sdp5qOtkZmbd\nbcQkUkmHAecAZwA7kXb6mOOdLMzMitFDal02e/QMRWWHkRGTSEkvNC+OiBkRsRA4DlhF2uzYzMxa\nNIq0v2Czh7t2R4BsU+VJwE2lc5FW278R2D1/5M+0WjVr2F5DXYEu88GhrkAXefdQV6AwbpHmM1J+\nkRhH+rtaVnF+GbBN/rCT899qTdp7qCvQZZxIB8/2Q12BwpRapHnu62bd/vxmZpYptUjz3NfNRkoi\nXU6a0Ndbcb4XWFr9timkKS7lPoNbomY2vD0IzK8450XahqsRkUgjYrWke0j9g9cASFL29YXV7zyP\n4uYlmpkNlu15Y5fxk8B/tPVT3bWbz0h6/nOBy7KEOpfU3BwDXDaUlTIz6xSlwUN57utmI+b5I+LK\nbM7oNFKX7n3A/hHx9NDWzMysM7hFms+Iev6ImA5MH+p6mJl1IifSfEbEPFIzM7PhyonUzMyA9i7I\n0Oxa6ZIOlbQgK3+/pAMGKDNN0hOSVkm6QdLEKrHeJOk+Sf2Sdqi4toOk27LPeUzSKQ08zlo6u0W+\nvWB9tRZjva2KqQvAZgXFqTHhpymbFbQbzZI9i4kDsKSoQPsWE2ZhMWEKVdTPUVGzKZY/UlAgKG73\nl20LijOvoDjwxvVkmtXIlm6taVfXbtla6cfy+mDROZL+LiKWD1B+D9Keq6cC15H2YL1K0k4R8VBW\n5lTgBOBI0tZy38xibhsRr1aEPJv0r8taQ6ElbQjMAX4FfDG7fqmkZyPiBw0+vlukZmaWtLFF2uxa\n6ScCsyPi3Ih4OCJOJ/1Wc0JZmZOAMyPi2oiYT0qoE4BDygNlLdl9ga8AlS2rI0i/OxwdEQsi4krS\nlMqT6z/S65xIzcwMaM+i9TnXSt89u15uTqm8pK2B8RUxVwJ3l8eU1EuafHsEA3d37AbcFhHlGw/P\nAbaRtHGNx1qLE6mZmQFta5HWWit9fJV7xtcp30vavb1ezEuB6RFxb5OfU7rWECdSMzPrOJJOBDYA\nvl061a7P6uzBRmZm1rBGBhtdT+r7LPdC7VvyrJW+tE75paTE2MvaLcpeoNT6/DCpm/eVtKLsa34v\n6ScR8fkan1P6jIY4kZqZGdDYEoEHZke5BVTf3TnnWul3DnB93+w8EbFI0tKszANZzI2AXYHvZuW/\nDPxb2f0TSL8DfJo0crj0Od+U1BMRfdm5/YCHI+L5KnV7AydSMzMD2rqyUc210iXNAJZExNey8hcA\nt0o6mTT9ZTJpwNIxZTHPB06T9Chp+suZpCkuVwNExFqT6SS9RGrF/ikinshOXwGcDlwi6duk6S8n\nkkYEN8yJ1MzMgPbtR9rAWumbAWvKyt8p6XDgrOx4BDi4NIc0K3O2pDHAxaT9Mm8HDhhgDulaVamo\n10pJ+5Fasb8ndUNPjYgf1nvmck6kZmYGtHet3VprpUfEXgOcmwXMqhNzKjC1gY8nIh5jgJyfzUH9\nUCMxqvGoXTMzsxa4RWpmZoB3f8mr25/fzMwy7XpH2umcSM3MDIBRPTA6x7IFo4I0U7RLOZGamRkA\nPT0wKsfImZ5+nEjNzMxGrQOjc/TTdnsi8ahdMzOzFnT7LxJmZpYZNSq9J236vrYtBz8yOJGamRmQ\nDTbKkRW6PZF09vP/M7BNizEaXv9/EC0uKM4hUb9MIy4q8NfRjxQUZ2xBcYr8+6/cpnioLSwq0MSi\nAlHcTle3FhRnRUFxADZq8f71C6lFTeuQby5Lf9EVGVk6O5GamVnj8k4k7fJE6sFGZmZmLXCL1MzM\nkkY2JB1Il7dInUjNzCzJ27XbxYsxgBOpmZmV5B1s1OUvCZ1Izcws8ar1uTiRmplZkvcdaZdnki5v\nkJuZmbWmy3+PMDOz1/gdaS5OpGZmlvgdaS5OpGZmlvgdaS5d/vhmZvYad+3m4kRqZmaJu3Zz6fLf\nI8zMzFrjFqmZmSVukebiRGpmZokHG+Xirl0zM0tKg42aPRrIJJKOl7RI0suS7pK0c53yh0pakJW/\nX9IBA5SZJukJSask3SBpYsX1qyU9lsV4QtIMSW8ru/52Sf0VR5+kXeo/0es6+veITXZcwuj3jm0p\nxoa8UFBt4JHr3lNMoM/8tZg4f123mDgfKSYMAEsLirNbQXFGRUGBgLEqJs7CYsLQ2v8ar3uxoOcC\nuKugOC9uX1CgvykoDsCSFu9fv5Ba1NSmrl1JhwHnAMcCc4EpwBxJfxcRywcovwdwBXAqcB3wWeAq\nSTtFxENZmVOBE4AjgcXAN7OY20bEq1mom4GzgCeBTbM6/BR4f9nHBbA38FDZuWcafHLALVIzMysp\nJdJmj/rvSKcAF0fEjIhYCBwHrAKOqlL+RGB2RJwbEQ9HxOnAPFLiLDkJODMiro2I+aSEOgE4pFQg\nIi6IiLkR8XhE3AV8C9hNUnmNBayIiKfKjqY2hnMiNTOztpE0GpgE3FQ6FxEB3AjsXuW23bPr5eaU\nykvaGhhfEXMlcHe1mJLeQmrZ3jFAorxG0jJJt0v6WIOP9honUjMzS/K8Hy0d1Y3LSiyrOL+MlAwH\nMr5O+V5Sl2zdmJK+JelFYDmwOWUtVuBF4GTgUOCjwG9IXcgH1nyiCh39jtTMzJrQmdNfzgZ+ALwd\nOAP4EXAgQEQ8A5xfVvYeSROAU4BrG/0AJ1IzM0saSKQzF8HMxWufe/7VgUq+ZjnQR2pFluul+vDC\npXXKLyW92+xl7VZpL3Bv+U0RsQJYATwqaSHwuKRdI+LuKp99N7BP1acZgBOpmZkl9btpmTwxHeXm\nPQOTfjFw+YhYLeke0sjYawAkKfv6wiofc+cA1/fNzhMRiyQtzco8kMXcCNgV+G6N6peertaUhZ1I\no3wb5kRqZmbtdi5wWZZQS9NfxgCXAUiaASyJiK9l5S8AbpV0Mmn6y2TSgKVjymKeD5wm6VHS9Jcz\nSXOMrs5i7gLsTHrv+SwwEZgGPEKWkCUdCbzK663YTwKfA45u5uGcSM3MLGnTO9KIuFLSOFIi6wXu\nA/aPiKezIpsBa8rK3ynpcNIc0LNIye/g0hzSrMzZksYAF5NmRd8OHFA2h3QV8AlgKmkS7pPAbOCs\niFhdVr2vA1tkn78Q+HRE/LyZx3ciNTOzpI2DjSJiOjC9yrW9Bjg3C5hVJ+ZUUqIc6Np8Utdvrftn\nADNqlWmEE6mZmSWdOWq37ZxIzcwsaWCwUdX7upgTqZmZJW6R5uKVjczMzFrgFqmZmSVukebiRGpm\nZonfkebiRGpmZolbpLk4kZqZWeJEmktHJ9IPcRvjWNRSjBubW7u4psn/cEkhce5jx0Li7Mh9hcT5\n4zveUUgcgEf7JtYv1IAVV21aSBzet6Z+mUZtObqYOEuKCcPYguIU+a9IUXV6cZOCAq0sKA6kxXla\n8UohtajJiTQXj9o1MzNrQUe3SM3MrAkebJSLE6mZmSXu2s3FidTMzBIn0lycSM3MLHHXbi5OpGZm\nlrhFmotH7ZqZmbXALVIzM0vcIs3FidTMzJJ1yJcUu7xv04nUzMySUeTLCl2eSbr88c3M7DXu2s2l\nyxvkZmZmrXGL1MzMErdIc3EiNTOzxIONcnEiNTOzxIONcunyxzczs9e4azcXJ1IzM0vctZtLlz++\nmZkNBknHS1ok6WVJd0nauU75QyUtyMrfL+mAAcpMk/SEpFWSbpA0seL61ZIey2I8IWmGpLdVlNlB\n0m1ZmcckndLss3V0i3QDXmAsz7UU4+P8vKDawCEFxfoFBxUS52d8qpA4H+aWQuIA9PT0FRLn93tu\nWEicD2xyWyFxAG5eemAhcTaeurSQOH1riumPe3Hq3xYSB4CJ9Ys0ZGFBca7qLSgQwCYt3v9sIbWo\nqU1du5IOA84BjgXmAlOAOZL+LiKWD1B+D+AK4FTgOuCzwFWSdoqIh7IypwInAEcCi4FvZjG3jYhX\ns1A3A2cBTwKbZnX4KfD+LMaGwBzgV8AXge2BSyU9GxE/aPTx3SI1M7NkVAtHbVOAiyNiRkQsBI4D\nVgFHVSl/IjA7Is6NiIcj4nRgHilxlpwEnBkR10bEfFJCnQAcUioQERdExNyIeDwi7gK+BewmqZT6\njwBGA0dHxIKIuBK4EDi57hOVcSI1M7Ok9I602aNGJpE0GpgE3FQ6FxEB3AjsXuW23bPr5eaUykva\nGhhfEXMlcHe1mJLeQmrZ3hERpa6v3YDbImJNxedsI2nj6k+1NidSMzNLSl27zR61u3bHZSWWVZxf\nRkqGAxlfp3wvEI3ElPQtSS8Cy4HNKWux1vic0rWGjIhEKukMSf0Vx0NDXS8zs47Svq7doXQ2sCOw\nL9AH/KjoDxjej7+2+cDegLKv19Qoa2ZmbTDzepg5Z+1zz79Y85blpARWOXKrF6g2cm5pnfJLSbmg\nl7VblL3AveU3RcQKYAXwqKSFwOOSdo2Iu2t8TukzGjKSEumaiHh6qCthZtaxGhi1O/nAdJSbtwAm\nTR64fESslnQPqSF0DYAkZV9fWOVj7hzg+r7ZeSJikaSlWZkHspgbAbsC361R/VIn9Lpln/NNST1l\n7033Ax6OiOdrxFnLiOjazbxT0l8k/VHSjyVtPtQVMjPrKG0YbJQ5FzhG0pGS3gV8DxgDXAaQze/8\nX2XlLwA+IulkSdtImkoasHRRWZnzgdMkfUzS9sAMYAlwdRZzl2zu6nskbSFpL9KUmkfIEnL29avA\nJZK2y6bpnEiaJtOwkdIivQv4HPAw8DZgKnCbpHdHxEtDWC8zs87RpnmkEXGlpHHANFLX6X3A/mW9\njJtR9rouIu6UdDhpDuhZpOR3cGkOaVbmbEljgIuBscDtwAFlc0hXAZ8g5Yv1SXNJZwNnRcTqLMZK\nSfuRWrG/J3VDT42IHzbz+CMikUZEeY/8fElzgceATwOXDk2tzMw6TBsXrY+I6cD0Ktf2GuDcLGBW\nnZhTSYlyoGulcTX16jUf+FC9crWMiERaKSKel/QH6qyDcvOU61l34/XWOrft5O3ZbvL27ayemVmL\nbgV+XXHOnW/D1YhMpJI2AN5B6hOvaq/zPsL4904YnEqZmRVmz+wo9yjp9V0bedH6XEZEIpX0HeAX\npO7cTYFvkPrTZw5lvczMOoq3UctlRCRS0ovoK0irPj8N/AbYLSKeGdJamZl1EifSXEZEIo2IKjOU\nzMysMG0cbNTJuvzxzcysJNaByNG6jC5/R9rlj29mZtYat0jNzAyAvh7oy5EV+vyOtHNtyWO8nRda\nitFX4Fv0P9ae9tqwsTxXSJx93rDdXz5bsriQOAA7cl8hcbbf5MFC4jzDJoXEAfjkrj8uJM6sh48o\nJE7jS3LXUXvB8uYU89cP69Uv0pgxRQUC/qbF+9etX6RF/TkTab8TqZmZGfT1iDU9ql/wDfcFaXvQ\n7uREamZmAPT19NA3qvmhM309/XTzzpZOpGZmBkB/Tw99Pc0n0v4e0c2J1KN2zczMWuAWqZmZAdDH\nOrkGWPbVL9LRnEjNzAxIsxTWOJE2zYnUzMwA6KeHvhxpob8NdRlJnEjNzAxopWu3u1OpE6mZmQGl\nFmnzibS/yxOpR+2amZm1wC1SMzMDoD9n125/lw83ciI1MzMA1rBOrlG7a7q8c9OJ1MzMAOhnVM5R\nu26RmpmZtdC1290t0u5+ejMzsxa5RWpmZkAr80i7u03mRGpmZkArSwR2987eHZ1IJ/F73s3ooa7G\na55hXCFx9uSWQuI8RW8hcW5hz0LiAIzluULifJyfFxJnWUHfI4BT+E4hcTbY7OlC4rx4498WEof3\nFxMGgPEFxfleQXEK9Tct3r9uIbWoJf8SgfUTqaTjga+Q/pbvB74cEb+rUf5QYBqwJfAH4F8iYnZF\nmWnAF4CxwB3AP0XEo9m1twNfB/bKPvMvwE+AsyJidVmZRRUfHcDuETG37kNlurs9bmZmr+nLVjbK\nc9Qi6TDgHOAMYCdSIp0jacDWhaQ9gCuA7wM7AlcDV0narqzMqcAJwLHALsBLWcw3ZUXeBQg4BtgO\nmAIcB5xV8XHB68l2PPA24J4Gvl2vcSI1MzPg9VG7zR4NjNqdAlwcETMiYiEpoa0CjqpS/kRgdkSc\nGxEPR8TpwDxS4iw5CTgzIq6NiPnAkcAE4BCAiJgTEUdHxE0RsTgirgX+D/CJis8SsCIinio7mprP\n40RqZmZtI2k0MAm4qXQuIgK4Edi9ym27Z9fLzSmVl7Q1qfVYHnMlcHeNmJC6gFcMcP4aScsk3S7p\nYzUfaAAd/Y7UzMwa16ZRu+OAHmBZxfllwDZV7hlfpXzpLXovqUu2Vpm1SJpIatGeXHb6xezrO0i7\nwX2K1IV8cNaCbYgTqZmZAZ07alfSpsBs4L8i4pLS+Yh4Bji/rOg9kiYApwBOpGZm1pxGRu3eOnMZ\nt858aq1zLz2/ptYty4E+eMMQ+F5gaZV7ltYpv5T0brOXtVulvcC95TdlifFm4DcR8cVaFc3cDezT\nQLnXOJGamRnQWNfuByZP4AOTJ6x17tF5K/nnSQPPZImI1ZLuAfYGrgGQpOzrC6t8zJ0DXN83O09E\nLJK0NCvzQBZzI2BX4LulG7KW6M3A76g+sKnSTsCTDZYFnEjNzCyTf2PvuvecC1yWJdS5pFG8Y4DL\nACTNAJZExNey8hcAt0o6GbgOmEwasHRMWczzgdMkPQosBs4ElpCmypRaoreS5ol+FXhryt8QEcuy\nMkcCr/J6K/aTwOeAo5t5fidSMzNrq4i4MpszOo3U/XofsH9ElFYX2QxYU1b+TkmHk+Z8ngU8Ahwc\nEQ+VlTlb0hjgYtJo3NuBAyLi1azIvsDW2fF4dk6kQUrlmf/rwBbZ5y8EPh0RTa3o4kRqZmZA6trN\nN9io/kzKiJgOTK9yba8Bzs0CZtWJORWYWuXa5cDlde6fAcyoVaYRTqRmZgaUVjZqPi0M91G77eZE\namZmQFvfkXY0J1IzMwO8jVpeTqRmZgZ07oIM7dbdv0aYmZm1yC1SMzMD2rsfaSdzIjUzM8DvSPPq\n6ES62YPPsPXqFoP8qZCqALD1zGrLSjbpu/WLNOLNE54rJM4mPcsLiVOkPzKxkDj7vGEnp/y246H6\nhRowdv1nC4lz+3EfLCTOisUT6hdq1J6vFBNn/HrFxPlmMWGAtObOMOdRu/l0dCI1M7PG9edskTaw\nsXdH6+6nNzMza5FbpGZmBsCanNNf8tzTSZxIzcwM8KjdvJxIzcwM8KjdvJxIzcwM8KjdvJxIzcwM\naO82ap2s6aeXdLmkYiagmZmZjXB5WqQbAzdKegy4FLg8Iv5SbLXMzGyweT/SfJpukUbEIcCmwL8D\nhwGLJc2W9ClJo4uuoJmZDY7SO9Jmj25/R5qrYzsino6IcyPiPcCuwKPAj4AnJJ0n6Z1FVtLMzNqv\ntLJR84nU70hzk/Q2YN/s6AN+CWwPPCRpSuvVMzOzwdKXM5F2+2CjpjvDs+7bg4DPA/sBDwDnA1dE\nxMqszMeBS4DziquqmZm1kzf2zifPYKMnSS3ZmcAuEXHfAGVuAYrZWsTMzGwYy5NIpwA/jYi/VisQ\nEc8BW+WulZmZDTovEZhP09+xiPhROypiZmZDy0sE5uOVjczMDPASgXk5kZqZGeAlAvPq7ET6Q2Bs\nizEOKqIimQ0KivN8MWE2WrO6mEBbPFNMHGCjHxVTpwc/t0MhcR5iu0LiAHyeSwuJcyP7FBJnbE8x\n4wEnvOOJQuIAzL9p52IC/ayYMKwpKA4Ab23x/qcKqUUtfYzKubJR/XskHQ98BRgP3A98OSJ+V6P8\nocA0YEvgD8C/RMTsijLTgC+Q/qW/A/iniHg0u/Z24OvAXtln/gX4CXBWRKwui7EDcBGwM+mbfFFE\nfKeR5y7p7l8jzMys7SQdBpwDnAHsREqkcySNq1J+D+AK4PvAjsDVwFWStisrcypwAnAssAvwUhbz\nTVmRdwECjgG2Iw2UPQ44qyzGhsAcYBHwXuAUYKqkLzTzfE6kZmYGtHVloynAxRExIyIWkhLaKuCo\nKuVPBGZnK+g9HBGnA/NIibPkJODMiLg2IuYDRwITgEMAImJORBwdETdFxOKIuBb4P8AnymIcAYwG\njo6IBRFxJXAhcHLj3zUnUjMzy7RjZaNsEZ9JwE2lcxERwI3A7lVu2z27Xm5OqbykrUndteUxVwJ3\n14gJqQt4RdnXuwG3RUR5J/4cYBtJG9eIs5bOfkdqZmYNa9Oo3XFAD7Cs4vwyYJsq94yvUn589t+9\nQNQpsxZJE0kt2vLW5njgTwPEKF1raESKE6mZmQGdO2pX0qbAbOC/IuKSouM7kZqZWcP+PPMu/jzz\nrrXOvfr8qlq3LCdtatJbcb4XWFrlnqV1yi8lDSTqZe1WaS9wb/lNkiYANwO/iYgvNvg5pWsNcSI1\nMzOgsY29N538fjad/P61zj07bxE3T/r6gOUjYrWke4C9gWsAJCn7+sIqH3PnANf3zc4TEYskLc3K\nPJDF3Ii0red3SzdkLdGbgd8x8MCmO4FvSuqJiL7s3H7AwxHR8ETD4d0eNzOzQdPGjb3PBY6RdKSk\ndwHfA8YAlwFImiHpf5WVvwD4iKSTJW0jaSppwNJFZWXOB06T9DFJ2wMzgCWkqTKlluitwGPAV4G3\nSuqVVN49oklIAAAWuElEQVQCvQJ4FbhE0nbZNJ0TSVN1GuYWqZmZAe1bazcirszmjE4jdZ3eB+wf\nEU9nRTajbPmLiLhT0uGkOZ9nAY8AB0fEQ2VlzpY0BriYNBr3duCAiHg1K7IvsHV2PJ6dE2mQUk8W\nY6Wk/Uit2N+TuqGnRsQPm3l+J1IzMwPaux9pREwHple5ttcA52YBs+rEnApMrXLtcuDyBuo1H/hQ\nvXK1OJGamRngbdTy8jtSMzOzFrhFamZmgPcjzcuJ1MzMAO9HmpcTqZmZAZ27slG7OZGamRnQ2IIM\n1e7rZk6kZmYGuGs3r85OpFtRZR+AJlxQREUyHy0ozkX1izSkoPps9OvV9Qs1asdiwozluULiPMfY\nQuIAPFx1o4vmHJRWWWvZC2xQSJwNebGQOADzx+9cTKCCfo4K+jFKlm/V2v3xbFqx1oadzk6kZmbW\nsP6co3Yb2Ni7ozmRmpkZwGtr5+a5r5s5kZqZGeBRu3kNi6eX9AFJ10j6i6R+SQcNUGaapCckrZJ0\nQ7bbuZmZFaQ0arf5o7tbpMMikQLrk3YD+BJpZf61SDoVOAE4FtgFeAmYI+lNg1lJM7NO1sZt1Dra\nsOjajYjrgevhtQ1fK50EnBkR12ZljiTtin4IcOVg1dPMzKzScGmRViWpNInlptK5iFgJ3A3sPlT1\nMjPrNKVRu823SId9KmmrYdEirWM8qbt3WcX5ZbQ+S9TMzDJrWIeeHN20a5xIzczMoD8bPJTnvm42\nEp5+KSCgl7Vbpb3AvbVunHIzbLzu2ucmbwuTtyu4hmZmReqfCTFz7XPxfPs/1gsy5DLsE2lELJK0\nFNgbeABA0kbArsB3a9173l7wXnf+mtlIs85kYPLa52Ie9E0akupYbcMikUpaH5hIankCbC3pPcCK\niHgcOB84TdKjwGLgTGAJcPUQVNfMrCP1sQ7reEGGpg2LRAq8D7iFNKgogHOy85cDR0XE2ZLGABcD\nY4HbgQMi4tWhqKyZWSfq7++hrz9H126OezrJsEikEfFr6kzFiYipwNTBqI+ZWTfq61sH1uRokfa5\nRWpmZkbfmh5Yk2Nj7xzJt5M4kZqZGQD9fT25WqT9fd2dSLu7PW5mZtaizm6RPkvrvypsUkRFMhsX\nFOfxYsKsOryYOGOOLyYOAL8uJsyHDppbTKC/LyYMQO9bKxfnyuc8phQS58PcWkicn/GpQuIAjB6/\nspA4q4/YqJA4XFtMGADWPNJigD8XUo1a+vrWIXK1SLu7TdbdT29mZq/pW9PDmtXNH428I5V0vKRF\nkl6WdJekneuUP1TSgqz8/ZIOGKBMze01JX1N0h2SXpK0osrn9FccfZI+XfeByjiRmpkZANHfQ3/f\nqKaPqDP9RdJhpGmNZwA7AfeTtsIcV6X8HsAVwPeBHUlrBlwlabuyMo1srzmatEPYv9d59H8krZY3\nHngbcFWd8mtxIjUzs2RNNv2l6aNuKpkCXBwRMyJiIXAcsAo4qkr5E4HZEXFuRDwcEacD80iJs+S1\n7TUjYj5wJDCBtL0mABHxjYi4AHiwTv2ej4inI+Kp7GhqjQInUjMzS/ryJNGedF8VkkYDk1h7K8wA\nbqT6Vpi7Z9fLzSmVl7Q1xW6v+V1JT0u6W9Lnm725swcbmZnZUBsH9DDwVpjbVLlnfJXypdXTeylu\ne82vAzeTWsj7AdMlrR8RFzUawInUzMySPsEa1S830H0jVEScVfbl/ZI2AE4BnEjNzKxJfcCaOmWu\nmwm/rNji7YWaW7wtzyL3VpzvJW2TOZCldcrn3l6zAXeTNkkZHRGrG7nBidTMzJJGEun+k9NRbsE8\n+MzAW7xFxGpJ95C2wrwGQJKyry+s8il3DnB93+x8S9trNmAn4NlGkyg4kZqZWcka6ifSavfVdi5w\nWZZQ55JG8Y4BLgOQNANYEhFfy8pfANwq6WTgOtLmrJOAY8pi1t1eU9LmwFuAtwM92facAI9GxEuS\nDiS1Yu8C/kp6R/qvwNnNPL4TqZmZJWuAhtthFffVEBFXZnNGp5ES133A/hHxdFZks/IoEXGnpMOB\ns7LjEeDgiHiorEwj22tOI02LKZmX/flh4DbS0x5PSvQCHgX+OSJ+0PCz40RqZmaDICKmA9OrXNtr\ngHOzgFl1Yk6lxvaaEfF5oOp0loiYQ5pW0xInUjMzS/pJ70nz3NfFnEjNzCxpZLBRtfu6mBOpmZkl\n7Rts1NGcSM3MLHGLNBevtWtmZtYCt0jNzCxxizQXJ1IzM0ucSHPp7ET6ILBeayFWLiqkJgBsVH8T\n+cYU9EM7Zr9i4rCgoDiQFvwqwlYFxflVQXGA3f7+/kLivGOrPxYSZ0NeKCTOE0woJE6h/rOgOGML\nigPAO1u8v5i/r5qcSHPp7ERqZmaNa9PKRp3OidTMzJI+8rUuu7xF6lG7ZmZmLXCL1MzMEr8jzcWJ\n1MzMEifSXJxIzcwscSLNxYnUzMwSr7WbixOpmZklbpHm4lG7ZmZmLXCL1MzMErdIc3EiNTOzxCsb\n5eJEamZmiVc2ysWJ1MzMEnft5uJEamZmiRNpLh61a2Zm1gK3SM3MLHGLNBcnUjMzSzxqN5fOTqQb\nAxu0FmKjLQqpCQCr7igmzphDi4nDLwuK8z8LigOwd0Fxinq2Av+B+NMR4wuJcyQzConzXxxWSJzN\nebyQOACL12xZTKD1iglTbILIk6HKDUK28qjdXPyO1MzMklLXbrNHA4lU0vGSFkl6WdJdknauU/5Q\nSQuy8vdLOmCAMtMkPSFplaQbJE2suP41SXdIeknSiiqfs7mk67IySyWdLamp3OhEamZmbSXpMOAc\n4AxgJ+B+YI6kcVXK7wFcAXwf2BG4GrhK0nZlZU4FTgCOBXYBXspivqks1GjgSuDfq3zOOqT+q1HA\nbsA/Ap8DpjXzfE6kZmaWtK9FOgW4OCJmRMRC4DhgFXBUlfInArMj4tyIeDgiTgfmkRJnyUnAmRFx\nbUTMB44EJgCHlApExDci4gLgwSqfsz/wLuCzEfFgRMwBvg4cL6nhV59OpGZmlpQGGzV71Hh9K2k0\nMAm4qXQuIgK4Edi9ym27Z9fLzSmVl7Q1ML4i5krg7hoxB7Ib8GBELK/4nI2B/9FoECdSMzNL+lo4\nqhsH9ADLKs4vIyXDgYyvU74XiCZjNvM5pWsN6exRu2Zm1rhG5pEumgmLZ6597tXn21WjEcGJ1MzM\nkkYS6eaT01FuxTyYM6naHcuzyL0V53uBpVXuWVqn/FJA2bllFWXurV75AT+ncvRwb9m1hrhr18zM\n2iYiVgP3UDZLXJKyr39b5bY7eeOs8n2z80TEIlKiK4+5EbBrjZjVPmf7itHD+wHPAw81GsQtUjMz\nS9q3stG5wGWS7gHmkkbxjgEuA5A0A1gSEV/Lyl8A3CrpZOA6YDJpwNIxZTHPB06T9CiwGDgTWEKa\nKkMWd3PgLcDbgR5J78kuPRoRLwG/IiXMH2XTad6Wxbko+wWgIU6kZmaW9JNvlaL+2pcj4sqs1TeN\n1HV6H7B/RDydFdmMsnQcEXdKOhw4KzseAQ6OiIfKypwtaQxwMTAWuB04ICJeLfvoaaRpMSXzsj8/\nDNwWEf2SDiTNM/0taS7qZaT5rg1zIjUzs6Q0LzTPfXVExHRgepVrew1wbhYwq07MqcDUGtc/D3y+\nTozHgQNrlanHidTMzBLv/pKLE6mZmSXe/SUXj9o1MzNrgVukZmaWtGmwUadzIjUzs8TvSHNxIjUz\ns6SNo3Y7WUcn0r/cD29uMcYLhdQk2eEbBQX6cUFxtioozq8LigPw0YLiFPVs7ysoDjCGlwuJcxP7\nFBKnp6BmRB89hcQBGDvuuULirPjU+oXE4aJiwgAwanRr98eo9rf8PNgoFw82MjMza0FHt0jNzKwJ\nHmyUixOpmZklHmyUixOpmZklHmyUixOpmZklHmyUixOpmZklfkeai0ftmpmZtcAtUjMzSzzYKBcn\nUjMzS5xIc3EiNTOzJO+gIQ82MjMzI7UslfO+LuZEamZmSd6E2OWJ1KN2zczMWuAWqZmZJX1A5Liv\ny+eROpGamVmyhnzvSPMk3w7iRGpmZknewUZOpGZmZpkuT4p5dHQifQV4ucUYO3y0iJpkfllMmFsf\nKSbOnicVE4cFBcUBeLCgOPsXE2blFqOLCQRs+MoLhcR5Yt0JhcR5mG0KifPbZXsUEgdgy97FhcRZ\ncdWmhcQp1JpWM5Qz3HDlUbtmZmYtcCI1M7O2k3S8pEWSXpZ0l6Sd65Q/VNKCrPz9kg4YoMw0SU9I\nWiXpBkkTK66/WdJPJD0v6VlJP5C0ftn1t0vqrzj6JO3SzLM5kZqZWVtJOgw4BzgD2Am4H5gjaVyV\n8nsAVwDfB3YErgaukrRdWZlTgROAY4FdgJeymG8qC3UFsC2wN/APwAeBiys+LoC9gPHZ8Tbgnmae\nz4nUzMwypZ29mz3qLrY7Bbg4ImZExELgOGAVcFSV8icCsyPi3Ih4OCJOB+aREmfJScCZEXFtRMwH\njgQmAIcASNqWNFri6Ij4fUT8Fvgy8BlJ48viCFgREU+VHU2t1TQsEqmkD0i6RtJfsqb1QRXXLx2g\n+V3Q0B0zM0vWtHAMTNJoYBJwU+lcRARwI7B7ldt2z66Xm1MqL2lrUuuxPOZK4O6ymLsBz0bEvWUx\nbiS1QHetiH2NpGWSbpf0saoPU8WwSKTA+sB9wJeoPjRtNtDL683vyYNTNTMza8E4oAdYVnF+Genf\n8oGMr1O+l5QrapUZDzxVfjFraa4oK/MicDJwKPBR4DekLuQDaz5RhWEx/SUirgeuB5BUbTrwKxHx\n9ODVysys25S6dmv5WXaUe7491WmziHgGOL/s1D2SJgCnANc2GmdYJNIG7SlpGfAscDNwWkSsGOI6\nmZl1kEZ29j4kO8rdTxqvM6DlWeDeivO9wNIq9yytU34p6d1mL2u3SnuBe8vKvLU8gKQe4C01PhdS\n9/A+Na6/wXDp2q1nNulF8l7AV4EPAb+s0Xo1M7OmFT/YKCJWk0bB7l06l/3bvTfw2yq33VlePrNv\ndp6IWERKhuUxNyK9+/xtWYyxknYqi7E3KQHfXbXCaVTxkzWuv8GIaJFGxJVlX/63pAeBPwJ7ArdU\nu+9bwIYV5z5KGgNtZjZ8zQT+s+Lcc4PwuY107Va7r6Zzgcsk3QPMJY3iHQNcBiBpBrAkIr6Wlb8A\nuFXSycB1pDExk4BjymKeD5wm6VFgMXAmsIQ0VYaIWChpDvB9Sf8EvAn4v8DMiFiafe6RwKu83or9\nJPA54Ohmnn5EJNJKEbFI0nJgIjUS6b8A21W7aGY2bE3mjeMp5wHva/PnNtK1W+2+6iLiymzO6DRS\n9+t9wP5l4142K//giLhT0uHAWdnxCHBwRDxUVuZsSWNI80LHArcDB0TEq2UffThwEWm0bj/p5W7l\n4qhfB7bIPn8h8OmI+Hnjzz5CE6mkzYBNaLL5bWZmQyMipgPTq1x7wwvWiJgFzKoTcyowtcb154Aj\nalyfAcyo9RmNGBaJNFuyaSKvb+CztaT3kIYpryCthjGL1Cc+Efg28AfSvCIzMytE27p2O9qwSKSk\n/opbSPOCgrSUFMDlpLmlO5AGG40FniAl0NOzl9hmZlaI9nTtdrphkUgj4tfUHkH8kcGqi5lZ93KL\nNI9hkUjNzGw4qL3cX+37upcTqZmZZdwizWOkLMhgZmY2LHV0i/QGYH6LMfYpcI+ZyvWu8trznQUF\nuqOgOJMKigOt/4WVHFS/SCM2WlDceLar371fIXF6ChrYsR0P1S/UgC/0/qCQOAD/8XDlFL+c3lVM\nGPYsKA7Az1pdiG0wFnLzYKM8OjqRmplZM9y1m4cTqZmZZdwizcOJ1MzMMm6R5uFEamZmGbdI8/Co\nXTMzsxa4RWpmZhl37ebhRGpmZhkn0jycSM3MLOMlAvNwIjUzs4xbpHl4sJGZmVkL3CI1M7OMp7/k\n4URqZmYZd+3m0dVduw8OdQW6yMxHh7oG3eWBmQuGugrd488zh7oGBSq1SJs9urtF2tWJtKiNRqw+\nJ9LB9cDMhUNdhe7xeCcl0lKLtNmju1uk7to1M7OM35Hm0dUtUjMzs1a5RWpmZhkPNsqjUxPpegAf\n/PGP2XbbbasWumXKFA4677xBq9QLBcWZV1CcwfT8ginMO3bwvtc8O3gf1ajNC/qL27yBMjc8/zs+\nOu/wYj5wEH2xqJ/urYoJw7/WLzJlyvOc968N1LuBWLUsWLCAI44Asn/f2mMp+ZLi8qIrMqIoIoa6\nDoWTdDjwk6Guh5lZG3w2Iq4oMqCkLYAFwJgWwqwCto2IPxdTq5GjUxPpJsD+wGLgr0NbGzOzQqwH\nbAnMiYhnig6eJdNxLYRY3o1JFDo0kZqZmQ0Wj9o1MzNrgROpmZlZC5xIzczMWuBEamZm1oKuTaSS\njpe0SNLLku6StPNQ16nTSDpDUn/F8dBQ16sTSPqApGsk/SX7vh40QJlpkp6QtErSDZImDkVdO0G9\n77ekSwf4Wf/lUNXXBldXJlJJhwHnAGcAOwH3A3MktTL02wY2H+gFxmfH+4e2Oh1jfeA+4EvAG4be\nSzoVOAE4FtgFeIn0M/6mwaxkB6n5/c7MZu2f9cmDUzUbap26slE9U4CLI2IGgKTjgH8AjgLOHsqK\ndaA1EfH0UFei00TE9cD1AJI0QJGTgDMj4tqszJHAMuAQ4MrBqmenaOD7DfCKf9a7U9e1SCWNBiYB\nN5XORZpMeyOw+1DVq4O9M+sO+6OkH0tqZIU7a4GkrUgtovKf8ZXA3fhnvJ32lLRM0kJJ0yW9Zagr\nZIOj6xIpaeWOHtJv5+WWkf7xseLcBXyOtMrUcaQVUG+TtP5QVqoLjCd1P/pnfPDMBo4E9gK+CnwI\n+GWN1qt1kG7t2rVBEBFzyr6cL2ku8BjwaeDSoamVWfEiory7/L8lPQj8EdgTuGVIKmWDphtbpMtJ\nu9D2VpzvJW19YG0SEc8DfwA8erS9lgLCP+NDJiIWkf6t8c96F+i6RBoRq4F7gL1L57Lul72B3w5V\nvbqBpA2AdwBPDnVdOln2j/hS1v4Z3wjYFf+MDwpJmwGb4J/1rtCtXbvnApdJugeYSxrFOwa4bCgr\n1WkkfQf4Bak7d1PgG6TNDmcOZb06QfaeeSKp5QmwtaT3ACsi4nHgfOA0SY+SdkE6E1gCXD0E1R3x\nan2/s+MMYBbpF5iJwLdJvS9z3hjNOk1XJtKIuDKbMzqN1N11H7C/h64XbjPgCtJv5k8DvwF2a8cW\nUF3ofaR3b5Ed52TnLweOioizJY0BLgbGArcDB0TEq0NR2Q5Q6/v9JWAH0mCjscATpAR6etYDZh3O\n26iZmZm1oOvekZqZmRXJidTMzKwFTqRmZmYtcCI1MzNrgROpmZlZC5xIzczMWuBEamZm1gInUjMz\nsxY4kZqZmbXAidTMzKwFTqRmZmYtcCI1a5KkcZKelPQvZef2kPSKpA8PZd3MbPB50XqzHCQdAFwF\n7E7aLus+4OcRccqQVszMBp0TqVlOkv4vsC/we+DdwM7eNsus+ziRmuUkaT1gPmnf1fdGxENDXCUz\nGwJ+R2qW30RgAun/o62GuC5mNkTcIjXLQdJoYC5wL/AwMAV4d0QsH9KKmdmgcyI1y0HSd4BPADsA\nq4BbgZUR8bGhrJeZDT537Zo1SdKHgBOBIyLipUi/jR4JvF/SF4e2dmY22NwiNTMza4FbpGZmZi1w\nIjUzM2uBE6mZmVkLnEjNzMxa4ERqZmbWAidSMzOzFjiRmpmZtcCJ1MzMrAVOpGZmZi1wIjUzM2uB\nE6mZmVkLnEjNzMxa8P8BkFEtrpI/UtsAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAU8AAAEWCAYAAADmTBXNAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzt3X28XVV95/HP997cm0dCgCCGBEiwgTFYihgDWmtFqiSU\nkj5MO/Aay4POK6/MC6x2tBaKUx0rLUqnnaKUTEYzSqVQRsSmmhZQ2+pMDRJoiIQHuUQwieEhQcJD\nwn06v/lj7ztzcrz33L1O9rnnnnO/b177lXP2Xmuvtc85/O7ee629liICMzNL09XqCpiZtSMHTzOz\nBjh4mpk1wMHTzKwBDp5mZg1w8DQza4CDZweSdKqkrZJekvQ7ktZJ+s+Hsb8/kPS5Muto1u7kfp6d\nR9LngRcj4ndbXZeySXoS+A8R8Y1W18WmNp95dqaTgO2trkQqSdNaXQezohw8O4ykbwHnAJ+V9LKk\nUyR9QdIn8+3zJX1N0guSnpf0HUld+bbfl7Q7v9x/TNK5+fqPS/pSVRkXStqe7+OfJL2+atuTkj4s\naZuk/ZL+RtKMMep6maT/I+nPJe0DPi7pdZK+JWmfpL2SbpE0L0//V8CJwN/lx/aRfP3Zkv4lr8+D\nkt7RjM/WrJqDZ4eJiHcC3wGujIg5EfGDmiQfAnYBxwLHAX8AhKRTgSuBN0fEEcB5wJO1+5d0CnAr\n8MF8H5vIgllvVbLfAlYCS4DTgcvqVPksYEdel2sBAX8CHA+8HjgB+Hh+bL8N/Aj4lfzYPi1pIfB1\n4JPA0cCHgTskHVvvczI7XA6eU88gsAA4KSIGI+I7kd34HgamA8sk9UTEkxHxxCj5/x3w9Yi4JyIG\ngT8FZgJvrUpzQ0T8OCKeB/4OOKNOfX4cEZ+JiKGIOBgRffm++yPiOeDPgF+sk/89wKaI2BQRlYi4\nB9gCnF/s4zBrjIPn1HM90AfcLWmHpKsAIqKP7Gzy48Czkm6TdPwo+Y8Hnhp5ExEVYCewsCrN01Wv\nDwBz6tRnZ/UbScflZe+W9CLwJWB+nfwnAb+ZX7K/IOkF4G1kfyDMmsbBc4qJiJci4kMRcTJwIfCf\nRu5tRsRfR8TbyAJSAJ8aZRc/zrcDIElkl9a7G61Szfs/ztf9bETMJTuzVJ30O4G/ioh5VcvsiLiu\nwfqYFeLgOcVIukDSz+RBbz/Z5Xol7xv6TknTgVeBg0BllF3cDvyypHMl9ZDdQ+0H/qWkKh4BvAzs\nz+9n/l7N9meAk6vefwn4FUnnSeqWNEPSOyQtKqk+ZqNy8Jx6lgLfIAtQ3wX+MiL+kex+53XAXrLL\n7tcAV9dmjojHyM4GP5On/RWyBpyBkur3X4AzyQL714Gv1Gz/E+Cj+SX6hyNiJ7CarOHrObIz0d/D\nv21rMneSNzNrgP86m5k1wMHTzKwBDp5mZg1w8DQza0BbDMTQ2z0rZvYcmZYpRutlMw5p/DStUGmg\nUa+7gb+LlQY+s9QGx4baJxvI1Mhn1sj3n3j8DTXQTkCj7qu8wkD0H9b/AOedMzv2PT9cKO392/rv\nioiVh1Neq7VF8JzZcyRvWXxpUh71N9Bzprs7Pc9EaOBYYs6s5Dx6tT85DwODScljqNj/XIeopOeJ\nxHoBqIE/ODE4lJZ+KC19I2UAyZ/ZvfHN9DJq7Ht+mO/ddWKhtN0LHq/31FhbaIvgaWaTXwCVUZ+r\n6EwOnmZWiiAYjAauLNpUSxqMJK3Mx4vsGxmYwszaX6Xgf51gws88JXUDNwLvIhtX8j5JGyPi4Ymu\ni5mVJwiGp9ATi60481wB9EXEjvx56NvInk02szZXIQotnaAV9zwXcugYjrvIRhM/hKQ1wBqAGdPm\nTkzNzKxh2YjanREYi5i0neQjYn1ELI+I5b3d6d1uzGzilXnmOV7biDI35Nu3STozIe+HJIWk+VXr\nrs7TPybpvPHq14ozz91kg+eOWETjA+ma2SQRwGBJ9zwLto2sIhticSnZ1etNwFnj5ZV0AvBusvmw\nRspbBlwEnEY2W8I3JJ0SMXb3gVaced4HLJW0JJ807CJgYwvqYWYlCoLhgksBRdpGVgM3R2YzME/S\nggJ5/xz4CIc+urYauC2fO+uHZFPVrKhXwQkPnhExRDZL413AI8DtEdF2c4ybWY2A4YILMF/Slqpl\nTc3eRmsbWVgwzZh5Ja0GdkfEgw2Ud4iWdJKPiE1kU9aaWYfInjAqbG9ELG9aZUYhaRbZjAPvLmN/\nbfGEUaW3m1dPnJeUp2so/d5LZVrauAhq4PbOcG/6yX73QHqn4u6DDTwPHbPTyzmQ9ty9DjbwnH5v\nT3IeNfA8eCN5eOVAUvKuBgYfqSSWARADiZ/z4Y0JkhPDlDa4TpG2kbHS9Iyx/nXAEuDBbAovFgEP\nSFpRsLxDTNrWdjNrL1mDkQotBRRpG9kIXJK3up8N7I+IPWPljYjvR8RrImJxRCwmuzQ/MyKezvd1\nkaTpkpaQNUJ9r14F2+LM08wmv6yfZzlnnhExJGmkbaQb2BAR2yWtzbevI7v1dz5Z484B4PJ6eccp\nb7uk24GHgSHginot7eDgaWYlqhQ7qyxktLaRPGiOvA7giqJ5R0mzuOb9tcC1Revn4GlmpSjzzLMd\nOHiaWSkCMTyFmlEcPM2sNGVetk92Dp5mVopADMQkncqmCRw8zawUWSd5X7abmSVzg5GZWaIIMRw+\n8zQzS1bxmaeZWZqswWjqhJS2ONLh6WL/yb1Jebr708vpGk4b6aNrML2Mgbnpf5ln/KSB2QbnpX+1\njVxxqTIjKf2M59M/tEpPesV69x1MzkNlenKWrp7Ez3n/S8llJA/yAShxAJIyzhfdYGRm1qBh9/M0\nM0sz1Z4wmvAjlXSCpH+U9LCk7ZI+MNF1MLPmqERXoaUTtOLMcwj4UEQ8IOkI4H5J99RM7GRmbSYb\nGKQzAmMREx4888FK9+SvX5L0CNlcIQ6eZm0sEIN+PHNiSFoMvBG4d5Rta4A1AD1zjprQeplZugim\nVCf5lh2ppDnAHcAHI+LF2u0RsT4ilkfE8mkz0ufWMbOJJioFl07QkuApqYcscN4SEV9pRR3MrFxB\nduZZZClC0kpJj0nqk3TVKNsl6YZ8+zZJZ46XV9If5Wm3Srpb0vH5+sWSDubrt0paV1terVa0tgv4\nPPBIRPzZRJdvZs0zTFehZTySuoEbgVXAMuBiSctqkq0im6htKdktvpsK5L0+Ik6PiDOArwF/WLW/\nJyLijHxZO14dW3Hm+fPAbwPvrIry57egHmZWokBUothSwAqgLyJ2RMQAcBuwuibNauDmyGwG5kla\nUC9vzS3C2WQnzA1pRWv7/6acp8HMbBLJph4uLaQsBHZWvd8FnFUgzcLx8kq6FrgE2A+cU5VuiaSt\n+fqPRsR36lWwLZ4wimnw6jHNj7czn01LX5mTXkZ3+mPK9B+RfoHQVXfS1NENNtAup9TH7tWTXkgj\nEp+5h8aeoZ/547QPQAPp9eruPiY5T+WF/WkZEp+FH2MnKeN5zpe0per9+ohYX0IlxhUR1wDXSLoa\nuBL4GFn3yRMjYp+kNwFflXTaaI3ZI9oieJrZ5BeQ8vTQ3ohYXmf7buCEqveL8nVF0vQUyAtwC9n0\nxB+LiH6gHyAi7pf0BHAKsGWUfEALuyqZWecZzs8+x1sKuA9YKmmJpF7gImBjTZqNwCV5q/vZwP78\nIZwx80paWpV/NfBovv7YvKEJSSeTNULtqFdBn3maWSkiVNpz6xExJOlK4C6gG9gQEdslrc23ryM7\nazwf6AMOAJfXy5vv+jpJpwIV4ClgpFX97cAnJA3m29ZGxPP16ujgaWalyBqMyns8MyI2kQXI6nXr\nql4HcEXRvPn63xgj/R1kfc8Lc/A0s5J4DiMzs2RZg9HU6YXo4GlmpfGQdGZmiUaeMJoqHDzNrDSe\nAM7MLFEEDFYcPM3MkmSX7Q6eZmbJEp5tb3ttETyjC4Zmp40cNe2V9C/x4HFpeZIHxQCGZjU8AlaS\nnpfSj793f3rdUvtED/em16vnQPoHHdPSz4C6B9LLqUxP/F9o9szkMroq6fVSd+IXU0LMc1clM7OG\n+LLdzKwhnTI/UREOnmZWiqy13VMPN10+/NMWYHdEXNCqephZOdxJfuJ8AHgEmNvCOphZiabSZXur\nph5eBPwy8LlWlG9m5RtpbS9pArhJr1Vnnv8N+AhwxFgJJK0hm06UaUceNUHVMrPDMZVa21sxb/sF\nwLMRcX+9dBGxPiKWR8Ty7tkNzExmZhMqQgxFV6GlE7TizPPngQvzudpnAHMlfSki3tOCuphZiTrl\nkryICf8TEBFXR8SiiFhMNjHTtxw4zdpf2fc8Ja2U9JikPklXjbJdkm7It2+TdOZ4eSX9UZ52q6S7\nJR1fte3qPP1jks4br36dcf5sZpNCWcEz78p4I7AKWAZcLGlZTbJVZLNcLiVrH7mpQN7rI+L0iDgD\n+Brwh3meZWQnc6cBK4G/HJlNcywtDZ4R8U/u42nWGUb6eZZ05rkC6IuIHRExANxGNlVwtdXAzZHZ\nDMyTtKBe3oh4sSr/bLIT5pF93RYR/RHxQ7IZOVfUq2BbPGEU3TA4N21whMFGeo/OHUpK3vVcb3IR\nM59Nvyf06rENDNihRgb5SK9bJfEXpOHkInj16PSfaddg+vEfsTPt+wcYnJM20EfPS+m/men9A8l5\nmD49Lf0r5ZxHJfTznC9pS9X79RGxvur9QmBn1ftdwFk1+xgtzcLx8kq6FrgE2A+cU7WvzaPsa0xt\nETzNbPKLgKHigyHvjYjlzazPWCLiGuAaSVcDVwIfa2Q/vudpZqUp8bJ9N3BC1ftF+boiaYrkBbgF\nGJnHvWie/8fB08xKUfI9z/uApZKWSOola8zZWJNmI3BJ3up+NrA/IvbUyytpaVX+1cCjVfu6SNJ0\nSUvIGqG+V6+Cvmw3s9JESf08I2JI0pXAXUA3sCEitktam29fB2wCzidr3DkAXF4vb77r6ySdClSA\np4CR/W2XdDvwMDAEXBERde/QO3iaWWnKHBgkIjaRBcjqdeuqXgdwRdG8+frfGCX5yLZrgWuL1s/B\n08xKETG1njBy8DSzkohhTz1sZpaurHue7cDB08xK4dkzzcwaEdl9z6nCwdPMSjOVpuFw8DSzUoQb\njCYhkXV1TRDd6dcP6krL08DYG/QflZ6p0pueZ2hO2kAqAMOz0n/4PS+l5dl/SvqxzO1LzkJXA2Np\nVHrSz5pm7E0rKLoaODPr7UnPE6nffznX275sNzNrgFvbzcwSRUyt4NmqqYfnSfqypEclPSLpLa2o\nh5mVy1MPN99fAP8QEf82H/VkVovqYWYl8j3PJpJ0JPB24DKAfJj8Bm7vm9lkEojKFGptb8WRLgGe\nA/6npH+V9DlJPzUxu6Q1krZI2jL88ssTX0szSxYFl07QiuA5DTgTuCki3gi8AvzUtKIRsT4ilkfE\n8u45cya6jmaWKm8wKrJ0glYEz13Aroi4N3//ZbJgambtbgqdek548IyIp4Gd+WjOAOeSjd5sZm3O\nZ57N937gFknbgDOAP25RPcysJAFUKiq0FCFppaTHJPVJ+qlbe/ncRTfk27dJOnO8vJKuz7tIbpN0\np6R5+frFkg5K2pov62rLq9WSrkoRsRVoybSjZtYkAZR0VimpG7gReBfZrb77JG2MiOqr1FVkE7Ut\nJZuX/SbgrHHy3gNcnc9z9CngauD38/09ERFnFK3j1OlXYGZNF1FsKWAF0BcRO/LujLeRzXZZbTVw\nc2Q2A/MkLaiXNyLujoihPP9msimGG9Iej2d2BcwZTMrSM31o/EQ1jpj9alL6/jn9yWUMDiaOcAJU\n9s1IzkNP+l354Wl1JwscPc+ctDwzd6YPcjE4NzkL055NP/4Dx6Z/N9E1PSn99J+k/Y4BKrN6k/N0\ndaceS0n3IYt/7PMlbal6vz4i1le9XwjsrHq/i+zsknHSLCyYF+C9wN9UvV8iaSuwH/hoRHyn3gG0\nR/A0szaQ1Bi0NyJadutO0jVkUwzfkq/aA5wYEfskvQn4qqTTIuLFsfbh4Glm5SmvG9Ju4ISq94vy\ndUXS9NTLK+ky4ALg3Hz6YiKiH+jPX98v6QngFKD67PgQvudpZuUIiIoKLQXcByyVtCQf/+IiYGNN\nmo3AJXmr+9nA/ojYUy+vpJXAR4ALI+LAyI4kHZs3NCHpZLJGqB31KugzTzMrUTn3TvPW8CuBu8iG\nQt8QEdslrc23rwM2AecDfcAB4PJ6efNdfxaYDtwjCWBzRKwlG2/jE5IGgQqwNiKer1dHB08zK0+J\nTw9FxCayAFm9bl3V6wCuKJo3X/8zY6S/A7gjpX4OnmZWng559LIIB08zK0eJneTbgYOnmZXGgyGb\nmTWi4HPrncDB08xK08h03O3KwdPMytFBY3UW4eBpZiWRG4wmm5nTBzh9ce2TWfUdOyN93qOTZu5L\nSr91f/qALPsHZibnebr3iOQ8/f3pX21lOH1gjK7utIFBhp5v4Cen9P8hD85Pz9OVPi4KlWlpD+kN\nzUwf5GNuX/pgIi3jM08zswZUWl2BiePgaWblmGL9PFsyMIik35W0XdJDkm6V1MCAlWY22SiKLZ1g\nwoOnpIXA7wDLI+INZA/uXzTR9TCzJvDsmf+fpPdLOqrkcqcBMyVNA2YBPy55/2ZmTVXkzPM4sgmU\nbs9npDusmxoRsRv4U+BHZKM374+Iu2vTSVojaYukLQMvHDycIs1sgviyvUpEfJRsYNDPA5cBj0v6\nY0mva6TA/Cx2NbAEOB6YLek9o5S7PiKWR8Ty3nnp3XvMbIIF2eOZRZYOUOieZz5u3tP5MgQcBXxZ\n0qcbKPOXgB9GxHMRMQh8BXhrA/sxs8lmCt3zHLerkqQPAJcAe4HPAb8XEYOSuoDHyYa0T/Ej4GxJ\ns4CDwLnUmSfEzNpHp1ySF1Gkn+fRwK9HxFPVKyOiIumC1AIj4l5JXwYeIDuL/Vdgff1cZtYWplDw\nLHLP82O1gbNq2yONFJrv899ExBsi4rfzmevMrN2VeNmeN1A/JqlP0lWjbJekG/Lt2ySdOV5eSddL\nejRPf6ekeVXbrs7TPybpvPHq1xZPGM3qHuCN83aOn7DKYy8fl1xOV+Kfzb0H5ySXMX9m+jP3e2Ju\ncp4zFqWNBQCwZcdJyXm6uhJv/i95JbmMoSdnJ+fpeTm9UUINPNvenfhnf+beoeQyIvH5eQD1Jj5D\nn/o9jlZmiS3p+UyWNwLvAnaR9fjZGBEPVyVbRdaYvRQ4C7gJOGucvPcAV+eTxH0KuBr4fUnLyPqb\nn0bWkP0NSadExJi/Ck89bGblKa+1fQXQFxE7ImIAuI2sl0611cDNkdkMzJO0oF7eiLg7Ikb+gm0m\nm9N9ZF+3RUR/RPyQbEbOFfUq6OBpZqVJ6Oc5f6Qfd76sqdnVQqD6cnNXvq5ImiJ5Ad4L/H1CeYdo\ni8t2M2sTxS/b90bE8ibWpC5J15A1WN/S6D4cPM2sHOU+PbQbOKHq/aJ8XZE0PfXySroMuAA4N+/D\nXrS8Q/iy3czKU15r+33AUklLJPWSNeZsrEmzEbgkb3U/m+xR7z318kpaSdY3/cKIOFCzr4skTZe0\nhKwR6nv1KugzTzMrjUoaDDlvDb8SuIts5LUNEbFd0tp8+zpgE3A+WePOAeDyennzXX8WmA7ckw/T\nsTki1ub7vh14mOxy/op6Le3g4Glmk1REbCILkNXr1lW9DuCKonnz9T9Tp7xrgWuL1s/B08zKM4We\nMHLwNLNydNBwc0U4eJpZeRw8zcwa4OBpZpZGlNfa3g7aIngORxcvDqVNsPmWeTuSy9kzcGRS+jcd\n86PkMp4bSB9M5C0Ln0zO0/fi/OQ8vTMGk/P0P582yr+G0gegiCPTR+zQYHdynkZ0JX5kA3PT69V9\nMP34Y1bihLRdJXT59j1PM7MGOXiamTXAwdPMLN1Uumxv2rPtkjZIelbSQ1XrjpZ0j6TH83/Lng/e\nzFppCk0A18yBQb4ArKxZdxXwzYhYCnwzf29mnSCy1vYiSydoWvCMiG8Dz9esXg18MX/9ReBXm1W+\nmbXAFDrznOh7nsflQ0ZBNgf8mBMN5SNLrwE44rWzJqBqZna4fM9zAuQjooz5UUfE+ohYHhHLZx41\nfQJrZmYNm0JnnhMdPJ/JJ2gi//fZCS7fzJqlaOB08GzIRuDS/PWlwN9OcPlm1iQiaQK4ttfMrkq3\nAt8FTpW0S9L7gOuAd0l6HPil/L2ZdQgHzxJExMURsSAieiJiUUR8PiL2RcS5EbE0In4pImpb482s\nnZV42S5ppaTHJPVJ+qlujfncRTfk27dJOnO8vJJ+U9J2SRVJy6vWL5Z0UNLWfFlXW16ttnjCqLdr\nmIXTX0jKs2zGruRynhmcm5T+qJ4D4yeq8YtzH03Os/nlMWcOGNOi1/wkOc+90xYn59k7e3ZS+hde\nShtIBCCeSisDoNKTnIVpB9IHLekaSjuNGpqRXoaG0ztGqn8gLUOlpNPBknYjqRu4EXgX2Rzq90na\nGBEPVyVbRTZR21LgLOAm4Kxx8j4E/Drw30cp9omIOKNoHdsieJpZGyj3knwF0BcROwAk3UbWT7w6\neK4Gbs577myWNC9viF48Vt6IeCRfd9gV9NTDZlae4pft8yVtqVrW1OxpIbCz6v2ufF2RNEXyjmZJ\nfsn+z5J+YbzEPvM0s9IkPHq5NyKWj59swuwBToyIfZLeBHxV0mkR8eJYGXzmaWalKbG1fTdwQtX7\nRfm6ImmK5D1ERPRHxL789f3AE8Ap9fI4eJpZOcrtJH8fsFTSEkm9wEVk/cSrbQQuyVvdzwb2549/\nF8l7CEnH5g1NSDqZrBGq7nQUvmw3s/KU1WgfMSTpSuAuoBvYEBHbJa3Nt68DNgHnA33AAeDyenkB\nJP0a8BngWODrkrZGxHnA24FPSBoEKsDa8bpSOniaWSlGnjAqS0RsIguQ1evWVb0O4IqiefP1dwJ3\njrL+DuCOlPo5eJpZaVRWf9E24OBpZuXooEE/inDwNLPSdMpz60U4eJpZeRw8zczS+cxzkpnd9Spn\nzepLynNs98Hkck6ZsWf8RFX2DqUNJAKw7eCJyXkW9O5PzvNqpH+1lUh/3vfomWmDoxzo700u48DM\n9IExYlr6/8W9+9M/s+HetM9s5r4GjqUr/XuJnsRjOfxHvfOCS9pPG2iL4GlmbSA6Z2bMIhw8zawU\nZffznOyaOZL8BknPSnqoat31kh7NBy69U9K8ZpVvZi0QUWzpAM18tv0LwMqadfcAb4iI04EfAFc3\nsXwzm2CehqMEEfFt4PmadXdHxFD+djPZaCdm1gmm2OyZrbzn+V7gb8bamA+OugbguON9a9asHUyl\nBqOWDEkn6RpgCLhlrDQRsT4ilkfE8nnHeOQ8s3agSrGlE0z4KZ2ky4ALgHPzUVHMrBMEHdMYVMSE\nBk9JK4GPAL8YEelTT5rZpNYpjUFFNLOr0q3Ad4FTJe2S9D7gs8ARwD1F50Y2szbiBqPDFxEXj7L6\n880qz8xaa6p1kncztpmVI8KDIU82r1Z6eHzgtUl5hnufTS7ntdPSBuDYM3hUchlvm/2D5Dz3HVyS\nnOef99ad+G9UJx+xLznPweGepPRP7Ts6uYzpC9Jvjw/+aHZynkYGx4juxPQNlNFWAanEquZtJH9B\nNg/R5yLiuprtyrefTzaH0WUR8UC9vJJ+E/g48HpgRURsqdrf1cD7gGHgdyLirnr1cx8gMytNWU8Y\n5TNZ3gisApYBF0taVpNsFdksl0vJ+oTfVCDvQ8CvA9+uKW8Z2Sybp5E9GfmXI7NpjsXB08zKEUAl\nii3jWwH0RcSOiBgAbgNW16RZDdwcmc3APEkL6uWNiEci4rFRylsN3JbP3/5Dshk5V9SroIOnmZWn\neGv7fElbqpY1NXtaCOyser8rX1ckTZG8tZLztMU9TzNrDwmt7XsjYnkTq9J0Dp5mVpoSG7d2AydU\nvV+UryuSpqdA3kbKO4Qv282sHOWOqnQfsFTSEkm9ZI05G2vSbAQuUeZsYH9E7CmYt9ZG4CJJ0yUt\nIWuE+l69DD7zNLNSZJ3kyznzjIghSVcCd5F1N9oQEdslrc23rwM2kXVT6iPrqnR5vbwAkn4N+Axw\nLPB1SVsj4rx837cDD5MNWnRFRAzXq6ODp5mVp8QRkyJiE1mArF63rup1AFcUzZuvvxO4c4w81wLX\nFq2fg6eZlaasM8924OBpZuXooEE/inDwNLOS+Nl2M7PG+LJ9cpnZNcjPTt+VlOdN03uTy7n5xSOT\n0p8z5+HkMnYOHpOc56Tevcl5ZnSnDyby8lD6Z/bMgblJ6Xt6hsZPVOOln8xKzsOs9JaLeD69595A\n2k+Gg6+ml3FE30ByHroSy1EDI5bUis6ZYqOItgieZtYmfOZpZtaAqRM7mzoNxwZJz0p6aJRtH5IU\nkuY3q3wzm3iqVAotnaCZj2d+gWxcvENIOgF4N/CjJpZtZhMtyDrJF1k6QNOCZ0R8G3h+lE1/TjaD\n5hQ6wTfrfCJQFFs6wURPPbwa2B0RD2qc1r18fL81AK9dmDjXgZm1RocExiImLHhKmgX8Adkl+7gi\nYj2wHuD1p0+fOt+IWTubQsFzIoekex2wBHhQ0pNk4+U9ICltZjczm5ym2D3PCTvzjIjvA68ZeZ8H\n0OURkd4D3MwmpU5pSS+imV2VbgW+C5wqaZek9zWrLDObDCK7bC+ydICmnXlGxMXjbF/crLLNrAWC\njgmMRbTFE0azBGf0plX16wdmJJdzYs9oPavGdnx3f3IZjw/0JOeZ1/1Kcp5pXemXTztfPio5zysD\nac/DVyoNXOwMpOeZ9lJ6D40Gvk66Eh/Vn7kv/XsZnpU+5kD3cGIQK+PZduiY+5lFeA4jMytNmf08\nJa2U9JikPklXjbJdkm7It2+TdOZ4eSUdLekeSY/n/x6Vr18s6aCkrfmyrra8Wg6eZlaeku55SuoG\nbgRWAcuAiyUtq0m2imyitqVkfcJvKpD3KuCbEbEU+Gb+fsQTEXFGvqwdr44OnmZWjggYrhRbxrcC\n6IuIHRExANwGrK5Jsxq4OTKbgXmSFoyTdzXwxfz1F4FfbfRwHTzNrDzFzzznS9pStayp2dNCYGfV\n+135uiK4nFQVAAAHl0lEQVRp6uU9Lp+eGOBp4LiqdEvyS/Z/lvQL4x1qWzQYmVmbKN7avjciljez\nKuOJiJA0UuE9wIkRsU/Sm4CvSjotIl4cK7/PPM2sHAFUotgyvt3ACVXvF+XriqSpl/eZ/NKe/N9n\nASKiPyL25a/vB54ATqlXQQdPMytJQFSKLeO7D1gqaYmkXuAiYGNNmo3AJXmr+9nA/vySvF7ejcCl\n+etLgb8FkHRs3tCEpJPJGqF21KugL9vNrBxB0cag8XcVMSTpSuAuoBvYEBHbJa3Nt68DNgHnA33A\nAeDyennzXV8H3J4/8fgU8Fv5+rcDn5A0SNZbdW1E1O347eBpZuUp8QmjiNhEFiCr162reh3AFUXz\n5uv3AeeOsv4O4I6U+jl4mll5/HimmVmqzhn0owgHTzMrRwBTaEi6tgieQnQrrWPAu2emD6bxk8qr\nSen/6WBtn93xdTcwcsK/HlicnOfUOc8k53lxIH0wldk9A0npH963ILkM9U9Mp5BXThxOznPkD9IG\nIBnuTR+AozIjfZCTafsTf2dlnTH6zNPMLFWU1treDhw8zawcAVGsD2dHaOZI8hskPSvpoZr175f0\nqKTtkj7drPLNrAXKe8Jo0mvmmecXgM8CN4+skHQO2agmPxcR/ZJeM0ZeM2tHvud5+CLi25IW16z+\nj8B1EdGfp3m2WeWb2QSLmFKt7RP9bPspwC9Iujcf9unNYyWUtGZkuKrn9qW3gppZC3gCuKaWdzRw\nNvBmsmdMT84fszpERKwH1gMs/7kZnfFpm3W0IIanzonORAfPXcBX8mD5PUkVYD7w3ATXw8zKNjIk\n3RQx0ZftXwXOAZB0CtAL7J3gOphZs5Q3JN2k17QzT0m3Au8gG25/F/AxYAOwIe++NABcOtolu5m1\nnwBiCp15NrO1/eIxNr2nWWWaWQtFdMxZZRF+wsjMSjOVGozUDlfNkp4jG/W51nxae8/U5bv8Tin/\npIg49nB2IOkfyOpUxN6IWHk45bVaWwTPsUja0soZ+Fy+y5/K5U91ngDOzKwBDp5mZg1o9+C53uW7\nfJdvrdDW9zzNzFql3c88zcxawsHTzKwBbRE8Ja2U9JikPklXjbJdkm7It2+TdGaJZZ8g6R8lPZyP\nfv+BUdK8Q9J+SVvz5Q/LKj/f/5OSvp/ve8so25t5/KdWHddWSS9K+mBNmlKPf7RZCCQdLekeSY/n\n/x41Rt66v5XDKP/6fAaEbZLulDRvjLx1v6vDKP/jknZXfcbnj5H3sI/fCoqISb0A3cATwMlkA4k8\nCCyrSXM+8PeAyIa7u7fE8hcAZ+avjwB+MEr57wC+1sTP4Elgfp3tTTv+Ub6Lp8k6VDft+IG3A2cC\nD1Wt+zRwVf76KuBTjfxWDqP8dwPT8tefGq38It/VYZT/ceDDBb6fwz5+L8WWdjjzXAH0RcSOiBgA\nbiObyqPaauDmyGwG5klKn+N2FBGxJyIeyF+/BDwCpM853FxNO/4a5wJPRMRoT3uVJiK+DTxfs3o1\n8MX89ReBXx0la5HfSkPlR8TdETGUv90MLErd7+GUX1Apx2/FtEPwXAjsrHq/i58OXkXSHLZ8WpE3\nAveOsvmt+SXd30s6reSiA/iGpPslrRll+4QcP3ARcOsY25p5/ADHRcSe/PXTwHGjpJmoz+G9ZGf6\noxnvuzoc788/4w1j3LaYqOM32iN4TgqS5gB3AB+MiBdrNj8AnBgRpwOfIRu3tExvi4gzgFXAFZLe\nXvL+xyWpF7gQ+F+jbG728R8ismvUlvSxk3QNMATcMkaSZn1XN5Fdjp8B7AH+a0n7tQa1Q/DcDZxQ\n9X5Rvi41TcMk9ZAFzlsi4iu12yPixYh4OX+9CeiRVHSAhHFFxO7832eBO8kuz6o19fhzq4AHIuKZ\nUerX1OPPPTNyKyL/d7TJA5v9O7gMuAD493kA/ykFvquGRMQzETEc2cTo/2OM/U7E78By7RA87wOW\nSlqSn/1cBGysSbMRuCRvdT4b2F91iXdYJAn4PPBIRPzZGGlem6dD0gqyz3VfSeXPlnTEyGuyhouH\napI17firXMwYl+zNPP4qG4FL89eXAn87Spoiv5WGSFoJfAS4MCIOjJGmyHfVaPnV97B/bYz9Nu34\nbRStbrEqspC1Jv+ArCXxmnzdWmBt/lrAjfn27wPLSyz7bWSXiNuArflyfk35VwLbyVo3NwNvLbH8\nk/P9PpiXMaHHn+9/NlkwPLJqXdOOnyxI7wEGye7bvQ84Bvgm8DjwDeDoPO3xwKZ6v5WSyu8ju584\n8htYV1v+WN9VSeX/Vf7dbiMLiAuadfxeii1+PNPMrAHtcNluZjbpOHiamTXAwdPMrAEOnmZmDXDw\nNDNrgIOnmVkDHDzNzBrg4GmlkfTmfOCKGfnTNtslvaHV9TJrBneSt1JJ+iQwA5gJ7IqIP2lxlcya\nwsHTSpU/U30f8CrZY5rDLa6SWVP4st3Kdgwwh2zU/RktrotZ0/jM00olaSPZCOZLyAavuLLFVTJr\nimmtroB1DkmXAIMR8deSuoF/kfTOiPhWq+tmVjafeZqZNcD3PM3MGuDgaWbWAAdPM7MGOHiamTXA\nwdPMrAEOnmZmDXDwNDNrwP8FKaipC7UCf1sAAAAASUVORK5CYII=\n",
       "text/plain": [
-       "<matplotlib.figure.Figure at 0x7f7d7de87e10>"
+       "<matplotlib.figure.Figure at 0x7f6f020c1c88>"
       ]
      },
      "metadata": {},
@@ -1120,9 +1091,7 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1150,14 +1119,25 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
        "<div>\n",
+       "<style>\n",
+       "    .dataframe thead tr:only-child th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "</style>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -1175,144 +1155,144 @@
        "      <td>10000</td>\n",
        "      <td>U235</td>\n",
        "      <td>scatter-Y0,0</td>\n",
-       "      <td>3.87e-02</td>\n",
-       "      <td>8.61e-04</td>\n",
+       "      <td>3.86e-02</td>\n",
+       "      <td>6.85e-04</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>10000</td>\n",
        "      <td>U235</td>\n",
        "      <td>scatter-Y1,-1</td>\n",
-       "      <td>6.88e-04</td>\n",
-       "      <td>3.63e-04</td>\n",
+       "      <td>6.95e-04</td>\n",
+       "      <td>3.15e-04</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>10000</td>\n",
        "      <td>U235</td>\n",
        "      <td>scatter-Y1,0</td>\n",
-       "      <td>-3.38e-04</td>\n",
-       "      <td>4.37e-04</td>\n",
+       "      <td>-1.06e-04</td>\n",
+       "      <td>3.79e-04</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>10000</td>\n",
        "      <td>U235</td>\n",
        "      <td>scatter-Y1,1</td>\n",
-       "      <td>-4.27e-04</td>\n",
-       "      <td>3.74e-04</td>\n",
+       "      <td>-3.63e-04</td>\n",
+       "      <td>3.18e-04</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>10000</td>\n",
        "      <td>U235</td>\n",
        "      <td>scatter-Y2,-2</td>\n",
-       "      <td>1.88e-04</td>\n",
-       "      <td>1.86e-04</td>\n",
+       "      <td>1.20e-04</td>\n",
+       "      <td>1.59e-04</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
        "      <td>10000</td>\n",
        "      <td>U235</td>\n",
        "      <td>scatter-Y2,-1</td>\n",
-       "      <td>8.96e-05</td>\n",
-       "      <td>2.02e-04</td>\n",
+       "      <td>3.93e-05</td>\n",
+       "      <td>1.86e-04</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
        "      <td>10000</td>\n",
        "      <td>U235</td>\n",
        "      <td>scatter-Y2,0</td>\n",
-       "      <td>4.03e-04</td>\n",
-       "      <td>2.04e-04</td>\n",
+       "      <td>1.81e-04</td>\n",
+       "      <td>1.85e-04</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>7</th>\n",
        "      <td>10000</td>\n",
        "      <td>U235</td>\n",
        "      <td>scatter-Y2,1</td>\n",
-       "      <td>1.48e-04</td>\n",
-       "      <td>2.24e-04</td>\n",
+       "      <td>1.24e-04</td>\n",
+       "      <td>1.81e-04</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>8</th>\n",
        "      <td>10000</td>\n",
        "      <td>U235</td>\n",
        "      <td>scatter-Y2,2</td>\n",
-       "      <td>1.11e-04</td>\n",
-       "      <td>2.01e-04</td>\n",
+       "      <td>2.06e-04</td>\n",
+       "      <td>2.26e-04</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>9</th>\n",
        "      <td>10000</td>\n",
        "      <td>U238</td>\n",
        "      <td>scatter-Y0,0</td>\n",
-       "      <td>2.34e+00</td>\n",
-       "      <td>1.08e-02</td>\n",
+       "      <td>2.33e+00</td>\n",
+       "      <td>1.10e-02</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>10</th>\n",
        "      <td>10000</td>\n",
        "      <td>U238</td>\n",
        "      <td>scatter-Y1,-1</td>\n",
-       "      <td>2.93e-02</td>\n",
-       "      <td>2.81e-03</td>\n",
+       "      <td>2.90e-02</td>\n",
+       "      <td>2.33e-03</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>11</th>\n",
        "      <td>10000</td>\n",
        "      <td>U238</td>\n",
        "      <td>scatter-Y1,0</td>\n",
-       "      <td>4.25e-03</td>\n",
-       "      <td>1.83e-03</td>\n",
+       "      <td>3.45e-03</td>\n",
+       "      <td>2.38e-03</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>12</th>\n",
        "      <td>10000</td>\n",
        "      <td>U238</td>\n",
        "      <td>scatter-Y1,1</td>\n",
-       "      <td>-2.60e-02</td>\n",
-       "      <td>3.28e-03</td>\n",
+       "      <td>-2.72e-02</td>\n",
+       "      <td>2.76e-03</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>13</th>\n",
        "      <td>10000</td>\n",
        "      <td>U238</td>\n",
        "      <td>scatter-Y2,-2</td>\n",
-       "      <td>-1.10e-03</td>\n",
-       "      <td>1.58e-03</td>\n",
+       "      <td>-2.02e-03</td>\n",
+       "      <td>1.44e-03</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>14</th>\n",
        "      <td>10000</td>\n",
        "      <td>U238</td>\n",
        "      <td>scatter-Y2,-1</td>\n",
-       "      <td>-4.81e-04</td>\n",
-       "      <td>1.67e-03</td>\n",
+       "      <td>8.07e-06</td>\n",
+       "      <td>1.49e-03</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>15</th>\n",
        "      <td>10000</td>\n",
        "      <td>U238</td>\n",
        "      <td>scatter-Y2,0</td>\n",
-       "      <td>-7.95e-04</td>\n",
-       "      <td>1.53e-03</td>\n",
+       "      <td>-3.74e-07</td>\n",
+       "      <td>1.79e-03</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>16</th>\n",
        "      <td>10000</td>\n",
        "      <td>U238</td>\n",
        "      <td>scatter-Y2,1</td>\n",
-       "      <td>1.06e-03</td>\n",
-       "      <td>1.96e-03</td>\n",
+       "      <td>6.54e-04</td>\n",
+       "      <td>1.49e-03</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>17</th>\n",
        "      <td>10000</td>\n",
        "      <td>U238</td>\n",
        "      <td>scatter-Y2,2</td>\n",
-       "      <td>-7.65e-04</td>\n",
-       "      <td>1.67e-03</td>\n",
+       "      <td>-1.93e-03</td>\n",
+       "      <td>1.36e-03</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1320,24 +1300,24 @@
       ],
       "text/plain": [
        "     cell nuclide          score      mean  std. dev.\n",
-       "0   10000    U235   scatter-Y0,0  3.87e-02   8.61e-04\n",
-       "1   10000    U235  scatter-Y1,-1  6.88e-04   3.63e-04\n",
-       "2   10000    U235   scatter-Y1,0 -3.38e-04   4.37e-04\n",
-       "3   10000    U235   scatter-Y1,1 -4.27e-04   3.74e-04\n",
-       "4   10000    U235  scatter-Y2,-2  1.88e-04   1.86e-04\n",
-       "5   10000    U235  scatter-Y2,-1  8.96e-05   2.02e-04\n",
-       "6   10000    U235   scatter-Y2,0  4.03e-04   2.04e-04\n",
-       "7   10000    U235   scatter-Y2,1  1.48e-04   2.24e-04\n",
-       "8   10000    U235   scatter-Y2,2  1.11e-04   2.01e-04\n",
-       "9   10000    U238   scatter-Y0,0  2.34e+00   1.08e-02\n",
-       "10  10000    U238  scatter-Y1,-1  2.93e-02   2.81e-03\n",
-       "11  10000    U238   scatter-Y1,0  4.25e-03   1.83e-03\n",
-       "12  10000    U238   scatter-Y1,1 -2.60e-02   3.28e-03\n",
-       "13  10000    U238  scatter-Y2,-2 -1.10e-03   1.58e-03\n",
-       "14  10000    U238  scatter-Y2,-1 -4.81e-04   1.67e-03\n",
-       "15  10000    U238   scatter-Y2,0 -7.95e-04   1.53e-03\n",
-       "16  10000    U238   scatter-Y2,1  1.06e-03   1.96e-03\n",
-       "17  10000    U238   scatter-Y2,2 -7.65e-04   1.67e-03"
+       "0   10000    U235   scatter-Y0,0  3.86e-02   6.85e-04\n",
+       "1   10000    U235  scatter-Y1,-1  6.95e-04   3.15e-04\n",
+       "2   10000    U235   scatter-Y1,0 -1.06e-04   3.79e-04\n",
+       "3   10000    U235   scatter-Y1,1 -3.63e-04   3.18e-04\n",
+       "4   10000    U235  scatter-Y2,-2  1.20e-04   1.59e-04\n",
+       "5   10000    U235  scatter-Y2,-1  3.93e-05   1.86e-04\n",
+       "6   10000    U235   scatter-Y2,0  1.81e-04   1.85e-04\n",
+       "7   10000    U235   scatter-Y2,1  1.24e-04   1.81e-04\n",
+       "8   10000    U235   scatter-Y2,2  2.06e-04   2.26e-04\n",
+       "9   10000    U238   scatter-Y0,0  2.33e+00   1.10e-02\n",
+       "10  10000    U238  scatter-Y1,-1  2.90e-02   2.33e-03\n",
+       "11  10000    U238   scatter-Y1,0  3.45e-03   2.38e-03\n",
+       "12  10000    U238   scatter-Y1,1 -2.72e-02   2.76e-03\n",
+       "13  10000    U238  scatter-Y2,-2 -2.02e-03   1.44e-03\n",
+       "14  10000    U238  scatter-Y2,-1  8.07e-06   1.49e-03\n",
+       "15  10000    U238   scatter-Y2,0 -3.74e-07   1.79e-03\n",
+       "16  10000    U238   scatter-Y2,1  6.54e-04   1.49e-03\n",
+       "17  10000    U238   scatter-Y2,2 -1.93e-03   1.36e-03"
       ]
      },
      "execution_count": 26,
@@ -1363,16 +1343,14 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[[[ 0.0016699   0.01076055]\n",
-      "  [ 0.00020076  0.00086098]]]\n"
+      "[[[ 0.00136183  0.01104314]\n",
+      "  [ 0.00022601  0.00068479]]]\n"
      ]
     }
    ],
@@ -1394,9 +1372,7 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1431,15 +1407,31 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[[[ 0.04126529]]]\n"
+      "[[[ 0.03500496]]\n",
+      "\n",
+      " [[ 0.03004793]]\n",
+      "\n",
+      " [[ 0.02536586]]\n",
+      "\n",
+      " [[ 0.03403647]]\n",
+      "\n",
+      " [[ 0.02498   ]]\n",
+      "\n",
+      " [[ 0.01892844]]\n",
+      "\n",
+      " [[ 0.02662923]]\n",
+      "\n",
+      " [[ 0.02875671]]\n",
+      "\n",
+      " [[ 0.01945598]]\n",
+      "\n",
+      " [[ 0.02612378]]]\n"
      ]
     }
    ],
@@ -1447,7 +1439,7 @@
     "# Get the relative error for the scattering reaction rates in\n",
     "# the first 10 distribcell instances \n",
     "data = tally.get_values(scores=['scatter'], filters=[openmc.DistribcellFilter],\n",
-    "                        filter_bins=[(i,) for i in range(10)], value='rel_err')\n",
+    "                        filter_bins=[tuple(range(10))], value='rel_err')\n",
     "print(data)"
    ]
   },
@@ -1461,14 +1453,25 @@
   {
    "cell_type": "code",
    "execution_count": 30,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
        "<div>\n",
+       "<style>\n",
+       "    .dataframe thead tr:only-child th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "</style>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr>\n",
@@ -1520,8 +1523,8 @@
        "      <td>10002</td>\n",
        "      <td>279</td>\n",
        "      <td>absorption</td>\n",
-       "      <td>7.37e-05</td>\n",
-       "      <td>7.77e-06</td>\n",
+       "      <td>7.77e-05</td>\n",
+       "      <td>7.87e-06</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>559</th>\n",
@@ -1534,8 +1537,8 @@
        "      <td>10002</td>\n",
        "      <td>279</td>\n",
        "      <td>scatter</td>\n",
-       "      <td>1.27e-02</td>\n",
-       "      <td>6.76e-04</td>\n",
+       "      <td>1.28e-02</td>\n",
+       "      <td>5.09e-04</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>560</th>\n",
@@ -1548,8 +1551,8 @@
        "      <td>10002</td>\n",
        "      <td>280</td>\n",
        "      <td>absorption</td>\n",
-       "      <td>9.14e-05</td>\n",
-       "      <td>9.21e-06</td>\n",
+       "      <td>8.92e-05</td>\n",
+       "      <td>7.32e-06</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>561</th>\n",
@@ -1562,8 +1565,8 @@
        "      <td>10002</td>\n",
        "      <td>280</td>\n",
        "      <td>scatter</td>\n",
-       "      <td>1.39e-02</td>\n",
-       "      <td>5.27e-04</td>\n",
+       "      <td>1.37e-02</td>\n",
+       "      <td>4.99e-04</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>562</th>\n",
@@ -1576,8 +1579,8 @@
        "      <td>10002</td>\n",
        "      <td>281</td>\n",
        "      <td>absorption</td>\n",
-       "      <td>8.98e-05</td>\n",
-       "      <td>8.99e-06</td>\n",
+       "      <td>9.50e-05</td>\n",
+       "      <td>7.80e-06</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>563</th>\n",
@@ -1590,8 +1593,8 @@
        "      <td>10002</td>\n",
        "      <td>281</td>\n",
        "      <td>scatter</td>\n",
-       "      <td>1.47e-02</td>\n",
-       "      <td>6.07e-04</td>\n",
+       "      <td>1.49e-02</td>\n",
+       "      <td>4.74e-04</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>564</th>\n",
@@ -1604,8 +1607,8 @@
        "      <td>10002</td>\n",
        "      <td>282</td>\n",
        "      <td>absorption</td>\n",
-       "      <td>1.13e-04</td>\n",
-       "      <td>1.28e-05</td>\n",
+       "      <td>1.15e-04</td>\n",
+       "      <td>1.00e-05</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>565</th>\n",
@@ -1618,8 +1621,8 @@
        "      <td>10002</td>\n",
        "      <td>282</td>\n",
        "      <td>scatter</td>\n",
-       "      <td>1.54e-02</td>\n",
-       "      <td>6.58e-04</td>\n",
+       "      <td>1.58e-02</td>\n",
+       "      <td>6.18e-04</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>566</th>\n",
@@ -1633,7 +1636,7 @@
        "      <td>283</td>\n",
        "      <td>absorption</td>\n",
        "      <td>1.13e-04</td>\n",
-       "      <td>9.64e-06</td>\n",
+       "      <td>1.01e-05</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>567</th>\n",
@@ -1647,7 +1650,7 @@
        "      <td>283</td>\n",
        "      <td>scatter</td>\n",
        "      <td>1.75e-02</td>\n",
-       "      <td>5.84e-04</td>\n",
+       "      <td>5.66e-04</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>568</th>\n",
@@ -1660,8 +1663,8 @@
        "      <td>10002</td>\n",
        "      <td>284</td>\n",
        "      <td>absorption</td>\n",
-       "      <td>1.10e-04</td>\n",
-       "      <td>1.12e-05</td>\n",
+       "      <td>1.08e-04</td>\n",
+       "      <td>9.66e-06</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>569</th>\n",
@@ -1674,8 +1677,8 @@
        "      <td>10002</td>\n",
        "      <td>284</td>\n",
        "      <td>scatter</td>\n",
-       "      <td>1.72e-02</td>\n",
-       "      <td>7.15e-04</td>\n",
+       "      <td>1.73e-02</td>\n",
+       "      <td>5.40e-04</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>570</th>\n",
@@ -1688,8 +1691,8 @@
        "      <td>10002</td>\n",
        "      <td>285</td>\n",
        "      <td>absorption</td>\n",
-       "      <td>1.27e-04</td>\n",
-       "      <td>1.92e-05</td>\n",
+       "      <td>1.16e-04</td>\n",
+       "      <td>1.44e-05</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>571</th>\n",
@@ -1702,8 +1705,8 @@
        "      <td>10002</td>\n",
        "      <td>285</td>\n",
        "      <td>scatter</td>\n",
-       "      <td>1.75e-02</td>\n",
-       "      <td>8.93e-04</td>\n",
+       "      <td>1.70e-02</td>\n",
+       "      <td>6.90e-04</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>572</th>\n",
@@ -1716,8 +1719,8 @@
        "      <td>10002</td>\n",
        "      <td>286</td>\n",
        "      <td>absorption</td>\n",
-       "      <td>1.24e-04</td>\n",
-       "      <td>1.26e-05</td>\n",
+       "      <td>1.16e-04</td>\n",
+       "      <td>1.02e-05</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>573</th>\n",
@@ -1730,8 +1733,8 @@
        "      <td>10002</td>\n",
        "      <td>286</td>\n",
        "      <td>scatter</td>\n",
-       "      <td>1.78e-02</td>\n",
-       "      <td>9.03e-04</td>\n",
+       "      <td>1.77e-02</td>\n",
+       "      <td>6.80e-04</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>574</th>\n",
@@ -1744,8 +1747,8 @@
        "      <td>10002</td>\n",
        "      <td>287</td>\n",
        "      <td>absorption</td>\n",
-       "      <td>1.24e-04</td>\n",
-       "      <td>1.64e-05</td>\n",
+       "      <td>1.20e-04</td>\n",
+       "      <td>1.36e-05</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>575</th>\n",
@@ -1758,8 +1761,8 @@
        "      <td>10002</td>\n",
        "      <td>287</td>\n",
        "      <td>scatter</td>\n",
-       "      <td>1.85e-02</td>\n",
-       "      <td>1.01e-03</td>\n",
+       "      <td>1.80e-02</td>\n",
+       "      <td>7.80e-04</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>576</th>\n",
@@ -1773,7 +1776,7 @@
        "      <td>288</td>\n",
        "      <td>absorption</td>\n",
        "      <td>1.32e-04</td>\n",
-       "      <td>1.37e-05</td>\n",
+       "      <td>1.30e-05</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>577</th>\n",
@@ -1786,8 +1789,8 @@
        "      <td>10002</td>\n",
        "      <td>288</td>\n",
        "      <td>scatter</td>\n",
-       "      <td>1.87e-02</td>\n",
-       "      <td>8.24e-04</td>\n",
+       "      <td>1.86e-02</td>\n",
+       "      <td>7.12e-04</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1821,26 +1824,26 @@
        "        mean std. dev.  \n",
        "                        \n",
        "                        \n",
-       "558 7.37e-05  7.77e-06  \n",
-       "559 1.27e-02  6.76e-04  \n",
-       "560 9.14e-05  9.21e-06  \n",
-       "561 1.39e-02  5.27e-04  \n",
-       "562 8.98e-05  8.99e-06  \n",
-       "563 1.47e-02  6.07e-04  \n",
-       "564 1.13e-04  1.28e-05  \n",
-       "565 1.54e-02  6.58e-04  \n",
-       "566 1.13e-04  9.64e-06  \n",
-       "567 1.75e-02  5.84e-04  \n",
-       "568 1.10e-04  1.12e-05  \n",
-       "569 1.72e-02  7.15e-04  \n",
-       "570 1.27e-04  1.92e-05  \n",
-       "571 1.75e-02  8.93e-04  \n",
-       "572 1.24e-04  1.26e-05  \n",
-       "573 1.78e-02  9.03e-04  \n",
-       "574 1.24e-04  1.64e-05  \n",
-       "575 1.85e-02  1.01e-03  \n",
-       "576 1.32e-04  1.37e-05  \n",
-       "577 1.87e-02  8.24e-04  "
+       "558 7.77e-05  7.87e-06  \n",
+       "559 1.28e-02  5.09e-04  \n",
+       "560 8.92e-05  7.32e-06  \n",
+       "561 1.37e-02  4.99e-04  \n",
+       "562 9.50e-05  7.80e-06  \n",
+       "563 1.49e-02  4.74e-04  \n",
+       "564 1.15e-04  1.00e-05  \n",
+       "565 1.58e-02  6.18e-04  \n",
+       "566 1.13e-04  1.01e-05  \n",
+       "567 1.75e-02  5.66e-04  \n",
+       "568 1.08e-04  9.66e-06  \n",
+       "569 1.73e-02  5.40e-04  \n",
+       "570 1.16e-04  1.44e-05  \n",
+       "571 1.70e-02  6.90e-04  \n",
+       "572 1.16e-04  1.02e-05  \n",
+       "573 1.77e-02  6.80e-04  \n",
+       "574 1.20e-04  1.36e-05  \n",
+       "575 1.80e-02  7.80e-04  \n",
+       "576 1.32e-04  1.30e-05  \n",
+       "577 1.86e-02  7.12e-04  "
       ]
      },
      "execution_count": 30,
@@ -1859,14 +1862,25 @@
   {
    "cell_type": "code",
    "execution_count": 31,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
        "<div>\n",
+       "<style>\n",
+       "    .dataframe thead tr:only-child th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "</style>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr>\n",
@@ -1893,38 +1907,38 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>mean</th>\n",
-       "      <td>4.19e-04</td>\n",
-       "      <td>2.40e-05</td>\n",
+       "      <td>4.17e-04</td>\n",
+       "      <td>2.05e-05</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>std</th>\n",
        "      <td>2.42e-04</td>\n",
-       "      <td>1.03e-05</td>\n",
+       "      <td>8.32e-06</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>min</th>\n",
-       "      <td>2.31e-05</td>\n",
-       "      <td>4.39e-06</td>\n",
+       "      <td>2.27e-05</td>\n",
+       "      <td>4.04e-06</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>25%</th>\n",
-       "      <td>2.03e-04</td>\n",
-       "      <td>1.64e-05</td>\n",
+       "      <td>2.01e-04</td>\n",
+       "      <td>1.40e-05</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>50%</th>\n",
-       "      <td>4.01e-04</td>\n",
-       "      <td>2.39e-05</td>\n",
+       "      <td>4.00e-04</td>\n",
+       "      <td>2.05e-05</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>75%</th>\n",
-       "      <td>6.17e-04</td>\n",
-       "      <td>3.02e-05</td>\n",
+       "      <td>6.08e-04</td>\n",
+       "      <td>2.60e-05</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>max</th>\n",
-       "      <td>9.28e-04</td>\n",
-       "      <td>5.88e-05</td>\n",
+       "      <td>9.38e-04</td>\n",
+       "      <td>4.27e-05</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1935,13 +1949,13 @@
        "                        \n",
        "                        \n",
        "count 2.89e+02  2.89e+02\n",
-       "mean  4.19e-04  2.40e-05\n",
-       "std   2.42e-04  1.03e-05\n",
-       "min   2.31e-05  4.39e-06\n",
-       "25%   2.03e-04  1.64e-05\n",
-       "50%   4.01e-04  2.39e-05\n",
-       "75%   6.17e-04  3.02e-05\n",
-       "max   9.28e-04  5.88e-05"
+       "mean  4.17e-04  2.05e-05\n",
+       "std   2.42e-04  8.32e-06\n",
+       "min   2.27e-05  4.04e-06\n",
+       "25%   2.01e-04  1.40e-05\n",
+       "50%   4.00e-04  2.05e-05\n",
+       "75%   6.08e-04  2.60e-05\n",
+       "max   9.38e-04  4.27e-05"
       ]
      },
      "execution_count": 31,
@@ -1968,15 +1982,13 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Mann-Whitney Test p-value: 0.7108210033985298\n"
+      "Mann-Whitney Test p-value: 0.3933685843661936\n"
      ]
     }
    ],
@@ -2006,15 +2018,13 @@
   {
    "cell_type": "code",
    "execution_count": 33,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Mann-Whitney Test p-value: 7.454144155212731e-42\n"
+      "Mann-Whitney Test p-value: 7.927841393301949e-42\n"
      ]
     }
    ],
@@ -2042,25 +2052,24 @@
   {
    "cell_type": "code",
    "execution_count": 34,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/usr/local/lib/python3.5/dist-packages/ipykernel/__main__.py:4: SettingWithCopyWarning: \n",
+      "/home/johnny/miniconda3/lib/python3.6/site-packages/ipykernel_launcher.py:4: SettingWithCopyWarning: \n",
       "A value is trying to be set on a copy of a slice from a DataFrame.\n",
       "Try using .loc[row_indexer,col_indexer] = value instead\n",
       "\n",
-      "See the caveats in the documentation: http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy\n"
+      "See the caveats in the documentation: http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy\n",
+      "  after removing the cwd from sys.path.\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<matplotlib.axes._subplots.AxesSubplot at 0x7f7d809ce2e8>"
+       "<matplotlib.axes._subplots.AxesSubplot at 0x7f6eee47c5c0>"
       ]
      },
      "execution_count": 34,
@@ -2069,9 +2078,9 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjkAAAGHCAYAAABSw0P1AAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAAPYQAAD2EBqD+naQAAIABJREFUeJzs3XuYHHWd7/H3d4aLIpAMQYPXVclFoiLMJNwkiYxhB4LK\nrh5lB4ln9SgHAcPGhRU9e5TLrq6LirCKYI6ImGWM4qq7EjIxIBGFkDgR2FVMJwEF3AUlE7MKeGHy\nPX9Udbq6uqqru6d7prvm83qeesJUV1f9qmeY+szvau6OiIiISN50TXYBRERERFpBIUdERERySSFH\nREREckkhR0RERHJJIUdERERySSFHREREckkhR0RERHJJIUdERERySSFHREREckkhR0Q6kpldYmZ7\nJrscItK+FHJEcsTMXm1mN5vZz8zsaTN71MzWmdn5LbzmoJldkLD/+Wb2ETM7skWXdmBSQo6ZfdHM\n9kS235nZVjO71Mz2H8d5P2hmpzezrCJTmWntKpF8MLMTgNuBnwNfAh4DXgwcBxzu7nNadN1/A17p\n7i+P7e8DNgN/6e43tuC6XcA+7v6HZp+7hmt/ETgD+F+AAdOA04E/Bf7Z3Zc1eN7fAF9z93c1q6wi\nU9k+k10AEWma/wP8Gpjv7r+JvmBmh05CeawlJzU7wN2fcvc9wIQHnIhn3H0o8vXnzOwuYNDM3u/u\nv5qsgolIQM1VIvnxcuDH8YAD4O5PxPeZ2Vlmdo+ZPWlmo2a2wcyWRF5/k5l928x+ETbHbDezvw1r\nUIrHfBc4DfiTSNPNg2a2GNhE0KR0Q7h/zMzeEXnvsWa21sx+HZbhjrA2KlrGS8L3HmFmN5nZKHBn\n9LXY8XvM7GozO93M/j0s93+Y2UDC/b/OzH4YNuttM7Ozm9DP5/sE4S5eq3Whmf3AzJ4ws6fC674l\nXnbgAOAvI5/l9ZHXX2Bm15vZY5H7emfCfb0vfK34fd1sZn8xjnsS6ViqyRHJj58Dx5nZK939x9UO\nNLOPAB8BfgD8X4IakWOBfmB9eNhfAr8BPgn8NnztMuAg4APhMX9H0FTzQuCvCB7wvwV+Anw4PP46\nwmAC3BVevx9YA/wQuISgb807gdvN7ER3/2F4fLE9/WtAAfggpRoij7wetRB4M3BNWP7lwM1m9hJ3\n3xVe/2jgVuA/w/vfJ/z3iZRz1upl4b+7YvuXA98CVgH7AX8BfNXM3uDut4bHnAV8AbgH+Hy4b0dY\n3ueF+8eAq8Nyngp8wcwOcverw+PeA1wFfBX4NPAs4EiC7+1XxnFfIp3J3bVp05aDDVhCEFb+SBBe\n/gE4maDfSvS4w4FnCPp+VDvf/gn7PkcQHPaN7Ps34MGEY/sIwss7El7bCtwSvx7BQ31tZN9HwnN8\nOeEcHwHGYvv2AE8DL43se3W4/9zIvn8N72NmZN/Lw89vLH6thGt/EfhvYEa4vRz4a4IQcm/WZwl0\nA/cD34nt/w1wfcL7/x/wKDA9tv8mYLR4fuAbwP2T/bOoTVu7bGquEskJd18PHE9QY3AkcBEwDPzC\nzN4YOfTPCWpDLss43++L/21mB5rZDILmmAOAVzRaTjM7CpgNDJnZjOJGUEN0G7AoXhSC2qBafcfd\nf7b3ze7/ThBIXh5evwt4PfBNd388ctyDBLU7tToQ+FW4bQeuIPh8/ix+YOyznA70ENRu9dZ4rTcT\nhMnu2Ge2DpgeOc+vgReZ2fw67kMkt9RcJZIj7j4C/A8z2wd4DUGgWQF8zcyOcvefEjzs9wAPVDuX\nmc0D/h44CTg4ehmCJqpGzQ7/TRtxtcfMprn77si+h+o4/yMJ+3YRBAuA5wHPJggmcUn70jwNvIEg\nML4I+Jvw3E/HDzSzNxB0DD+KoMaqKLP/j5k9lyDInA3874RDPLwuwMcJAtwmM9tOEIJucve7arsl\nkXxRyBHJIXd/BhgBRsxsG0HzyluBy2t5v5lNA75HUDPwt8CDwO8ImqD+gfENWii+96+B+1KO+W3s\n64rgUMVYyv5mj/Yac/fv7j252TrgpwS1Tn8W2b+QoHbtDuC9wH8RNCm+Cxis4TrFz2sVwdQASe4H\ncPefmtlcgvB1CkEN0Llmdqm7X1rznYnkhEKOSP4VO/E+P/x3B8GDcx7hwzHB6whqPk539x8Ud5rZ\n4QnHpnXUTdu/I/z3N+5+e8oxrfRLgsA2K+G12Qn7auLuj5nZlcCHzewYd98UvvRmgpA2EIZPAMzs\nfyWdJmHfrwj66nTX8nm5+9MEHbW/FtbofQP4P2b2MZ+EOYVEJpP65IjkhJm9LuWl08J/fxr++02C\nh+mHzSytdmOMoOYjOlx8P+DchGOfJLn56snw3+mx/SMEQedCM3tO/E2tntPHg/l11gN/ZmaHRa47\ni6D2Yzz+iSDQXBzZN0bwee/9o9LMXkoweWDck8Q+r7C8XwfeYmavjL8h+nmZ2SGx9z5D0CxpwL51\n3YlIDqgmRyQ//snMDiD4y/2nBEOVXwu8jaC56QYAd99hZn9P0Ax1p5n9C/B7YAHwC3f/PwRDvXcB\nN5rZ1eH5zyK5pmEEeJuZfZJghuPfuvu3CYLMr4FzzOy3BA/we9z9Z2b2boIh5D+2YPbgXxAMQz8J\n2E1yAGimSwhmJ77LzD5H8LvwPODfCfrNNMTdR8P7ea+ZzXX3rcAtwPuBYTO7CZhJEBa3EXQQjxoB\nlpjZCoLh7Q+FNUIXE9Su3WNmKwmG6B9C0HzYDxSDzjoze4xgdN3jBLV15wHfdvcnEZlqJnt4lzZt\n2pqzETy0VwI/JggKTxMM1b4SODTh+P9J0JT1FMG8K7cD/ZHXjyN4WP6WoDPvRwmGqY8BiyLHHQB8\nGdgZvvZg5LU3EASH34evvSPy2pEEzSq/DMvwIDAEvC5yzEfC9x2SUP6PEMw6HN03BlyVcOyDwBdi\n+14X3v/TBHPwvJNghNSTNXzWXwR2p7z2MoKh6NdH9v0lQfB8Kvz+vIPkIfBzgO+Gn/lY7ByHEsyR\n8zOC5rZfEHQsflfkmHeH7y9+pgXgY8CBk/3zqU3bZGxau0pEJGRm3wDmufvcyS6LiIxfR/bJMbPz\nzOyhcDr2jWa2oMqx8yxYlfmhcJr05Rnnvjg87lPNL7mItAsze1bs69nAUoKaEBHJgY7rk2NmZxBM\nM382wdo4Kwjauud4wvo8BFXpOwimOb8y49wLwvOmDWsVkfx40MxuIGjKeilwDkEz0BWTWCYRaaJO\nrMlZAVzn7jd6MLHZOQRtz+9KOtjdf+juH3D3r1JlxWIzO5BgHop3E3SWFJF8u5VgDamrCTrn3kPQ\n12hH1XeJSMfoqJocM9uXYDTBR4v73N3NrDid/Xh8Fvg3d7/dzP7vOM8lIm3O3ZPmqRGRHOmokEMw\nuqCbYGhk1ONAwx0FzewvCIaNar0XERGRnOi0kNN0ZvYi4NPAEnf/Yx3vmwEMUBrOKSIiIrV5FkFf\nuGF339mqi3RayHmCYO6ImbH9M4HHGjxnH/BcYEtk9tduYJGZnQ/s78nj7AeAf27wmiIiIgJvB25q\n1ck7KuS4+x/NbIRgld1/BQiDyesJOg82Yj3w6ti+GwimQv+HlIADQQ0Oq1at4ogjjmjw0p1hxYoV\nXHll1YFpuaD7zBfdZ/5MlXudCvf5wAMPcNZZZ0H4LG2Vjgo5oU8BN4RhpziE/ADCKevN7EbgUXf/\nUPj1vgRTmxvBNPcvNLPXEEw9v8ODqc5/Er2AmT0J7HT3B6qU43cARxxxBL29vU28vfYzbdq03N8j\n6D7zRveZP1PlXqfKfYZa2t2j40KOu381XJDuMoJmqnsJVvf9VXjIi4BnIm95AfAjSmvuXBhuGwjW\nfEm8TLPLLSIiIhOr40IOgLtfA1yT8lp/7OufU+d8QPFziIiISOfpxMkARURERDIp5EimwcHByS7C\nhNB95ovuM3+myr1OlfucCFqFvEFm1guMjIyMTKUOYiIiIuO2ZcsW+vr6APrcfUurrqOaHBEREckl\nhRwRERHJJYUcERERySWFHBEREcklhRwRERHJJYUcERERySWFHBEREcklhRwRERHJJYUcERERySWF\nHBEREcklhRwRERHJJYUcERERySWFHBEREcklhRwRERHJJYUcERERySWFHBEREcklhRwRERHJJYUc\nERERySWFHBEREcklhRwRERHJJYUcERERySWFHBEREcklhRwRERHJJYUcERERySWFHBEREcmljgw5\nZnaemT1kZk+b2UYzW1Dl2HlmdnN4/B4zW55wzAfNbJOZ/beZPW5m3zCzOa29CxEREWmljgs5ZnYG\n8EngI8DRwH3AsJkdmvKWA4AdwAeA/0o5ZiHwT8CxwBJgX2CdmT27iUUXERGRCbTPZBegASuA69z9\nRgAzOwc4DXgX8I/xg939h8APw2M/nnRCd18a/drM/hL4JdAHfL+JZRcREZEJ0lE1OWa2L0HwuK24\nz90dWA8c38RLTQccGG3iOUVERGQCdVTIAQ4FuoHHY/sfBw5rxgXMzIBPA993958045wiIiIy8Tqx\nuarVrgHmAa+t5eAVK1Ywbdq0sn2Dg4MMDg62oGgiIiKdZWhoiKGhobJ9u3fvnpBrd1rIeQIYA2bG\n9s8EHhvvyc3sM8BSYKG7p3VSLnPllVfS29s73kuLiIjkUtIf/lu2bKGvr6/l1+6o5ip3/yMwAry+\nuC9sXno9cNd4zh0GnNOBk9z94fGcS0RERCZfp9XkAHwKuMHMRoBNBKOtDgBuADCzG4FH3f1D4df7\nEjQ/GbAf8EIzew3wW3ffER5zDTAIvAl40syKNUW73f13E3VjIiIi0jwdF3Lc/avhnDiXETRT3QsM\nuPuvwkNeBDwTecsLgB8RjJYCuDDcNgD94b5zwtfviF3uncCNTb4FERERmQAdF3IA3P0agg7CSa/1\nx77+ORnNcu7eUc12IiIikk0PdxEREcklhRwRERHJJYUcERERySWFHBEREcklhRwRERHJJYUcERER\nySWFHBEREcklhRwRERHJJYUcERERySWFHBEREcklhRwRERHJJYUcERERySWFHBEREcklhRwRERHJ\nJYUcERERySWFHBEREcklhRwRERHJJYUcERERySWFHBEREcklhRwRERHJpX0muwCSD4VCgR07djBr\n1ixmz5492cURERFRTY6Mz+joKKecchpz585l6dKlzJkzh1NOOY1du3ZNdtFERGSKU8iRcTnzzGWs\nX78RWAU8DKxi/fqNDA6eNcklExGRqU7NVdKwQqHA8PAagoDz9nDv2xkbc4aHl7Ft2zY1XYmIyKRR\nTY40bMeOHeF/LYq9shiA7du3T2h5REREohRypGGHH354+F/fi72yAYBZs2ZNaHlERESiFHKkYXPm\nzGFgYCnd3csJmqweAVbR3X0BAwNL1VQlIiKTqiNDjpmdZ2YPmdnTZrbRzBZUOXaemd0cHr/HzJaP\n95xSMjS0iiVLjgOWAS8BlrFkyXEMDa2a5JKJiMhU13Edj83sDOCTwNnAJmAFMGxmc9z9iYS3HADs\nAL4KXNmkc0qop6eHtWtvYdu2bWzfvl3z5IiISNvoxJqcFcB17n6ju/8UOAd4CnhX0sHu/kN3/4C7\nfxX4QzPOKZVmz57NqaeeqoAjIiJto6NCjpntC/QBtxX3ubsD64Hj2+WcIiIiMvk6KuQAhwLdwOOx\n/Y8Dh7XROUVERGSSdVrIEREREalJp3U8fgIYA2bG9s8EHpuMc65YsYJp06aV7RscHGRwcLDB4oiI\niOTH0NAQQ0NDZft27949Ide2oPtJ5zCzjcA97n5B+LURLJp0tbtfkfHeh4Ar3f3q8Z7TzHqBkZGR\nEXp7e8d7WyIiIlPGli1b6OvrA+hz9y2tuk6n1eQAfAq4wcxGKA33PgC4AcDMbgQedfcPhV/vC8wD\nDNgPeKGZvQb4rbvvqOWc0hyFQoEdO3ZomLmIiEyIjgs57v5VMzsUuIygSeleYMDdfxUe8iLgmchb\nXgD8CChWWV0YbhuA/hrPKeMwOjrKmWcuCxfzDAwMLGVoaBU9PT2TWDIREcmzjgs5AO5+DXBNymv9\nsa9/Tg0drKudU8bnzDOXsX79RoKlHxYB32P9+uUMDp7F2rW3THLpREQkrzoy5EjnKBQKYQ3OKuDt\n4d63MzbmDA8vY9u2bWq6EhGRltAQcmmpHTuK3Z4WxV5ZDMD27dsntDwiIjJ1KORISx1++OHhf30v\n9soGAGbNmjWh5RERkalDIUdaas6cOQwMLKW7ezlBk9UjwCq6uy9gYGCpmqpERKRlFHKk5YaGVrFk\nyXHAMuAlwDKWLDmOoaFVk1wyERHJM3U8lpbr6elh7dpb2LZtG9u3b9c8OSIiMiEUcmTCzJ49W+FG\nREQmjJqrREREJJcUckRERCSXFHJEREQklxRyREREJJcUckRERCSXFHJEREQklxRyREREJJcUckRE\nRCSXFHJEREQklxRyREREJJcUckRERCSXFHJEREQklxRyREREJJcUckRERCSXFHJEREQklxRyRERE\nJJcUckRERCSXFHJEREQklxRyREREJJcUckRERCSX9pnsAojEFQoFduzYwaxZs5g9e/ZkF0dERDpU\nR9bkmNl5ZvaQmT1tZhvNbEHG8W81swfC4+8zs1Njrz/HzD5jZo+Y2VNm9mMz+9+tvQuJGx0d5ZRT\nTmPu3LksXbqUOXPmcMopp7Fr167JLpqIiHSgjgs5ZnYG8EngI8DRwH3AsJkdmnL8CcBNwErgKOBb\nwDfNbF7ksCuBPwXOBF4BfBr4jJm9oVX3IZXOPHMZ69dvBFYBDwOrWL9+I4ODZ01yyUREpBN1XMgB\nVgDXufuN7v5T4BzgKeBdKccvB25190+5+1Z3/zCwBTg/cszxwJfc/U53f9jdVxKEp2NadxsSVSgU\nGB5ew9jY1cDbgRcDb2ds7CqGh9ewbdu2SS6hiIh0mo4KOWa2L9AH3Fbc5+4OrCcIKkmOD1+PGo4d\nfxfwJjN7QXidk4DZ4XEyAXbs2BH+16LYK4sB2L59+4SWR0REOl9HhRzgUKAbeDy2/3HgsJT3HFbD\n8e8DHgAeNbM/AGuA89z9B+MusdTk8MMPD//re7FXNgAwa9asCS2PiIh0vk4LOa2yHDgWeAPQC/w1\ncI2Z9U9qqaaQOXPmMDCwlO7u5QR9ch4BVtHdfQEDA0s1ykpEROrWaUPInwDGgJmx/TOBx1Le81i1\n483sWcDfA6e7+9rw9f8ws6OBC4HbqxVoxYoVTJs2rWzf4OAgg4OD1e9EKgwNrWJw8CyGh5ft3bdk\nyVKGhlZNYqlERGQ8hoaGGBoaKtu3e/fuCbm2BV1aOoeZbQTucfcLwq+NYCjO1e5+RcLxXwGe7e6n\nR/b9ALjP3c81s4OA3cCp7j4cOeZa4KXufkpKOXqBkZGREXp7e5t4h/nSyJw327ZtY/v27ZonR0Qk\np7Zs2UJfXx9An7tvadV1Oq0mB+BTwA1mNgJsIhhtdQBwA4CZ3Qg86u4fCo+/CrjDzN4P3AIMEnRe\nfg+Au//GzDYAV5jZ74CfA68D3gH81QTdU+6Mjo5y5pnLGB5es3ffwEBQK9PT01P1vbNnz1a4ERGR\nceu4Pjnu/lWCZqTLgB8BRwID7v6r8JAXEelU7O53E8x/czZwL/Bmgqapn0ROewawmaAzyI+BvwE+\n6O6fb+3d5JfmvBERkcnWcc1V7ULNVekKhQJz584lCDhvj7yyClhGoVBQTY2IyBQ2Uc1VHVeTI+3v\n3nvvDf9Lc96IiMjkUciRpvunf/ps+F+a80ZERCZPJ3Y8ljZWKBT4/ve/R7BM2HLACWpwNgDns3Dh\nYjVViYjIhFDIkaYqLc9wI3AxsCzyahfnn3/uxBdKRESmJDVXSVOVlme4n2DEfoFglYwrgD0cffTR\nk1U0ERGZYhRypKkql2d4FrCT7u6PaXkGERGZUAo50nRDQ6tYsuQ4gqaqlwDLWLLkOC3PICIiE0p9\ncqTpenp6WLv2lpYsz9DIMhEiIjI1KeRIyzRzeYbxLBMhIiJTk5qrpCNomQgREamXanKk7RUKhbAG\nJ7pMxNsZG3OGh5exbds2NV2JiEiFptXkmNkXzGxds84nUlSae0fLRIiISO2a2Vz1BPB4E88nAkTn\n3tEyESIiUrumNVe5+weadS6RqOLcO+vXL2dsrLRMRHf3BSxZorl3REQkWV01OWa2r5ntMLMjWlUg\nkSSae0dEROpVV02Ou//RzJ7VqsKIpGnl3DsiIpJPjTRXfRb4gJm9292faXaBRKpp5tw7IiKSb42E\nnAXA64E/NbN/B56Mvujub25GwURERETGo5GQ82vg680uiIiIiEgz1RVyzMyAjwC/cvenW1MkERER\nkfGrd54cA7YDL2pBWWQKKRQK3HrrrWzbtm2yiyIiIjlVV8hx9z3ANmBGa4ojeTc6Osopp5zG3Llz\nWbp0KXPmzOGUU05j165dCj4iItJUjcx4fDFwhZm9qtmFkfxLWmjzO9+5i9mzj0gMPiIiIo1qJOTc\nCBwD3GdmT5vZaHRrcvkkR4oLbY6NXU2w0OaLgbezZ89L2bnzd2iFcRERaaZGRlf9VdNLIVNC8kKb\nBeBetMK4iIg0W90hx92/1IqCSP6VL7RZDDTZK4wr5IiISCMaWoXczA43s78zsyEze16471Qze2Vz\niyd5Ulxos7t7OUHNzSPAf4SvaoVxERFprrpDjpktBv4dOBZ4M3Bg+NJrgEubVzTJo8qFNi8m+DE8\nj1LwWUV39wUMDGiFcRERaVwjNTn/APytu58M/CGy/3bguKaUKoOZnWdmD4Udnzea2YKM499qZg+E\nx99nZqcmHHOEmX3LzH5tZr81s3vMTPMBNVlxoc1CoUBv7wK6u6cDnwP6iK8wfvnll2hIuYiINKyR\nkPNq4BsJ+38JHDq+4mQzszOATxLMvHw0cB8wbGaJ1zazE4CbgJXAUcC3gG+a2bzIMYcDdwI/Iegc\n8mrgcuB3rbuTqc3d2bJlczjS6mzgNoJOyBcC8OSTT3LMMcdoSLmIiDSskZDza+D5CfuPBn4xvuLU\nZAVwnbvf6O4/Bc4BngLelXL8cuBWd/+Uu2919w8DW4DzI8f8HXCLu3/Q3e9394fc/dvu/kQrb2Qq\nSx5pNZvg2wV33TVCs4aUa5JBEZGpqZGQ8xXg42Z2GOBAl5m9FvgEwRw6LWNm+xK0a9xW3OfuDqwH\njk952/Hh61HDxePD9bhOA7aZ2VozezxsAju92eWXkvKRVlFBh+M9ey4hOpfO2NhVDA+vqSuoVJtd\nWURE8q+RkPMh4KcEPUQPJGji+R5wF0GNSCsdCnQDj8f2Pw4clvKewzKOfx7BfXwAWAOcTNAc9y9m\ntrAJZZYEySOtVtHVtZzgx/JtsXeUhpTXKml2ZU0yKCIyddQdctz9D+7+HuDlwBuAs4BXuPsydx9r\ndgEnQPEz+Ka7Xx02V30c+DZBU5i0SOVIq2WccMKRwB7GO6Q8bXblRmqERESkMzUy4zEA7v4IwZ/f\nE+kJYAyYGds/E3gs5T2PZRz/BPAM8EDsmAeA12YVaMWKFUybNq1s3+DgIIODg1lvnfJ6enq4+uor\n+d73/hyAxYsXM3v2bE455TTWr1/O2JgT1OBsoLv7ApYsqX1IeXKfH9AkgyIiE2toaIihoaGyfbt3\n756Qa1vQpaVzmNlG4B53vyD82gjaIq529ysSjv8K8Gx3Pz2y7wfAfe5+buTr7e7+PyPH/AvwlLsn\ntm2YWS8wMjIyQm9vb/NucIoYHR3lzDOXMTy8Zu++gYGlDA2tYteuXRxzzAns3FlqZZwxYyabN9/N\ny172sprOXygUmDt3LuXLRRB+vYxCoaCQIyIySbZs2UJfXx9An7tvadV1Gq7JmUSfAm4wsxFgE8Fo\nqwOAGwDM7EbgUXf/UHj8VcAdZvZ+4BZgkKDz8nsi57wC+IqZ3Ql8FziVoCluccvvZooq7y+zCPge\n69cv39tf5te//iNBX/bnAr/i17/+KO997/msXXtLTecv9vkZb42QiIh0ro4LOe7+1XBOnMsImp3u\nBQbc/VfhIS8iaH4qHn+3mZ0J/H24bQNOd/efRI75ppmdQ9Cp+ipgK/Bmd797Iu5pqin2l0lblDNQ\nXgMzNjaz7gU7h4ZWMTh4VuScsGRJUFskIiL513EhB8DdrwGuSXmtP2Hf14GvZ5zzBsLaIGmtrP4y\n1V6rpy9NcXblbdu2sX37dmbNmqUaHBGRKaQjQ450tuTVyKE4gqraa40s2Dl79myFGxGRKahpIcfM\nHgDmuHt3s84p+ZTVXwZoeV+aQqHAjh07VLsjIpJjzazJ+SAwLfMoEbL7y7SqL03SqK6FCxfzrW99\ng56ennGfX0RE2kfTQo67f7NZ55L8y+ovs3btLaxbt46NGzdy/PHHc/LJJzflukmjuu688zxmzz6C\nbdseUNAREckR9cmRSZXUX6baHDo9PT0NNzWljeoCZ+fOZbzpTX/OnXfeMd5byiyDmslERCZGTSHH\nzH5EsBhnJnfXzHgyLmlz6LzlLW9jv/32Sw0/1YyOjjI4WAw2ySO3vv/9DXUNUa9HVnATEZHmq7Um\nR01RMiGqzaHz3e/+T7q7p5M0gWDWJIFnnrmMe+8trleVPqqrVcs9VJv8sNYJDkVEpD41hRx3v7TV\nBRGBanPovBjYE1lwE6ITCKbVwBQKBTZs2BAJTiuB8wgqJoORW3ABcBRwb+YQ9XqbmyqvX3vZRURk\nfOpehRzAzKab2bvN7GNmdki4r9fMXtjc4kneFQoFbr311r2rgpfPoRN1Y/hv+iSBUaOjo5xyymnM\nnTuXs88+O9z7GeAdwL5EVz6Hl9DV9TNOPHER27dvT1yhPHq+pUuXMmfOHE455TR27dqVeF/J108u\n+1/8xZmp5xERkXFw97o24EjglwTLI/wReHm4/++AG+s9X6duQC/gIyMjLvXbuXOnDwwsdYIqFQd8\nYGCpj46O+sDAUu/uPsThyw73OxwVOW6Vg0e2LzvghUKh7Pylc6xKOAcO08u+njFjZmJZks/3sMMq\n7+4+xAcGlibeX/nxd1Qte1fXtNTziIjk0cjISPH3ba+38lld9xtgPfCP4X//JhJyTgB+1srCttOm\nkDM+1UJ0nHLOAAAgAElEQVRDMegE/wN0OUwLj+t36AnDwcMOX04MGlu3bo2FiqVhqIkHnX38yCOP\n8oULF1cNMJXnqx6wko9fWlF2OCTcn3weEZG8mqiQ00hz1QLguoT9vwAOa+B8MsUUOxeX+te8mKCP\nylUMD6/hiSeeYO3aWxgeHgb2AJ8Nj7sZOJ5oU9OSJcdVTBJY3q+nAKwBXgo8TNAvpvjvc+jq6ubO\nOzeklmXbtm2Za23Fm8qSj18FHE15M9mrw/3J5xERkfFpJOT8Hjg4Yf8c4FcJ+0XK1BoaxsbGYsf1\nALdQHA21cuVK1q69pWIIdnm/nuK17gXKgwx8hnvvHcksS3o/oeT1tJKP7wHeCljs/WcRhLDG1uUS\nEZF0jYScfwU+bGb7hl+7mb0E+DgZK32LQLXOxeWhIf24hwFYvHgxSYprY3V3Lwf+I/JKtVXP08tS\nfr5VwCPAKrq7L2BgoHI9rbTj4a8I/j6I1ibdDSSfR0RExqne9i2C9am+A+wCniH4bf0HgqfCc1rZ\nttZOG+qTMy7lnYvT+9fUelxceb8eq9qnZv78BZnXKD9fcufk9OtHt+QybN68efwfqohIh2jbjsd7\n3wivBc4F/gZY0spCtuOmkDM+tYaGesNFXKFQ8IsvvtihO+zAHO/42+WrV6+u+RqFQsHXrFlTcyfh\n4vErV64Mz/1wLOQ87ICvWbOmpvOJiOTBRIUc8+CBXZOwiWotcI67V04mMoWYWS8wMjIyQm+vVrJo\nVNoCnY0el6RQKDB37lxgHvCTyCvBBICFQoHZs2eP6xq1lyE6ISDh18v2lkFEZCrYsmULfX19AH3u\nvqVV16lrgU53/6OZHdmqwsjUk7RA53iOS1LsI7N+/UbGxq4Angf8ku7uj7FkSakvzHiukSY6Q3JQ\nhuWMjTnF2Za7uy8oK4OIiDRPI6uQrwL+F3Bxk8sisjcUdHd3MzY21rRalaGhVQwOnsXw8EV79y1Z\nsrRi+HmzJC3I2d9/MosX93H77csmpAwiIlNdIyFnH+BdZrYEGAGejL7o7u9vRsFkakkKBcHgvz1N\nWa27p6eHtWtvaWmTVFTSgpwbNixnyZLjKBQKE1IGEZGprpGQ8yqg2H42J/Za7R18RCKSQgEsB17C\n+vUbm7ZadyuapIqitVDVFuSET3Pqqae2pAwiIlJSd8hx95NaURCZuoozIMdDQZCZlzE2dgXDwxc1\nvFp30srh9a4mXk16LVS8+1ppgsFmBq1q99LM+xQR6TSN1OSINFXWDMhBR+H6w0FS+DjppCWYGbff\n/p29+8bbHHb66X/OXXdtAT4BvI2gFuo8ghXPf0SwtMQO4MdA82Y2Trq/4r24e+pr42n2ExHpJI3M\neCzSVFkzIAeL3peHg0KhwK233sq2bekzGZQ3gQUzDH/3u3fy3e9uLttXbA6rJul6o6OjLFz4Or7/\n/e+xZ89vgQuBc4ClwGcIlpI4HJgb7ruIgw/uYffu3VWvVauk+yveS7XXRESmjFZOwpPnDU0G2FRJ\nMxsHk/UdVTb78M6dOzMn7tu6dat//vOfT5hhuL7VxLOuNzCw1Lu6espWLy+tLP5wwmzHRzkc7NBV\n14SGSbJWRq/3PkVEJlLbz3g81TeFnOZKXgahqyLElMJQKVh0dx/ivb0LfNOmTQnn6HcYDR/ya+qe\ndTgIMtMcLnLYsPd6J564KCNkXBH++4lYADrKAe/qmpa5NEU1a9ZUv5d671NEZCJNVMhRnxxpC/Eh\n3vvssw/PPPNMRWfhtFFLW7Ys45hjjsOsuABmcYTW+whW+r4SeDR8z/con3U4eTXxTZs2MTy8FtgD\nXBFuSxkb+yjf//454VFp/Yg+QjCj8l/vLWexIzXAnj3vYXj4Ew13pi5v4qu8l2qvabVzEZkqFHKk\nrVQb4p3dQXkP7p+hfITWbwg6ARc74HaFX1fOOuzu3HrrrXuD1Xvfez5wEPBZyoe1/y5y7bSQ8TRw\nY0o5Ad4IfKLhkValWZzLZ1CGCwj6//xn6n1O5Cgrje4SkUnVymqiVm0Ev70fIniSbAQWZBz/VuCB\n8Pj7gFOrHHstwZ/uyzPOqeaqCZbeD+VzXlppPN5E0+/BwpzF5q3rHPYva9Lq7z/Z+/tPLtuX3Rxl\n4Xl6vLwf0TTv6zsm472Lm9I/ZnR01Ht7F8Sa55aGzXP/tre5r7iNtx9QPe655x7v7Z0/adcXkfam\nPjnp4eIMgj+l3wG8ArgOGAUOTTn+BOCPwPsJhrlcBvwemJdw7J8TjPl9RCGnPSV3UN7f4aCEYFG9\nc+68ea/yQqGQ2M+nq+vAGvq8XBeGivJ+RJs3b04p5zSH5zpcW9aZupqtW7dWXfW8FPwucig47Kwo\nU2/vfN+8eXOzvxWJkjpqB0HzuprvWUTyTyEnPVxsBK6KfG0EnS3+JuX4rwD/Gtt3N3BNbN8LCcba\nHhHWEinktKHkDsrFILPUg869xWBxYWZQGR4eTglC/5hRGxM9b8GDTs0bnLBjb7WO1MVajU2bNqUG\nmFpGkRWVB6p+D2qXyjtmF8NFVmgar6TAWBpxptFdIhJQyEkOFvuGtTJviu2/AfhGynt+Hg8swCXA\njyJfG3AbcH74tUJOG9u5c6efeOLiWIB42INmmrQAlBxULr300ipBqCscIl6qjQlGVi2uet7iQ3zr\n1q2+cuVKX7lypRcKBS8UCr5mzZrEUWDxAJM2iiypJqQyUCWXK/6ZNbv5KHtYeykEisjUppCTHCye\nT9Bf5tjY/o8Dd6e85/fAGbF97wX+K/L1B4FbI18r5LSx8gBwR8KDteDFWpw/+ZOXe9BMVDn/TvWa\nnODBvHBhcjBIao4qhpCsWpisAJMVFtJqQlauXFklsBE2wWWHpkZlD2u/sGr5867VtWginUQhZ4JC\nDtAH/BdwWOT1mkPOokWL/I1vfGPZdtNNN9XxrZZ6VAaArQ4LvLIDcI8X+8fMmDGzLHDAUd7VNX3v\nA75aYHH3vTUw0YdTUnNUZQCqDBS1BJissJBWE5Jdk/KJukLT+L835dcZ79xAnaqepsc4BSPJg5tu\nuqniObloUXFwh0JONFg0vbmKYMztM+F5i9uecN+DVcqimpxJUAoA93t501T5SCLY3/v7T3b3IJD0\n9S1IfchUCyxZ4gEo60GfVduyZs2a2Dm2etDfp1BTKEkKbEGTW1fdoakexYfxwoWLUzpcj3+W505V\nT9Nj0XiCkUgnUE1OerhI6nj8CHBRyvFfAb4V2/cDwo7HQA8wL7Y9CnwUmF2lHAo5k6AUAI7yoNkp\n2sH1QC8OJS8+EJIeFgsXLk58WCTV2NQrqxYmebmJ8hA0PDzsr3zlkR4f6g77+8KFryv7LOLl3bRp\nU8XQ7Vr7EMU/51o+i6TPN15z1tu7YMJGd7WbRpseGwlGIp1EISc9XLwNeIryIeQ7geeGr98IfDRy\n/PEETVbFIeSXEAxBrxhCHnnPQ/Han4RjFHImSdYcNuvWrSs7NuiL8omaHxa1DNuO194Uv67loVZZ\n2/K5hEDT7eXz+6xymOaHHPK8xGBx0klLKub6iYaL8mve4XBhYvNRvTUIaQ/jE09c3HBgzFMTTSNN\nj40GI5FOopBTPWCcC/yMYHK/u4H5kdduB66PHf8W4Kfh8fcDAxnnf1Ahp32tXr0688GRPAKrOFFe\n5SioWkY91VJrMTCw1Pv7T65osjGb7rNmzfVCoZDQPNblZtMjQaG47lXyQ66vb0HCMO39Y+coD3Oj\no6N+0klLPN6s199/csOjupr9MM5jE00jn1GjfbJEOolCTptvCjmTJ+vBMTw87L29893s4FgQKF8h\nfPXq1Qlz2ezncJkHtR0XldV2VAaAozxe29LdfYj3959cZY6cLl+48HU+OjrqhUIhpfmqlsU3a5/0\n8Itf/GJK+cs7RGc1pcUfyM1+GOe1iSarY3ucanJkKlDIafNNIWdypT04KkdSFWtvSg+JYk3J/PnH\nJNSIHORBU1F5QLn55ptjD57sB9H06TMcDvDylch7HPbf+4BLDgpZo6Tix2eHoqAsWedMOnd6aFm7\ndm3THsbJo+bW7P1edfKDvZGO7fUGI5FOo5DT5ptCzuRKenDMmDHTu7rKm2xKtTfRh36pg3LlA7qy\ndgam+cteNisWAKoHi8svvzxy/soRUsUHd/pf7cVylI9Smj790ITjaxk6fkBGELrIk+ccqgwtwbpU\nxdFqXRXlbORhXGqCjI+aC66xevXqVvwYTahix/bh4eHMPkfjGfEn0gkUctp8U8hpD9EHR/UHfTRg\nHBF5eNRbg1JbTc7y5cvD1/tjD+zS18WakeR1rqaHW3mIe/DBB6us35U06WEx4MWXqSivKQk+Hw+P\nr5zluXySw2KwucLhs7HPs/QwrqcDcakzedKouWm+cOHiFv8ktV4jfY6aMeJPpB0p5LT5ppDTXmqb\nbfdghxd7V9e0lBFaWed4uZevjVVZ21IMBEFTTpfH15EqTlIYrRmpts7V/PkL/OKLLy4bMZZ0/JFH\nHu2VcwVFm+oeDl8/2IuzPZe250aOG60IZtFJDru6pkXCSPQcQdBZt25d3Q/zUm3WKxK+J6Xg2MxJ\nC6Oj4eoNEY2O/sprnyORRijktPmmkNNesmf7rRxVVDkKKmtRzn/zyqaU8v470VqMauc68cTFFfdQ\n/Kt93bp1NT1Eo3/ll673bi81UVVe98ADp3tlc1yPl2p8SscW19wq/3wvCj/LpEU4u3zNmjV1P8xL\nAfVcrxYyxzuqKHmF9PJFU6vVqox35uKJCHAinUIhp803hZz2k9ZZ8+CDe8JZf2sZBfVcT2quCR6G\nxQdUcdXxoKknKZRk1Sy1oo9J6f6LQSbenyer8/EGT+tTU7qfL1c9x/XXX1/Xwzx5qH/2/Efj+3zi\nAa8/MYjFa2yyRqdVC6YaFi5STiGnzTeFnPYzOjpa8cDMmjiwUCj45s2bY7MEl9f6pM19M9HDgLMe\npOXNWOU1TDNmzIwEkGpD05NrJ8prctLPUb6qe7TDdfD6xRdfXFb+9GH5lctC1FNzkvTZVQ94pT5b\nSfMlpc8a/bnEn5f0z081OSLuCjltvynktJekpoQTT1xc08SBRdHmn3iHz6R+MCeeWFoeIimANGsY\ncK3NJMUyFGuWvvjFL/qll17q69atq2kenHnzXpU4i3P0fkp9crJqcuJ9dqZXlP9rX/tawrlGE957\nlAejrrJrW9Jk99las/e/e3vnV9TYlNb/+pKXOmm7B7VAlXMlJX2PJ2tY+ETPIJ2nGauldRRy2nxT\nyGkv6csLZNfk1Grnzp2+cOHisgdwsW9PUgBp1jDgrD4u1UJQ5WvF5SLKa0r23ffZqWt9Fc+1Y8cO\nP/jg4sM+aSRX0CcnGOZeOQw/CCvB18HszMVh/NVqlpL7Fm3atKmi1q62zs21jL6rdly0U/emun62\nJnpY+ETPIJ3HGauldRRy2nxTyGkfWQ+wpJWxG/kLOilsBA/r/VMDyNatW/3yyy/35cuX+/XXX9/Q\nSJ6sB2m1EFT+2h2eXMtyVJ3nus4rh8YH56htKH88NKTPJVRZcxIEoIMOquxAnfU9TR56X+yTE/xM\nlOb/SQteX/JSR+uXVz02rZ/NRA0Lb/Vornr6LGW9t920e/nyQCGnzTeFnPZRSyff8f6FWVtNQPm+\nY489wSuHddfXt2S8q5qXvxY9V7HzdKHBc3n43gsd2Lv8RW3NQtGvj/bKxUn382nTDontW+CwuUpZ\nSuVMW1V99erVFTVx8dFVmzZVr51JD2m1laPaz1czH6qt7AOU3DRcvca0uLRIu9f2tHv58kQhp803\nhZz2Uesv9Phf0PU8WGp/eEf37eeV8+Qc4nBUzX9RZ93bypUrI+Wq7OhbXuZ6zpV0j+mv9fbOzxg6\nXxyevy4WEl7rQX+d8sVGK/cVOx/v71nNXNEalGp9tZL6Xrmn1fhEJ1aM3veCcdUSZj1UGw0/rRzN\nlVRj09V1YObPzowZM33RopPaurZHcxlNHIWcNt8UctpLPZ06G/lrrZGanOrHB8PPa5niv9Th90KP\nD/MulSt5cr7KMpzs8f40ZtO9v//kGu6xtpqB8u/F/QllK46gSvrrP6sMB3qp9qWestT+0EqenPEo\nL02YWLrW5s2bx/WXf1r5kqY3qOe8rarJyQ6x1ZYWObCmMk1WbYpGwE0shZw23xRy2ks9nTob/Wst\nKUiV+uSU9gUjcbI61X7Waxl6vHPnzoqOzdDl/f0n7z02WJT0oIowse++z04Y+v4qr2we2t/7+09O\nvcdSLUpXeL/pQbKyWajYSTleK7OPw/kJn1EtM1fj8GIvn326VM5aJ2SsdbLFvr4FYU3FFan33Ug/\nm6zyBcE2WlsyzXt759d8jVaM5qpeQ9QV/uyn1YBdWOW9ScucTGxtiuYymlgKOW2+KeS0p6yHzXge\nfElBKml0Vfmon7S/bI+oePgn/SLP+oVfXpNTuebTcce9NqFWYpWX98kp3Xsw19Ci2PHFIdzXeTwg\npY/iwvv6Fnj1zyDpM8qqydkQ/rufx9fMCjoQX7f38xnvQ6vaDMnNqFnIbgK9KPx6p8dn2q7l+vWO\n5qqleaiWTv7ln1d0aZE7qr63+oK1ra9NUU3OxFLIafNNIaezFH+BZ/U7qeWvtaQgFd8XPFz29/js\nyUEQOaKmX6a1/NItPSirH1coFGIT9VXee1IHbZjnSc00s2fP9s2bN++9/0b6aaxcuTKxT0v1xUaj\nASneqbv4QA2OyRrplfXQOvHEReE9fCJyTz01LRbajMAAH/cghC71eICtp2YjK/jX2zyUVUP0hS98\nITxP0vD/ytqe6HsnuzZlsuYymooUctp8U8jpDMl/jbf+r7XR0dGwhid5dFUtv8hr+YVfelBmn6/2\nofbxjtJLvdSpuViTcoDPmDGzxs7G6Z91rbVjQS3NtR6En1eHX8c7JxfLWrrvag+ttCCSvNREeYBq\nZWCIzvBc+pm5rmU/r/U2D9VSQxQ0oVbOx9TT89zMjtaTWZsy0XMZTWUKOW2+KeR0hqRf4LB/Zt+S\nZikUCr5y5UpfuXLl3pmIa61hqPUXfj0THqY99NPPUblsQfB1UCt07LEnRJbEqK2fRtJnnVTbULnc\nRrHpLGuY9xV777vWELVwYWn26qCjd9KouPIAlaQZgSGoyboucu1pHoS6+Gc7/pqN8YSKajVEDz74\nYBh0Svd10EHT/bbbbst8bzvUpkzUXEZTmUJOm28KOe0v/Rf4tRUP7vH+tVbvcNdaf5H3959cEciK\no6GKRkdHE/9yTjpf0kP1pJOW+Gtec3RKUOn3yo7D0700GWCXmx1c9UEZzIBcut6MGTP9wQcfrPkz\nrGxqq17D1dV1YNUQlRx8p/mMGTNrmCenFKCSyj+ewJA9T1HlCL7xPoRb3Tx08803++GHz6nr/zXV\npkwNCjltvinkTI5mzm2zcuXKcf+11uhw11p/kQc1DumjoaLni3f6TButFb/ujBkzU4JKLUPKi68X\n+42Uh6wZM2aGgeITHswW/ImK8FXLZ1geIKqXK7qmWFxWEJk371V1B6ii8QaG7I7IF3qzazayPo9a\npjioppGRUvE12JpRm6IZjNuPQk6bbwo5E6sVc9tMRn+GuGrV4uUrf6/zpNFQ9ZwvrbyldaXiQaX6\nkN9SbdjDHvRXKf/+zJv36po+//Iy3eFw0d4ZlJPL/mUPapLKm8Fq6RScHSSq99lKC1BBP57xrZNW\n2zxF9dVsZD3ct27d6r2988Ph6tHPcnpFc1O9tSn1/v/XivlxNINx+1LIafNNIWdiNXNum4n6K3i8\nNUSldZSinV83eVAjUn9TQvZDdHNFUKl+/AUJr5eWeqhlJFupTNcmXLurbARXZe1X/U2OtQSJ17ym\nt6KJsDgcP+2cpaBQnOjwwvAaFyYGtjTVfl7rmbE76+FebXh8sXZvvHPV1FuzVc//40n3nrRvsubc\nkWwKOW2+KeRMnGbPbdOsv+Qqf4mXj0Bq7tT513q82SraWbax8pY/dEpLU5SCyvTph1YZ/fOwJzVT\ndXX17B29lPV9K5Wp35Pm+entXVBxH9GHffS/a22SCObvOcCDGrIvedDP5hAvTqZ43HEnVHzWSU2E\nyUHheRWBASibvLGaWn5ea6mdyHq4p9XoHXxwj998880N//8W/R7U8/9trccm3XtSR/KBgex1yNR0\nNbkUctp8U8iZOM3oHNmK0RL11EI0dt7oL+elHl8Hq96/SLNrMUoz+gbXOiqx2aK8GaqymSo+Uqla\nTVr5EPjGHka1NklUr72Y7mYHhwGnWJbkCROL0pv+pvt45rVxr3X0UdYEken9bJJfD4b8z5o1u67/\n34qzXMeH3Q8MLE2YcTt5luysOZyqzYZcmnW8/POoPupPMxhPNoWcNt8UcibOZM+dUU35pH/lv3gb\nrRJPriFqzv2nhY5p02YkPPxP9iDAUdEJtPI8V3hX14F+4omLy65XS83EeB9GtTZJJIeSYg3OND/k\nkOeljDLb6vEmwuzAmDQR3vh/VuurHUv+PM8666zY65UzKjdaq1KaHTt7Da7091dOPllLzVC968c1\n8r1QB+bmUchp800hZ2K1w9wZSVpRJV75y7x5w3zTQseRRx7twQKKF3nQ3FYMAP2J16i3GbBazcR4\nPsNaA3BttVjxB3zlw79YS5UcJEphKPh3fN+rJFkB5vOf/3zKUPSdnrxQarEmrnIuqbQpCYoP+uqT\nR5Z/D4aHh/3SSy/1devW7b2X6p3gK/8fz25u/byXat6CfeNdJb74s5NWU6UOzI1TyGnzTSFnYrXr\n3BmtmmekPNTd0XAISBPvy1I9AKRfIym8NPLXbqMhttbPP/sB+fHIz1ZX5GGbXENU/pkl1YQkL4dR\n62eS9hnWMwIrCCrXhmUvdoiOB4pXpJyvci6p5Jmoq9WqFING+YSOtfSXSfp/vL57DwLdeFaJr6Wm\narL/yOpkCjnVA8Z5wEPA08BGYEHG8W8FHgiPvw84NfLaPsDHgfuB3wK/AL4EPD/jnAo5k6DdZiJt\nVVNa0kiiVs3SnBUAenvn13Se8QzXbXQxyWbNHl0KN5eFD7G0h3/pvKVglrw4alqNxHg/w6RAWN4v\n5Q4PauQO8vKgUu3e04fUr1y5Mna/1zq8JuN9a/aePxh1doVH50nKaqK89NJLE//fSZocM/isy/vk\nwDSfPv3Qve+r5fdGPFimN29W1lRJ/RRy0sPFGcDvgHcArwCuA0aBQ1OOPwH4I/B+YC5wGfB7YF74\n+sHAMPAWYDZwTBicNmWUQyFH3L21TWnFX87j+Ys0SykAXOGl6v7SL/FaO1BX6xtTa+1OI4tJTp8+\nI/Hz7+1dkLmkRdCXqj8STIoPsGKTz4bEh/CaNWtiK7bXXiMx3s9w/fr1FZ3Bodvhck/qAH/22Wdn\nBplq5S8f6l+c+HFaxvuuCO+jy5Obyapftxis4pInx+zytLW9qk0MWe1nKvv7WqqpUgfmxijkpIeL\njcBVka8NeBT4m5TjvwL8a2zf3cA1Va4xHxgDXlTlGIUccfeJbUprRU3Wzp07Ex6awciqtKAWDy3p\nNSWVa1+N57MZGFjqXV3TKx6c++777IQHX/n1kteJKi68GX2ALc48pnjfWbVgZs+q6IydpvbmmGKt\nXmkW6aA/1cGe1CSVNSkjvMSTV30/au+9lu7zjsi5KqcPiC4uGszzZF5ZyxWEn6T+MsF9VX7vKj+f\n4si36nMxVZuhOvozFQ+WwerztdVUqSanMQo5ycFiX4JamTfF9t8AfCPlPT8Hlsf2XQL8qMp1lgDP\nAAdWOUYhR8q0W1NardI6gBZXGY9Ka05ZvXp1ykOhv+LB22gtV+khl9w8NH/+MZFJ+dKv9+lPfzo8\nT3ItTRAYoucu1vZ8ee/nUmtzWbW1ruKy+w1d5JX9s5L6A1WGslIn4cplN4L3dMfOUR5yy2ffLpax\ncvqA5zxnmn/hC1/wQqHga9eurfrZfP3rX08IndHFSctH7KV39q72+QfljXZ4Tv6ZSh5On1VTpT45\njVPISQ4Wzwf2AMfG9n8cuDvlPb8Hzojtey/wXynH7w/8ELgxoywKOdLx6u1TlNacUhp5Ej1PfeeO\nBoeksFh6yGXVdoy3f07y8O9ge5XHa6aCtb+SakKyVy2PuueeezLKVay9iD7ok0ZGRfuNBNdfvXp1\nYjjdsWNHZM0zq3g93hcoCJDxMpYmj4zO7lxrp/DKxUmTR7Wld1YudqqON0Nm1yBWL2NXuBp9ck1V\nOwx86GQKOZMQcgg6If8rsLlaLY4r5EhO1DM6LCscnHhivLag+tpXxXNXm6QvubmiWm1HbfeS3D8n\nOpNz0rlXelrNVHyl9VJtSu1NGuVzLsXL1e+VwbGWeWPKrx+vbawMrZ9InO/IPdosWxx9lhTqsua1\n2br35yL6mZT/HBaDW6mzcnEW7eTv28EOz419/v1eqslJr0HM+pmOL3q7cOFiX716dcfV1rYjhZzk\nYNGy5qow4HwD+BHQU0NZegFftGiRv/GNbyzbbrrpptq/0yKTqJ6anKxAlFRbUMu5q03SF38w1dbR\nN32m3+IDPql/TnJtVPTcX6j6el/fgrAvR2nm6FqbNErfh+s8qfNwMOqreL3i7NdZC6heWPX6jY4M\nvPnmm/2ww14YK2Mx1JUHytL39nOR4FGtv01xvqLkzspJHfBLHY8rZ6hOmiAwvXYyeeBApzZDt5Ob\nbrqp4jm5aFHx/2WFnHi4SOp4/AhwUcrxXwG+Fdv3AyIdjyMB5z7gkBrLoZocyYVaR4fV+lCMPhRq\nX9ahtj4to6OjYT+SpOaJfk9quijve1L+gE2v2YjXpERrCmoPebU2aZQC5JfCB3Pxgb0h3H+gl+ZM\nOt/LRxilB75q1693jqfkGrfDPVjYtfjeoC9LsQ9MZe1Pel+poDnswPDY5M7K0Sauaj9j5bVf1e+r\nXefgyjvV5KSHi7cBT1E+hHwn8Nzw9RuBj0aOP56gyao4hPwSgiHoxSHk+wDfIqjxeTUwM7LtW6Uc\nCuKeLagAABSdSURBVDmSC/X8kq93uHzWubM721auuD46OlrRjFCqSRj1eC3AjBkzwxFZ2Z2fk0dg\ndYcPzWItQ+0hrxY7d+6smE03GOFVau6CEzzex2TBgmP9oIOmezzUdXVVDp9PUuoYnNwHKT6Mu/oM\nxfdXfO7F73Ot4Xh0dNT7+uZXPTbagbjYhyu5dscc3ue11OQUqcZmYinkVA865wI/I5jc725gfuS1\n24HrY8e/BfhpePz9wEDktT8hGC4e3faE/y6qUgaFHMmVWn7JN/pXb9q5663JiVq5sjh8OHmU1KWX\nXlrzZIFp5a18f+Ww6fGOskkPD8UAE62hKg9q/f0nVwS+rO9H9Zl8P+fxeWhqn6E4uaamlqUoip91\n1kKdvb3zfceOHYk/g5s3b/bVq1cnBOB+h2s1GqrNKOS0+aaQI1NZM//qTW5uSO6TE9WMxSqzRj1V\nvr9y2HS9TRvROYayQ1609ib9PmtZXqP6mlPFTteVzUpm01MWLi19jkHNSXpfqOyAFO1fk35sV1cw\nhD9twsT0wNjlvb3za57YUlpPIafNN4UckeZIbiKqbZjuePv8ZIW09PcHNUxp868kSWqWylreAPDl\ny5fXFdSSamoqJ3usv+N29mvps0NnL0UR7XtT2QQXH71VfZh/c2afltZSyGnzTSFHpLmKtRHr1q2r\nuZaoluaz8S67kdzROahRqFVpVunyWpLkeWfKH8zJq4qXjqllLqNS35niKun1D8F/yUtelhI+osO1\nk8u3Y8eOhKBVHBWVdN/xIfldDid70KRW7KtVfM9OLx+5Va1/1xWpQ+RlYinktPmmkCPSPqo1n41n\n9Ez5LMvxPiy1T+lffeh72rwzpWs0awQc1NJ0lPzahz70IY93fg5qV64N/7tyVFuxfKXyF5eieHdG\nIDEPRpRd5EENUWlagcqanOKQ+uodw4OJHEtlX7gwe10raR2FnDbfFHJEOksj/YjK++RE52GprU+P\ne22TGB58cE9FiIouq1BrUMserbbG0zpPB01pXV45GWEwe3AxbAW1TxeG4aP4+smeNEtx+uiqWtbp\nSn6tfEHWO2LHJq2nVb4eVlDrc93eCQZlcijktPmmkCOSf+Pt0+Ne23IUmzdvruivkxRisoJadk1O\nwZOG2RevlbzK9/7e33+yu6f1n+r30lpZBY8P+08PXsXZo+OBakHVoHb99dcnlCG9Y3j5eljRZS+0\nwOZkUshp800hR2RqGG+fnsqFRcv79ixcuHjvsc0YtZY+Od5RHq+5iV+r1hqjyvWm0gNgevC61iub\nv/odqg9Xj85HlF6GKyLnTAt8G8rCmEwshZw23xRyRKaGZsyIGzTzTK+oQUla6b0V5U2b8TlNrWGr\n1gBY7bjksFL7fERp5+7trV4jlLSGlkwchZw23xRyRKaW8dSypK2V1cqOr/HytmJG31oDYP2j4NJn\nUK61DFkTGEZXTJeJN1Ehxzx4YEudzKwXGBkZGaG3t3eyiyMiHWDbtm1s376dWbNmMXv27MkuTtPU\nel/Vjtu1axeDg2cxPLxm774TT1zM+953LkcffXTm55V07lNOOY316zcyNnYVsBjYAJwP/IaBgVMY\nGlpFT09Pg3ct47Flyxb6+voA+tx9S6uuo5DTIIUcEZHma2YQTApOvb0LuO66a5g/f/54iyrjMFEh\nZ59WnVhERKRes2fPblotV09PD2vX3pLbGjTJppAjIiK51szgJJ2la7ILICIiItIKCjkiIiKSSwo5\nIiIikksKOSIiIpJLCjkiIiKSSwo5IiIikksKOSIiIpJLCjkiIiKSSwo5IiIikksKOSIiIpJLCjki\nIiKSSwo5IiIikksKOSIiIpJLCjkiIiKSSwo5IiIikksKOSIiIpJLHRlyzOw8M3vIzJ42s41mtiDj\n+Lea2QPh8feZ2akJx1xmZv9pZk+Z2XfMbFbr7kBERERareNCjpmdAXwS+AhwNHAfMGxmh6YcfwJw\nE7ASOAr4FvBNM5sXOeYDwPnA2cAxwJPhOfdr4a2IiIhIC3VcyAFWANe5+43u/lPgHOAp4F0pxy8H\nbnX3T7n7Vnf/MLCFINQUXQBc7u7fdvf/AN4BvAD4s5bdhYiIiLRUR4UcM9sX6ANuK+5zdwfWA8en\nvO348PWo4eLxZvZy4LDYOf8buKfKOUVERKTNdVTIAQ4FuoHHY/sfJwgqSQ7LOH4m4HWeU0RERNpc\np4UcERERkZrsM9kFqNMTwBhB7UvUTOCxlPc8lnH8Y4CF+x6PHfOjrAKtWLGCadOmle0bHBxkcHAw\n660iIiK5NzQ0xNDQUNm+3bt3T8i1LejS0jnMbCNwj7tfEH5twMPA1e5+RcLxXwGe7e6nR/b9ALjP\n3c8Nv/5P4Ap3vzL8+mCCwPMOd/9aSjl6gZGRkRF6e3ubeo8iIiJ5tmXLFvr6+gD63H1Lq67TaTU5\nAJ8CbjCzEWATwWirA4AbAMzsRuBRd/9QePxVwB1m9n7gFmCQoPPyeyLn/DTwt2a2HfgZcDnwKMFw\ncxEREelAHRdy3P2r4Zw4lxE0Kd0LDLj7r8JDXgQ8Ezn+bjM7E/j7cNsGnO7uP4kc849mdgBwHTAd\nuBM41d3/MBH3JCIiIs3XcSEHwN2vAa5Jea0/Yd/Xga9nnPMS4JImFE9ERETagEZXiYiISC4p5IiI\niEguKeSIiIhILinkiIiISC4p5IiIiEguKeSIiIhILinkiIiISC4p5IiIiEguKeSIiIhILinkiIiI\nSC4p5IiIiEguKeSIiIhILinkiIiISC4p5IiIiEguKeSIiIhILinkiIiISC4p5IiIiEguKeSIiIhI\nLinkiIiISC4p5IiIiEguKeSIiIhILinkiIiISC4p5IiIiEguKeSIiIhILinkiIiISC4p5IiIiEgu\nKeSIiIhILinkiIiISC51VMgxsx4z+2cz221mu8zs/5nZczLes7+ZfdbMnjCz35jZzWb2vMjrR5rZ\nTWb2sJk9ZWY/NrPlrb+bzjE0NDTZRZgQus980X3mz1S516lynxOho0IOcBNwBPB64DRgEXBdxns+\nHR77lvD4FwD/Enm9D3gceDswD/h74GNmdm5TS97Bpsr/cLrPfNF95s9Uudepcp8TYZ/JLkCtzOwV\nwADQ5+4/Cve9D7jFzC5098cS3nMw8C7gL9x9Q7jvncADZnaMu29y9y/G3vYzMzsBeDNwTQtvSURE\nRFqok2pyjgd2FQNOaD3gwLEp7+kjCHK3FXe4+1bg4fB8aaYBo+MqrYiIiEyqjqnJAQ4Dfhnd4e5j\nZjYavpb2nj+4+3/H9j+e9p6wFudtwNLxFVdEREQm06SHHDP7GPCBKoc4QT+ciSjLq4BvApe4+20Z\nhz8L4IEHHmh5uSbb7t272bJly2QXo+V0n/mi+8yfqXKvU+E+I8/OZ7XyOuburTx/dgHMZgAzMg57\nEFgGfMLd9x5rZt3A74D/4e7fSjj3SQRNWj3R2hwz+xlwpbtfFdk3D7gd+Ly7f7iGcp8J/HPWcSIi\nIpLq7e5+U6tOPuk1Oe6+E9iZdZyZ3Q1MN7OjI/1yXg8YcE/K20aAZ8LjvhGeZy7wEuDuyLlfSdBv\n54u1BJzQMMGIrJ8RBC0RERGpzbOAlxI8S1tm0mty6mFma4DnAe8F9gOuBza5+7Lw9RcQhJVl7v7D\ncN81wKnAO4HfAFcDe9x9Yfj6qwhqcG4F/iZyuTF3f2Ii7ktERESab9Jrcup0JvAZgiaoPcDNwAWR\n1/cF5gAHRPatAMbCY/cH1gLnRV5/C0Fz2VnhVvRz4OXNLb6IiIhMlI6qyRERERGpVSfNkyMiIiJS\nM4UcERERySWFnBR5XQzUzM4zs4fM7Gkz22hmCzKOf6uZPRAef5+ZnZpwzGVm9p/hPX3HzGa17g5q\n18x7NbN9zOzjZna/mf3WzH5hZl8ys+e3/k6qa8X3NHLstWa2px0WrW3Rz+4RZvYtM/t1+H29x8xe\n1Lq7yNbs+zSz55jZZ8zskcjvnf/d2rvIVs99mtm88PfpQ9V+Huv97CZCs+/TzD5oZpvM7L/N7HEz\n+4aZzWntXWRrxfczcvzF4XGfqrtg7q4tYSMYbbUFmA+cABSAVRnv+RzBkPLFwNHAXcD3I6+/E7gS\nWEgwdO5M4Eng3Am6pzMIhru/A3gFweKmo8ChKcefAPwReD8wF7gM+D0wL3LMB8JzvAEoTqa4A9hv\nkr9/Tb1X4GCCoY5vAWYDxwAbCUb35eY+Y8f+OfAj4BFged7uEzgceAL4GHAk8LLw5zjxnB18n58n\n+P21kGD6jPeE73lDB93nfODjBLPR/yLp57Hec3bwfa4hmDfuCODVwLcJnjvPztN9Ro5d8P/bu99Y\nKa4yjuPfHy2F1IYQpL1GqxioGAwGEGokpagoQa0Wq4n6qiG2aUytVZMGNb6wMf4lFitSUmNESxts\nbKy1NU1r8PKC0DaxrQYq2KIQawNXBZEibVIsxxfPWTt33b1cdnd27g6/TzK5d2dmz5zn7tzZ58zM\nmUM8K+93wPozrltVf5SJPOUP6RSwqDBvFfHMnde0ec+0fHC5qjDvzbmct4+xrY3Atj7F9RjwvcJr\nAc8Ba9usfzdwf9O8R4FNhdcHgc83/R1eBD5W8WfY81hbvGcJ0XPv4rrFCbyOGONtHnBgrIPQoMYJ\n/BS4o8q4+hTnbuDLTes8Dnx1UOJsem/L/bGbMgcpzhbrzczfM8vqFidwAfA0sALYTgdJji9XtVa7\nwUAlTSbqWKxfIuJqV7+leXnRw431Jc0mxgArlvk88XDGsWIuVRmxtjGd2Cf+1XFlu1BWnJIEbAHW\npZQqH7ekpH1XwBXAPkkP5dP+j0la3ev6j1eJ++0jwJWK54g1ngT/Jkp+CFs7HcbZ9zK71cc6NY5D\nlQwqXXKctwEPpJSGOy3ASU5rLQcDJXaiMgYD/UFXtR2fmcA5uT5FbeuX54+1/hDxz3UmZfZDGbGO\nImkK8C1ga0rp351XtStlxflFYl/e2ItK9kAZcV5EtBK/QJz+X0k8Ff1eSZf3oM6dKOvz/AywF3hO\n0ktEvJ9OKe3susad6STOKsrsVul1ysn6rcRtEXt6UWYHSolT0ieAhcCXOq/a4D0MsCsa3MFAbQKR\ndC5wD7G/XF9xdXpK0mLgRuKesjprNPDuSyltyL/vyg2PTwE7qqlWKW4kzkB/kDizvBzYJOlgNy1k\nmxA2AW8BLqu6Ir2Ub/6/FXhvSulkN2WdVUkO8B3gx6dZZz8wQrT0/kcxGOiMvKyVEeA8SdOazuYM\nNb9HMRjoNuD2lNI3x1/9rhwm7h8Zapr/f/UrGDnN+iPEtdchRmfxQ8RNYlUpI1ZgVILzemBFhWdx\noJw4lwEXAn+NRiIQrbT1kj6XUqriKeBlxHmYuMeu+XLcXqr7wuh5nJKmAl8HVqeUHsrLn5K0CLiJ\nGNKm3zqJs4oyu1VqnSRtBD4AXJ5SOtRteV0oI87FxHHoSb1yIDoHWC7pBmBKviR2WmfV5aqU0pGU\n0jOnmf5D3Lg3PR8IGs5kMFBgzMFAhzmzwUC7lrPhJ5rqp/z6kTZve7S4frYyzyeldIDYiYtlTiNa\nje3KLF0ZseYyGgnObOA9KaWjPaz2GSspzi1ET6MFhekgsI64+b7vStp3TwK/JToHFM0lhnTpu5I+\nz8l5av5CeJmKjv8dxtn3MrtVZp1ygrMaeHdK6dluyupWSXFuI3qOLeSV49DjwF3AgvEmOI0Kemp9\nV/eD+Y96KdGyexq4s7D8tUSrb0lh3ibiTvF3EZnoTmBHYfl84l6fO4gstzH1pYsjcf/PC4zu5ncE\nuDAv3wJ8o7D+UqLHWKN76s1EN8Fi99S1uYwP5Z3yPmAf1Xch72msxFnPXxJfgG9t+vwm1yXONtuY\nCL2ryth3P5znXUt0J78BeAlYWrM4twO7iEdbvBFYk7dx3QDFOZn4oltIdDn+dn49Z7xl1ijOTcBR\n4pEAxePQ1DrF2WIbHfWuquQPMggTccf6XcCxvEP9EDi/sHwW0RpaXpg3Bfg+cfruONHqv6iw/Cv5\nPc3T/j7GdT3xTIUXidZeMUkbBjY3rf9R4I95/V3AqhZl3ky09l8gemxcUvXn1+tYC593cTrVvA8M\nepxtyt9PxUlOifvuGuIZMieI52JV9uyYsuIkLr3/iHje0QlgD/DZQYoz//81/t+K0/B4y6xLnG2W\nvwxcXac4W5Q/TAdJjgfoNDMzs1o6q+7JMTMzs7OHkxwzMzOrJSc5ZmZmVktOcszMzKyWnOSYmZlZ\nLTnJMTMzs1pykmNmZma15CTHzMzMaslJjpmZmdWSkxwzMzOrJSc5ZmZmVktOcsxsQpG0XdIGSd+V\n9E9JI5KukXS+pM2Snpe0T9L7Cu+ZL+lBScfz+lskvbqwfJWkHZKOSjos6QFJswvLZ0k6JekqScOS\nTkj6vaR39Dt+M+sdJzlmNhFdDfwDuBTYANwO3APsBBYBvwbulDRV0nTgN8ATwNuAVcTI2z8rlPcq\n4Ja8fAUx4vEvWmz3a8A6YAExOvlWST5Omg0oj0JuZhOKpO3ApJTSO/PrScAx4OcppTV53hBwEFgK\nrASWpZTeXyjjYuBZYG5K6U8ttjET+DswP6W0R9Is4ADwyZTST/I684CngHkppWdKCtfMSuQWiplN\nRLsav6SUTgFHgN2FeX8DRJyxWQCsyJeqjks6DuwFEjAHQNIlkrZK+rOkY0RCk4A3NG13d+H3Q4Vt\nmNkAOrfqCpiZtXCy6XVqMQ+ioXYBcD+wlkhKig7ln78iEptriTNAk4A/AOeNsd3GaW43Bs0GlJMc\nMxt0TwIfAf6Sz/qMImkGMBe4JqW0M89b1qIcX7s3qxm3UMxs0N0GzADulrRE0uzcm2qzJAFHictd\n10maI2kFcRNyc1LTfBbIzAackxwzm2hanVFpOy+ldAi4jDiePUzcz7MeOJoy4OPAYuKem1uAm7rY\nrpkNCPeuMjMzs1rymRwzMzOrJSc5ZmZmVktOcszMzKyWnOSYmZlZLTnJMTMzs1pykmNmZma15CTH\nzMzMaslJjpmZmdWSkxwzMzOrJSc5ZmZmVktOcszMzKyWnOSYmZlZLf0XBEUScTQrMsYAAAAASUVO\nRK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYwAAAEWCAYAAAB1xKBvAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzt3XuYFOWZ8P/vXd3TwzDIQcDIUWWRuAMRYiaiYohKshFF\nfPfVmKwaE3eVmJ+YbOJxk/UU3uRN1ORNDETXGLMxmhjFbEQ0Z3EVVOLgAjJoZIKJDHgAgpyZme6+\nf39UdVNdXd1dPTM9Mz3cn+vigumurn6qh37uek73I6qKMcYYU4rT2wUwxhhTHSxgGGOMicQChjHG\nmEgsYBhjjInEAoYxxphILGAYY4yJxAKGMd1IRL4sIvf2djmMqQQLGKbPE5FTReQ5EdkpIn8TkRUi\n8sEunvMzIrI88Nh/isj/6cp5VfXrqnpZV85RiIioiOwVkT0isllEvi0isYivPU1EWitRLnPosIBh\n+jQRGQwsBb4HHA6MAW4F2nqzXGFEJN4DbzNVVQcBHwY+AfxzD7ynMYAFDNP3TQJQ1Z+pakpV96vq\nb1V1beYAEblcRF4Rkd0isl5ETvAev0FE/ux7/B+9x/8euBs42btbf1dE5gEXAdd5jz3uHTtaRB4V\nka0i8rqIfN73vreIyGIReUBEdgGf8R57wHv+aK9V8GkReUNEtonIV3yvrxORH4vIDq/810VtBahq\nC7ACmOY736W+z2GjiHzWe7we+BUw2ru2Pd51Ob7PaLuIPCwih3uvGeBd13bv83lRRN5T9m/P9CsW\nMExf9xqQ8irW2SIyzP+kiHwcuAW4BBgMzAW2e0//GfgQMAS3VfKAiIxS1VeAK4DnVXWQqg5V1XuA\nB4HbvMfOEREHeBxYg9uymQX8q4h8zFeEc4HFwFDv9WFOBd7rvf4mL2AB3AwcDUwAPgpcHPVDEZHj\nvGtr8T38DjDH+xwuBf6fiJygqnuB2cAW79oGqeoW4Crgf+G2VkYDO4BF3rk+7X1u44Dh3ue1P2r5\nTP9kAcP0aaq6C7fCVeAHwFYRWeK7270Mt5J/UV0tqvpX77WPqOoWVU2r6s+BDcCJZbz9B4GRqvpV\nVW1X1Y1eGT7pO+Z5Vf2l9x6FKtRbvZbRGtzgM9V7/ALg66q6Q1VbgTsjlOklEdkLvAI8DXw/84Sq\nPqGqf/Y+h/8GfosbVAq5AviKqraqahtu4D3f61rrwA0UE72W3Srvd2EOYRYwTJ+nqq+o6mdUdSww\nBfdu+Dve0+NwWxJ5ROQSEVntdam86712RBlvfRRuN867vnN8GfB3zWyKcJ63fP/eBwzy/j068Poo\n5zrBe/0ngOlAfeYJrwX2gjcx4F3gLIpf71HAf/mu7RUghXt9PwF+AzwkIltE5DYRqYlQPtOPWcAw\nVUVVXwX+E7fyB7eS/bvgcSJyFG5rYD4wXFWHAusAyZwq7PSBnzcBr3tdVpk/h6nqWUVeU443gbG+\nn8dFeZHXgngYeB64CUBEaoFHgTuA93jX+yTFr3cTMDtwfQNUdbOqdqjqraraAJyC29V1SSeu0fQj\nFjBMnyYix4nI1SIy1vt5HPBPwAveIfcC14jIB8Q10QsW9biV5FbvdZdyMMgAvA2MFZFE4LEJvp//\nCOwWkeu9AeqYiEzp6pRen4eBfxORYSIyBje4leMbwOUiciSQAGpxrzcpIrOBf/Ad+zYwXESG+B67\nG/ia93khIiNF5Fzv36eLyPvEnba7C7eLKl3+JZr+xAKG6et243a9rPT67l/AbSlcDe44BfA14Kfe\nsb8EDlfV9cC3cO/C3wbehzurKOMpoBl4S0S2eY/9EGjwumh+qaop3DvracDrwDbcAOWvdLviq0Cr\nd+7f4w6eR54urKovA88A16rqbuDzuEFoB3AhsMR37KvAz4CN3vWNBr7rHfNbEdmN+9lO915ypFee\nXbhdVf+N201lDmFiGygZ0zeIyOeAT6rqh3u7LMaEsRaGMb1EREaJyAxvPcR7cVtN/9Xb5TKmkJ5Y\nmWqMCZcA/gM4BngXeAjfNFlj+hrrkjLGGBOJdUkZY4yJpF91SY0YMUKPPvro3i6GMcZUjVWrVm1T\n1ZFRju1XAePoo4+mqampt4thjDFVQ0T+GvVY65IyxhgTiQUMY4wxkVjAMMYYE4kFDGOMMZFYwDDG\nGBOJBQxjjDGRWMAwxhgTiQUMY4wxkVjAMMYYE4kFDGOMMZFYwDDGGBOJBQxjjDGRWMAwxhgTiQUM\nY4wxkVjAMMYYE4kFDGOMMZFYwDDGGBOJBQxjjDGRWMAwxhgTiQUMY4wxkVjAMMYYE4kFDGOMMZFY\nwDDGGBOJBQxjjDGRWMAwxhgTiQUMY4wxkVjAMMYYE4kFDGOMMZFYwOgm2/e0sWbTu2zf09bbRTHG\nmIqI93YB+oPHVm/m+kfXUuM4dKTT3Hbe8cydNqa3i2WMMd3KWhhdtH1PG9c/upYDHWl2tyU50JHm\nukfXWkvDGNPvVDRgiMiZIvInEWkRkRtCnhcRudN7fq2InOB77osi0iwi60TkZyIyoJJl7azWHfup\ncXI/xhrHoXXH/l4qkTHGVEbFAoaIxIBFwGygAfgnEWkIHDYbONb7Mw+4y3vtGODzQKOqTgFiwCcr\nVdauGDusjo50OuexjnSascPqeqlExhhTGZVsYZwItKjqRlVtBx4Czg0ccy5wv7peAIaKyCjvuThQ\nJyJxYCCwpYJl7bThg2q57bzjGVDjcFhtnAE1DreddzzDB9X2dtGMMaZbVXLQewywyfdzKzA9wjFj\nVLVJRO4A3gD2A79V1d+GvYmIzMNtnTB+/PhuKnp55k4bw4yJI2jdsZ+xw+osWBhj+qU+OegtIsNw\nWx/HAKOBehG5OOxYVb1HVRtVtXHkyJE9WcwcwwfVMnXcUAsWxph+q5IBYzMwzvfzWO+xKMd8BHhd\nVbeqagfwC+CUCpbVGGNMCZUMGC8Cx4rIMSKSwB20XhI4ZglwiTdb6iRgp6q+idsVdZKIDBQRAWYB\nr1SwrMYYY0qo2BiGqiZFZD7wG9xZTveparOIXOE9fzfwJHAW0ALsAy71nlspIouBl4Ak8D/APZUq\nqzHGmNJEVXu7DN2msbFRm5qaersYxhhTNURklao2Rjm2Tw569zeWZ8oY0x9YLqkKszxTxpj+wloY\nFWR5powx/YkFjAqyPFPGmP7EAkYFWZ4pY0x/YgGjgizPlDGmP7FB7wqzPFPGmP7CAkYPGD6o1gKF\nMabqWZeUMcaYSCxgGGOMicQChjHGmEgsYBhjjInEAoYxxphILGAYY4yJxAKGMcaYSCxgGGOMicQC\nRgXZPhjGmP7EVnpXiO2DYYzpb6yFUQG2D4Yxpj+ygFEBtg+GMaY/soBRAbYPhjGmP7KAUQG2D4Yx\npj+yQe8KsX0wjDH9jQWMCrJ9MIwx/Yl1SRljjInEAoYxxphILGAYY4yJxAKGMcaYSCxgGGOMicQC\nhjHGmEgsYBhjjInEAkYfYanQjTF9nS3c6wMsFboxphpYC6OXWSp0Y0y1sIDRyywVujGmWlQ0YIjI\nmSLyJxFpEZEbQp4XEbnTe36tiJzge26oiCwWkVdF5BURObmSZa2EKOMSlgrdGFMtKjaGISIxYBHw\nUaAVeFFElqjqet9hs4FjvT/Tgbu8vwG+C/xaVc8XkQQwsFJlrYSwcYmw7LWZVOjXBY61pIXGmL6m\nkoPeJwItqroRQEQeAs4F/AHjXOB+VVXgBa9VMQrYB8wEPgOgqu1AewXL2q384xIHcFsPVz+yBkcg\nEYvlDWxbKnRjTDWoZJfUGGCT7+dW77EoxxwDbAV+JCL/IyL3ikh92JuIyDwRaRKRpq1bt3Zf6bsg\nbFyiI6W0JbXgwPbwQbVMHTfUgoUxps/qq4PeceAE4C5VfT+wF8gbAwFQ1XtUtVFVG0eOHNmTZSwo\nbFwiyAa2jTHVppIBYzMwzvfzWO+xKMe0Aq2qutJ7fDFuAKkKwS1aa+MO8cAnbQPbxphqU8kxjBeB\nY0XkGNwg8EngwsAxS4D53vjGdGCnqr4JICKbROS9qvonYBa5Yx99XnBcYkXLNhvYNsZUtYoFDFVN\nish84DdADLhPVZtF5Arv+buBJ4GzgBbcge5Lfae4CnjQmyG1MfBcVfBv0dqZge3te9psINwY02eI\nO0Gpf2hsbNSmpqbeLkYkwWAQ/NnShRhjeoKIrFLVxijHWi6pXhAMBhd8YCwPr2rN/nzj2Q0seGJ9\nzrTc6x5dy4yJI6ylYYzpNRYweljYGo37X3gDIPvzrY83k4iHpwuxgGGM6S19dVptvxW2RiOoJubQ\nnsrtKrRZVcaY3mYBo4dFWaORUuXmcxqy03IH1Dg2q8oY0+usS6qHheWOuqBxLA83teYNcJ85+Uib\nJWWM6TNsllQvKTVLyhhjekI5s6SsS6qXZHJHAazZ9C6A5ZIyxvRpneqSEpGXVLVqUnX0VbbWwhhT\nTTrVwrBg0XW2NasxptoUDRgiEhORZT1VmEOJbc1qjKk2RQOGqqaAtIgM6aHyHDJsa1ZjTLWJMoax\nB3hZRH6Huy8FAKr6+YqV6hBgW7MaY6pNlIDxC++P6WZhGWxteq0xpq8qGjBEJAb8g6pe1EPlOeT4\nU6DbrCljTF8WZQzjKG9PClNBNmvKGNPXRemS2gisEJEl5I5hfLtipToEBLueMrOmMhlrobwMtdaV\nZYyptCgB48/eHwc4rLLFOTSEdT3NmDii07OmrCvLGNMTIueSEpGBqrqvwuXpkmrIJbV9TxszvvkU\nBzoOBocBNQ5L55/Kr9a9xcJlLSRi0Sv+Qudbcf0Z1tIwxpTUrTvuicjJwA+BQcB4EZkKfFZV/7+u\nFfPQFNb1BHDWnc9SG48ByryZE7hw+vhIFX5Xu7KMMSaqKKlBvgN8DNgOoKprgJmVLFR/FrZg70BH\nmvaUsrstSVtSWfR0S5fO15ZKU5+IdUt5jTEmI1IuKVXdFHgoVYGyHBIyC/YymyMl4g61Mck5JuZI\n5BQh/vMNqHF/naLKnIXLWbJ6c7eX3xhz6Ioy6L1JRE4BVERqgC8Ar1S2WP2bf8FefSLGnIXLwbcl\n6962FOs278ymP49yvoZRgznrzmcBaEsppJTrHl3LjIkjrGvKGNMtorQwrgCuBMYAm4Fp3s+mCzL7\nYUx8z2HcOKch7/kFT6wvaw3G3vaUNwZykCUzNMZ0p5ItDFXdBthK7wqaMnoI9YkYe9sP9vSVO3Bt\nyQyNMZVmO+71AWOH1ZEKTG8ut7L3j2XU18ZIxB1unNNg3VHGmG5jAaMPCA6ED6hxOpW5du60Mdx4\ndgMdyTQ1jrBg6Xob+DbGdJtObdFqul9Y5tpybd/TxoIn1tOeUtpTbveWDXwbY7pLp1oYImJbtFZA\nZiC8s5W77eJnjKmkznZJfa5bS2EK2r6njTWb3o00Yyp0EV8yyc797Zb11hjTZZFzSVWDasglVY7O\nJBVcsnozX3p4NUlf3KiNCeKIJSU0xuTpllxSpbqdVPWlcgtmXFFSkfv3x8jkiYoyHjFj4ghijkPS\n19KwhXzGmO5QbND7W0WeU+CMbi7LISFqqyEsqaAjQvOWncycdETB87fu2E8i5tCWTOc9Z0kJjTFd\nUTBgqOrpPVmQQ0E5rYaw8Yh97Skuv7+Jm+ZMZsqYIaEtlLDXZZSztsM2ZDLGBJUc9BaRgSLy7yJy\nj/fzsSIyp/JF63/KmcWUWZtRG889vi2pfOWX67jo3heY8c2nctZZbN/TRvOWXVx6ytHUxg8mI6yN\nSVlrOx5bvZkZ33yKi+9dmfcexphDV5R1GD8CVgGneD9vBh4BllaqUP1Vuek75k4bw9CBCa74ySr2\ndeQmCN7TlrvOYnnLNq72DXbHHfjCrEnMnnIke9tTkVsKnR07Mcb0f1Gm1f6dqt4GdAB4u+5J8Ze4\nRORMEfmTiLSIyA0hz4uI3Ok9vzY40C4iMRH5HxHpF8GpMyu6Rw8ZULCLCdwWSvOWnVy3eE3OzKhk\nGhYua2FYfSJvbUexqbqdWctRztRfY0z1itLCaBeROtyBbkTk74CSNYOIxIBFwEeBVuBFEVmiqut9\nh80GjvX+TAfu8v7OyKRSHxyhnFWhnBXdj63enNNqCOMGEyEmDsFtSjL7avjfo9Sge7mtINtP3JhD\nR5QWxs3Ar4FxIvIg8AfgugivOxFoUdWNqtoOPAScGzjmXOB+db0ADBWRUQAiMhY4G7g32qVUD/+K\n7kJ359v3tOW1GgDijlAbl5wWyughA7KpQPxSac2p6P3dTbvbkhzoSHPdo2tz3rucVlCU8xlj+o+i\nLQwREeBV4H8DJ+F2RX3BS3leyhjAv1NfK7mth0LHjAHexN0a9jrgsBJlnAfMAxg/fnyEYvUdxe7O\nW3fsD201JOIOd198AkPqEowdVsfylm3MvvPZkMAC80+fmPNY1P2/w1pBYbOmbD9xYw4tRVsY6i4D\nf1JVt6vqE6q6NGKw6BJvFtY7qrqq1LGqeo+qNqpq48iRIytdtG5T6u7cTXme3xeVSiuTRw/J7sZ3\n3eK1dKRyV+sLEHMc7nlmI6d84w987w8b2L6nrazuJn8rqNCsqULn60imWNy0iZa3d3f68zHG9D1R\nuqReEpEPduLcm4Fxvp/Heo9FOWYGMFdE/oLblXWGiDzQiTL0WaUGl4cPquX286fin1VbExNuP//4\nnDv8mJM//0CBtqQbiNqSyrd+9xqnfOMpVrRsK9jdVKxrrFhgu/K0idTGD57vg0cN4/z/eIFrFq/l\nI//vGW567OVu/NSMMb0pyqD3dOAiEfkrsBf3BlZV9fgSr3sROFZEjsENAp8ELgwcswSYLyIPee+z\nU1XfBP7N+4OInAZco6oXR7uk6hDlbj/TNdS8ZRfgtiz8XT1jh9WRSkfLBdaWTHPt4rX84JJGls4/\nNWeqbaGuse172lj26jvEA0GpxnF4cOUbfP/pFi/oKfNmTuDkCYdz/n+8kHPs/c+/wSUnHc3E9xTt\nWTTGVIEoAeNjnTmxqiZFZD7wGyAG3KeqzSJyhff83cCTwFlAC7APuLQz71WNMoPL1wUq6mDf//BB\ntcycFN7V5rZCjufqR9Zku6UcIBaTvG4qcIPGFT9ZRRrltvOOZ+q4oQXXXew+kGTBE+uJieRsHQvQ\nnkqxaFkLbcmDr1n0dAuHDTgutJyrN71rAcOYfiDKnt5/7ezJVfVJ3KDgf+xu378VuLLEOZ4Gnu5s\nGfqycjdNCht4zpzj3mc3cu+zG0nEY7QlU8QdQqfjZhYAZhbjhQ1cx0S4del62gMnqK+NkUorV542\nkXue2ZiTr6rGcRhRoPzTvPEWY0x1sy1ae1nUTZMefOGvnPyNp0JTggD86Lm/0JGGve0pkml3Dcbn\nPjyB2rjDwEQs73yZ8ZLQrrFUmkQstxuqPhHj1nMms+L6M5g95UjaUvndaSf/3XAuOTl3ptolJ4+3\n1oUx/YQFjCrw4At/5Su/XEd7Ms2etlTewHPYAHoiFuPMKaN47oYzuPviE6iN5waAzHhJ2LqLm8+Z\nTDIwNpJS5fTjjmB5yzbmLFyOePuoJGIOtXGHG89uoHXHfr4waxK//+JM7jj/eH7/xZl89dz3VfCT\nMcb0JNvTu4/bvqeNWx9vznvcv4q70AB6fSJG6479TB49hE98cBz3P/9G9vkLGsfmdWv5u7sOGxDP\nG18BsuMdGe2pNDGBWx5vZkA8lj32/MZxGGP6FwsYfVzrjv3UxJy8ldwdqYOruMMG0C9oHMuchcup\ncdzXBidTPdzUyhdmTcoGjeGDaksu3luz6d288Q6AlEIqpXSkkkD0ZIWWQt2Y6mIBo49zF/Dlz3i6\n+ZyGghV8fSLGnIXLc2Y+BUVZkR0MIsX22ij33GFTecuZAFBJFsiMCWcBo4/ztx5iInSk0tx8zmQu\nmn5U6LEAy159h5gUTygcXPMRpZIcPqiWG89u4JbHm0On7RY6d1DYVN6rH1mDI+7YSzBNSk9W4JZM\n0ZjCLGBUgajTbzOVXdzJXzsRd9x0IYlY7pjEM6+9w/N/3s59K/6S81xYJfnY6s0seGI9iQLrPDLT\nbkulbA+byps5X1vS7da6dvFahg5MsOlv+1jwxPoeqcBtLxBjirOAUSWC3UNB/srOrz4RI6Wa1+Wz\nvGUbJ/3fP+RU/Jl1FWGVZKHz+53Z8B6+fHZDyco1StdWWzLNZ+9vYr9XpkwFfu3i7q/AMy2Ynfs7\nLJmiMUVYwKhC/i4aoGBlNzDhcOvcyZx+3BE5g9tu6vT8pIUZYZVkWKsgaMmaLXz57Ia8sjZv2QkI\nk0cPzgY+/yB9eypNKp3OW2i4P2TlYVsyzU9XvsFVs44t+hkFyxDWOtu+p40HV77Bwqc2EI85pNJK\nqoy9QIw51FjAqDL+Pvb9HUlUYUBNjGRIZbevPU1bKp13d1woaWFGWCUZpVWQiMdyAs1jqzdzjS9t\nSdyBb18wjbnTxuR1s/163Vvc+ngzMUfYX6QVA7Bw2QYunD4+8v7kYWMSj63ezHWL12ZbVZlZaDFH\nqI3njqVY68IYly3cqyLBzLHJtDuldW97KidNh9+CpevzMtAWS1pYGw/fMCnTKgguAPRL+gJNWCsm\nmYZrF6/Jliezyn15yzZ3bCTu3uXHSmwAHC+xZWxGoUy7LW/v5vpH14Z+Zqm08q2PT+OBy6az4voz\n+tWAt22la7rKAkYVCVvR7Rd3HGoCT2ta8yrXTNLCGl/NHBO4+qOTeO6GwpXk3Glj+MEljQyIh5dh\n/unHZgPNgyvfKBDExOuicvkr9T1tKdpTiuPbVbA2LgTfbm97inW+cxQS9nk5Iixv2Vr0cxxcVxMp\nXUs1KbSniTHlsC6pKlKqWyiZSpMMNBzaUkp9SC6pg6nTc8cXwvjHACaPHkJY2yQREy6cPj57/KJl\nG0LP1ZZMc/n9Tdx+/lTmThsTOjYyIB5j0UXvz+4q+Ot1b/GVX67LOc+Cpes5c/KRRSv1sM9rX3uK\nrz/5Ckp4MybuwOTRxbeQr7Z1Gjb7y3QXa2FUkVLdQpfPnMCAQBNjQI2TN8XWf76Zk45g5qSRRafq\n+u9MV7RsC22dXHXGwUHo1h37ScTyg1RGW1KzubAKpTXJ7Co4fFAt4w6voy5wXQ7i7ROSL9P1Anif\nV+5r21OgqtTGneznVeO1ar59wbSSCw6r7U691GZdxkRlAaPKzJ02hudumMXVH51EbdyhvjZGIu7w\ntX+cwmUfmpA3NpFKa6dn+RQaA5gxcQS3nDOZmphQ4wgphYVPbchWoFEGyP0zsQrtAghuBX35/U15\nA+H7OlJc9uMX8yrsYIUO8INLGhlYkxvA6mri/OCSRn4+72R+/8WZLP7cKTx3w6yiYxaldh/sq8rZ\nmteYYqxLqgoNH1TLVbOO5cLp43O6RrbvaUMDaUSCP5cjrLuoxnFo3rKLBU+sz13DkVJIuS2HFdef\nUXLarL/CKrQwMVNBtwX72TztKeVLD6/Odq0U6npZOv9U0oGONLcVMzj7ur3tB++2C3U5hU4tVnh8\nzRbOmTq6z3bvRN2sy5hSLGBUseBivtYd+6mribO7LZl9rK4mHrrwLKxSDD5Wn3A3Y/Jz71S14JqM\nTMshGARWtGwrWmH5ryWzduPl1p2EDpj4JNPQvGUXMyeNpHXHfjTYwkopW3YeKFhhBqfdXtA4loeb\nWkNXlofdqR9Iprnl8fX8nyfWZ6cM90XlbtblV21jNqZyLGBUseAXOWrXQ9jaBIXQitNxBFJKbUwQ\nR7jtvOOZPHpIwS4n//v5g0A56U38azeicY+tT8Tclk5OeZTLfvwid3x8KiuuPyOvRRZskWRSwIcN\nDmfu1K9dvCav1ZNMwzWPrGbowJrs3ut9raItlS0gjOXWMn4WMKpUoS9yqa6HsEry2sVrAMnZo9u/\ndwZACnjon0+k8ZjhANn3ATjQkc4JKJ2tHEutQE/EIKWSM05TExMmjx4CuNNtB9Q4eelL2n1dZVO9\n7WK372lj2avvEC+ygBHyV73PnTaGoQNrmHf/Kg4kg+8Dn/3JKhSKtlSqhc2uMkEWMKpQsS/y3Glj\naBg1mNWb3mXauKF526OG7+HtUGCWaVYypVz4wz9yx/nH563Urk/E2NueipQYsVgFWmoF+r98aAJ/\nf+Rgrl28lpjjBo7bzz8YoIoN4vor/kxZYpKfpDEorIVWaGoxkB2cL9ZSiaIvtE4KjWFZbq1DlwWM\nKlTsi7y8ZVvRijms2yqladASEQNoT6a55pE1NIwazLD6ROQKLSzAXbN4LQ2jBucEtGIr0AHuW/46\nz90wi+duOCMnUG3f0xboMspfxZ2p+AsmafQy7Ya1DMJWvd9+/vFcXUbXWTkVbWe6gSoRYGx2lQmy\ngFGFim3Jep3Xv17ozrbQjJnMsZlZTR857gh++8rbeRVie0r52HeewXEkZ0vWYhVaWIBrT6Y5685n\nuePjU7OvLVURx2NOtlL879e2smjZhrz9MzItn5+ufIOFgecL7RpYn4hx6zkHkzR+YdakkpVv5n0e\n+uMbfOd3r9FRIm4cSKYiVbSd6Qaq1DhDNcyu6gstsUOJBYwqVOiL/OS6t/IGY8PubAsNQM+YOIIH\nV77BomUbeGbDNgQl7gjJ4MyjwJasmVaHv7Xg/yIXWpeRGVvwV4buGEGCy3/8Yt4AdnsyzcqN27ng\nd69lWxCZ/TOCg9Nh044hPNgm0+m8jL5RKp/lLdu486mW0GAh5E7wijq9uXXH/rzNr4q1Tio9ztCV\n2VWVZgPyPc8W7lWpudPGsOL6M7JJ8mZMHMGiZS15x7Wnwu9sM4n/ghXA959uoS2p7G5L4nbva86q\n7jDtKeVj330mu4gubHX4becdTyIkB1XYiuPJowcjYWMZqnz9V6+G5qiKORKaMyt4jZlg6y9KWmFF\ny7a8cwaT9WV+bnl7N8+89o7XmsstS9yBz314AoNqc+/FMtObw/jfZ93mnXnjKmG7I2aOD1vFHRNh\n2avvdNuCwkL/V3pTtS6irHbWwqhi/jvhNZveJRFz8iowf0LAUsK6jupq4px3whj+8/m/Fn1tKu1u\nbtQwanDoHe+K68/gyatO5aw7n6Xd13Io1Cd+5WkTWbhsAzFH2Nee9o4t/P5721Ks27wzOwuqmIZR\ngxE52AZTwR3RAAAbAklEQVToCLR0MvtkLFrWkt2FMDO2oWmlLaUkYk7OdWSICGMPH0h7Klrfv/8u\nuT2VImwI50ZvU6qD+3e8RtyJkdI0N50zOa/FtLc9xS2PN/Pvj63rtfGPSrMB+d5hAaOfCOtqqY07\nOQkBS1UKYedoT6X42YubIpUh5girQ8YIMl/kqeOGcsfHpxbtE/dXoCD8r2ljeGz1lpKzmQAWPLGe\nM6cUT0j42OrNXBsydTdTxl+veytnz/JMAA5OMw4GhIyOlHLTY+tQ39M1sfDpxmHdSUH1tTGmjBlS\ncP+Omx9bx61zp7DgifU5s772tLl/99b4R6V1ZUC+GgNkX2EBo58oNkAZtVIIO8eVp03knmc25rRc\nBiYc2pP5O+Sl0sq0cUOLfpGL9YmHVaCPvrSZsOXedTUx9nfkBpFSff3NW3Zx3eK1tId0aXWk3fGR\nr//q1bznyhWMJY6440NBUXYxTKXdbMOF9u9IpmHc4QNZcf0ZLHv1HW55vDkbLOBgKpchdTWRPu9M\ngMmUr7sr1e6qrMP+r954dkO2268vB8hqDlgWMPqRsMq43EHR4DkAFj2dOzaSVrh17hRuXrIuGzRq\nYsLt5x/PxPccVnJmTaFB5bAKNBFzmDdzAouebsmpGMYdXsfl9zflDPK3p1Ls3N+enWabkakkHG9x\nYlAiJtw4p4FblzRH+Zhz1MYd0ul00e6yRCwWGsjC7pLjDsQcJ9sVdtt5x7O3PVUisCjDB9Vy+nFH\n8O+P5aaB39+R5PL7m3LOl6kgC3XrPLjyDb7v+7y7q1Lt7sra/3913eadLHhifdFzl/ou9ERF3hcC\nVldYwOhnwvJLldvXGzxHWACYO20MZ0450ksxrtl0GFDezJpSs6k60mkunD4+dMbT7ecf7N7a35Ek\nlVau+MlLpDSd3W+j0LqLjETc4cmrTnUr5ZiT7erxq407fOKDuWMYmbTot513PLsPJHOCZ1ChrpJC\nrcKwoF8oFYt/pfvwQbVc0Dg2p/tMvSCZCZT+CrJQF+SiZS05q/67Y9ZVpWZzZV77iXueL3nurqxf\n6g79YeW8BYx+rjsWXxUKAMMH1TJz0sjQ10SZmhp2t1WsdRI838FNoHZx6Y/+SEohmXYr/C/+fDUN\nowYXvDsfmIiRVuW289xW0fY9baRCpr5+7rQJXHbqhJz1GfWJGFt2HgCUTX/bz4In1lNogXptvHi6\nlGKfrf+zzHwu/kF3EbhpzsFuGICHm1pzzh9cCOm/WYjaBel/TWfvwpu37MQpY7pwMcEyhGYvcNyZ\nYv7p0sXWL/VERd4fBuotYPRz3bX4qjOJ64opdLe14voz8pIElirXc3/eRnDCUkph9nef4Za5U0Lv\nzj998lFc9qEJoQsaYyJ0pNJc8w/vZfqE4Tnv5R8TijuSM14Q9LkPT8h5j8x1hwWHTGW8ZtO7odcd\nlool2A1z5WkTS46JBG8Wwrog73wqd7fEA8kU9YkYd/5hQ+hiyVLcAfv8hI2dWTUedpMxY+KI/Jli\nbSluXpI7U2z4oFpuPLuBWx9vpibmkPJuGMJuKipRkRdq0YV1o/ZV0pX9EvqaxsZGbWpq6u1i9El9\nbaBtzaZ3ufjelTmp2A+rjfPAZdMjTY3NXE99IsbsO58tmKJjQI3Dlz4yKW8wO9MVlVls6D/f3vYU\nL2zczrd+9xqJmLtwMVPpbN/TxoxvPlWwiyujvjbGTy87ibHD6rKfe7Fuj0IVYaHfWVg53J0FNadi\nDhsTKbVJ1PSv/z6ne80RiDuSN414QI3DiuvPKDjJIPN5zlm4PO/zqo073H5+ed0+YdecKUMmfX7M\nEfYGgnjmmF+ve8sLFkJHGm4+p4GLph9V9LxRu1OjfqeWrN6c040qEj1jQqWIyCpVbYxyrLUwDhHd\n3ULoqq50lfkr17ZUumjexBrH4fD6RDYQZLQn08z+7jN8ftYkDq9P5Nypz506ioebNnvHucdncl+V\nHoB2pdLKus07+cQ9z+essehIHUzbcu3igzOSgq2tqx9ZgyMUvJsvb4LAQILjTIWE7amSVkLXnBS6\nC8/5/SRTbop8n4E1Me7+1AeYPHpwaIuqnA2sgvuvLHv1HW5e0pzzu65xHO59diN3/fdG4OC1+PeF\nL7cV7k9g2ZFKc/M5k7nopKOKfraQ243qTtpIZzMmVMN4hgUM0ys621UWZe2CX3sqxYCaGMmQbqmO\nNHzrd69lf86cLxMscs7j5b66OWShHLgzrdp9g+E3zmlgwdL1RcvZlkzz05VvMHPSyLyK8OA6kPDK\nJMoEgSgzh4KibK/rf79ggA/9/QSCTRpl09/2Me8nTXllCy5knH+6m+Kl0CB9cP+VsJli7akUP1z+\nel75YyLZgFfuRI3gRIqv/HIdCFw0vXTQGD6oliF1NXkLbathPMNSg5heE0xvEqU5HpYKY0CNQyIm\n1CdixByIidu9FXfcu+N/+8XLpNV9vCvaU8qCJ9Zz45yGnD3Iv/aPU3jkilP4/Rdn8vN5J7Pi+jOY\nMnpIXjnDLFy2gfpErGQlHUz3MXxQLRd8YGzOMRc0js22JMcOq2PBE+vLTp2RCeSZ66uNO4RkdCk4\nmB82uF0bExLxg5/XjXMa8sp27eI1LF2zhesWr8k+3pZUvvW71zjlG+5e8cGyBfd/Dyv/gBqH+acf\nG5qWpiOVG/CipkAJy/cFcOvj6/PSyBT6vMcOq8ubkVcNmYAr2sIQkTOB7wIx4F5V/UbgefGePwvY\nB3xGVV8SkXHA/cB7cFdt3aOq361kWU3P8nc7RBmzyCh0B/zk5z/Elp37AWH0kAFs2Xkgr8lfG3dw\nSqyZKKXGcZgyekjJgfkde9vztrcNJiQEt8tpb3uKG+c08JX/WkchwXQfMyaO4OFVuTOiHm5q5Quz\nJmVnDgU3hwqbORSm2Pa67ak080+fmL3r9ys0uK0i/PRfTqQmHsuO6QRbVG1J5ZpH8l/rPpfO2e+l\nVEsgyloigJvPmRypKyxo7LA6OkJW+tfEJPIU3eUt23LSwMQd+lwm4DAVCxgiEgMWAR8FWoEXRWSJ\nqq73HTYbONb7Mx24y/s7CVztBY/DgFUi8rvAa02V6sripUJdWc1v7so555WnTcxr8idiDvNOd3NU\nhVVM9YkYKT24J4YD7OsI7wIpNiaUXSjobW8bc/8iEZeiM4WC4ywAdTVOdlMmf7qPez71gaIze9Zt\n3pk3g2tvW4qbHltH+jHK+sxnTBzBPZ9qpNg4SKabJuxzFVUuvu+P3Hbe8UwdN5TXt+5hT3sy77jg\nDoZ+wenAQNFV3YXWEsUcoSOl2QHvjFL/J4PB5OZzJrvdUD7+VfnFpuhmPiv/RI2Y44RmA+hrKtnC\nOBFoUdWNACLyEHAu4K/0zwXuV3eq1gsiMlRERqnqm8CbAKq6W0ReAcYEXmuqUHcsXgq7g8zMcsmc\nc+GyDQS3EfT38bv7ZRxMLnjjnAamjB6SrRAyay7WbdnJgqXrI4+zhPVvZ+oFf2Wa2bDJf77gOpDa\nuHD9me/ljt++lpfuA6RggsPte9r46tLwr0omABb7zP2V54FkClWlriZeNLgXS3PSllLwEjwu37CV\nh1fljxGV4g+sUW44ghV8uSlp/J9P2PtddNJRIHDrkmZijpNd0xNlim6hCQt9ffwCKhswxgD+rHWt\nuK2HUseMwQsWACJyNPB+YGXYm4jIPGAewPjx47tYZFNpYV8WB6F5y66CiwDD+O8gwzZFSsRieTOG\n/JVzof0yguefOm4oZ04+MvL0ySj5oYIbNmXez90tcA0xcUim3QHfUyeO5Bu//lPO6zvSaZau3ZLT\nenLkYJfGnX/YEJoCxc8/4OtXaFJBZtZUoUATZbDcEYkULGrjDv8842juW/EX4jG3RXDjnIMZe/N2\nbwzsx1IooBRqFYZvW3wwXX6hYDKoNo6Iu9dJOp1m94FkpNl/1byTYZ8e9BaRQcCjwL+q6q6wY1T1\nHlVtVNXGkSOjVzimd4R9WfZ1pLj8/qbsfhrdcc5Ma6LYoHrUQc7gccUGNKNUnCnV0HEEt30hdKTT\ntKfcfvc5C5dzQePYnEHcL310Ut6K7rTCWzsPsH1PG4uW5S68CxMc8M0Im1TgF7Z/ScaVp02kNi4F\nB8vD+v396mtjDKhx12dcP/vvuWlOAx3JNDWOsGDpepas3kzrjv1oYPV6e0o563vLWbJ6c6f2yQj7\nne1tT7Fuy06at+zCIX+FevOWndkuuANJd1zsK79cx6+b3+rUwHw1jF9AZVsYm4Fxvp/Heo9FOkZE\nanCDxYOq+osKltP0IP+dtL+Lxj+w2ZlV6OWkFOmKUt0hYWUJ7hMellX14BjAwYor0631cFMrS+e7\n+a7GDqtj2avvhJbt9t/+ieNGDSYRi2Wn4xYSHPDNqE/EaCtSsYfdCQdT0s+bOYHZU47kV+veytkm\nN2wBZcaXZx/H9AnDc/JnfXVpM+0pzc4muuaRNdx10Ql5OzGCO+3ZHdtp7NSq7UtPOTq7TiP7GT22\njpiTv8eMG1yk4Eyp528ona2gL+9kWEwlA8aLwLEicgxuEPgkcGHgmCXAfG98YzqwU1Xf9GZP/RB4\nRVW/XcEyml7gbsNawxUPvMS+wAKrzvbj9sQXMKw75NrFaxk6MMHk0YOz7xlWluyYSIG1EcW6smoc\nh73tqexssmc3bA0tnzsrSvPulmPi7oee6d4JDvhmZCr+VCBgCDCoNh46hhP2mXzn969lx4cyASQz\nq2p16w6efPntnPPX18aYPmF4zmy5B1e+kTeA3p5SPvvAKneldoGFhLv2d+TNTgvbsTC4+j7YigA3\ndXxw/U5mOvHk0YM50JGfFiYzUypqy7VaAkVGxQKGqiZFZD7wG9xptfeparOIXOE9fzfwJO6U2hbc\nabWXei+fAXwKeFlEVnuPfVlVn6xUeU3Pmjx6CGktPGOoMyr9BQyfDprmip+sIo3mtDaCZcn8u1BW\n1WJ39v7PpeXt3Ty25s3Q4/Z3pNm0Y3+kDLhBxbL6OgL/93+/j8F18Wxm3GKfSUoh5cuQu+jpluxG\nXgvOfR9/eGVrzl17Kq15FXrYdsOAl7IkPA3MgWSKqx9ZnZ2dVhsTxHEreHDHuvwBuz2VJpXO39el\nkIGJGHdffAIzJx3B9j1tOI6QCgSuZIGuvv6iouswvAr+ycBjd/v+rcCVIa9bTnCKi+lXOrvSuzcV\nGp/Y1xFtd7tS+0+IF0Djjlsx+lOoZ865etO7Rcu4YOn6ggkci322xVo4KYUvPrw6NOeRuwCteI0b\nnBJ7+/nFf++tO/aHbjfsl4gJjiMc6EhTGxMQIZVO0+btQw/u+o8n5p9K85u7mPHNp3KSRUbJEhBz\nJCfbb1o1GzBbd+zPTtH1C9sSua/lcesKSw1iek219eP6g5wjktOdBqW71MKzlaZZFFgXIiIs/uz0\n7EI3//mOHj6waBkzA7JD6hJlfaalBus7Uhqa82j4oFpmHXcET657q/BrC2TIzeylMnpIXU5OqSgT\nBy48cTz/eMLY7NqVnfs7uPLBl3JyYNXGHLbsPFB0P5RiHIEU4YG7I5kKPecxI+qzmWfD9oavtg2T\ngixgmF5Vbf24Byu7nXk7/pXqUgtrVR3cf+JgRdeRUp7f+DeumnVs3jlq4rFsCyTMgWTK22GvvAyo\nhSYjhAnuj/GHAoPwYWtNMjJjB0C2lZDpPpo7bUzOQrtg9lmAn724iatmHbybD9tkyv1Zi05zjjvu\ndN+w5IqZ1kM6rTz5+Q/lTNu9dvHa0PNd9+ha0t7iz5+/uCn7WYZtYFWNLGAYU6bhg2qZOemInB3/\nonaphS06XBjSX79w2YbQ9Btjh9URjzl5g7H1tTGSKc12yxRKWhilbD9d+Qbfe6qlYFeTPzAW6j76\n3IcncOaUUQVTswfv+v2L+4IpQH697s28GUzBhW6Fujgnjx5StLXyhVmTmD3lSH604i88suoN4k4s\n28WYURs/uAI/U/awfeGBbKvTv+uhXzUkGCzGAoYxndTZLrVgq2r+6RNzsuZC4X3AwyrGG89uYMqY\nIaHdMoUqqEL96sMH1XLVrGOZOm4oV/xkVV7lmYjnrhkI6z6qjTtFN44qNSPMP96R6aK6b8VfcoKS\nP2hlzj1j4ojQsRu35bQ2L6jVxh32tic5+3vLvR0MHT59ylFF3yvKwsxiqmWBXiEWMIzpgu7oUrtw\n+vi8/FbFKpZCgapQt0yxdROFuq0mjx5MOjAbKRGTnE2nINrkheD73TinoeBdf1h5iw2UZxIexsTJ\n2cs97PNy08G460IOJFMkU2nu9loumQDxo+f+wk1eNt2w6wkLkDWO0JEu3o0HboDq6xM7SrEd94zp\nA/w7sXVlcLTUecrZXa6cMhVqsYS9XyLucM0/TOLbXqsqbAwjynuE7Q4Yd2Dllz9SsFLevqctdPwp\nI7Pro3+nxFKfy5WnTWThUxtyFhRmxkZq47G8fT36Gttxz5gq010zxkqdp9iudcFjyylTOXma2pNp\n7vjNn7j5nMlMGTMkO9Op3Pdo3rIrb/A/maZoXrLhg2oZUpcouBo+SjbigunT/QEj5uSszu+LgaIz\nLGAY00d0pXsrePddbGrvgcBK6APJVMHur652uRWaIpvZjKrUvtnFFeodKd5rUqhM5XQZBT+XvHGl\nOQ39LliABQxjql65+4sEu6Er2S2dGeO4ZnH+zKKuzhiaPHpIXpqQmpjkrUYPC6b+Cr47uoz8rY51\nm/NT4lfz2gs/CxjGVLFy9xdp3bGfupp4zkyqupp4Rad6zp02hoZRgznrzmdz1jt0RyqYb318Ktcu\nXptdlX37+cUH3DOVdyUWjZZK/9IfWhoWMIypYuWMSUDv7cUw8T2HccfHy1+3UkpXNkaqxKLRcn8f\n1cYChjFVrNwA0Js5vCqVCqacAfdKV97VvDlSFBYwjKlinQkAvZnDqydTwfRG5V2NSTXLYeswjOkH\n+lNG1O7UXetbylVNvw9bh2HMIabakjj2lN5qTfXX34cFDGNMv9ZfK+/eUHi3d2OMMcbHAoYxxphI\nLGAYY4yJxAKGMcaYSCxgGGOMicQChjHGmEgsYBhjjInEAoYxxphILGAYY4yJxAKGMcaYSCxgGGOM\nicQChjHGmEgsYBhjjInEAoYxxphILGAYY4yJxAKGMcaYSCxgGGOMicQChjHGmEgsYBhjjImkogFD\nRM4UkT+JSIuI3BDyvIjInd7za0XkhKivNcYY07MqFjBEJAYsAmYDDcA/iUhD4LDZwLHen3nAXWW8\n1hhjTA+qZAvjRKBFVTeqajvwEHBu4JhzgfvV9QIwVERGRXytMcaYHlTJgDEG2OT7udV7LMoxUV4L\ngIjME5EmEWnaunVrlwttjDEmXNUPeqvqParaqKqNI0eO7O3iGGNMvxWv4Lk3A+N8P4/1HotyTE2E\n1xpjjOlBlWxhvAgcKyLHiEgC+CSwJHDMEuASb7bUScBOVX0z4muNMcb0oIq1MFQ1KSLzgd8AMeA+\nVW0WkSu85+8GngTOAlqAfcClxV5bqbIaY4wpTVS1t8vQbRobG7Wpqam3i2GMMVVDRFapamOkY/tT\nwBCRrcBfK3T6EcC2Cp27J/WX64D+cy395Tqg/1zLoXQdR6lqpBlD/SpgVJKINEWNwn1Zf7kO6D/X\n0l+uA/rPtdh1hKv6abXGGGN6hgUMY4wxkVjAiO6e3i5AN+kv1wH951r6y3VA/7kWu44QNoZhjDEm\nEmthGGOMicQChjHGmEgO+YDRnzZ56uy1iMg4EVkmIutFpFlEvtDzpc8pZ6d/J97zMRH5HxFZ2nOl\nDtfF/19DRWSxiLwqIq+IyMk9W/qccnblOr7o/b9aJyI/E5EBPVv6nHKWuo7jROR5EWkTkWvKeW1P\n6+y1dOn7rqqH7B/ctCN/BiYACWAN0BA45izgV4AAJwEro762iq5lFHCC9+/DgNd661q6ch2+578E\n/BRYWq3/v7znfgxc5v07AQyttuvA3ZbgdaDO+/lh4DN9+DqOAD4IfA24ppzXVtG1dPr7fqi3MPrT\nJk+dvhZVfVNVXwJQ1d3AKxTYf6QHdOV3goiMBc4G7u3JQhfQ6WsRkSHATOCHAKrarqrv9mThfbr0\nO8HNWVcnInFgILClpwoeUPI6VPUdVX0R6Cj3tT2s09fSle/7oR4wemSTpx7SlWvJEpGjgfcDK7u9\nhNF09Tq+A1wHpCtVwDJ05VqOAbYCP/K61+4VkfpKFraITl+Hqm4G7gDeAN7EzUj92wqWtZiufGer\n8fteUrnf90M9YBgfERkEPAr8q6ru6u3ylEtE5gDvqOqq3i5LN4gDJwB3qer7gb1Ar/ebl0tEhuHe\n+R4DjAbqReTi3i2Vgc593w/1gNGVTZ6ivLYndeVaEJEa3P88D6rqLypYzlK6ch0zgLki8hfcJvoZ\nIvJA5YpaUleupRVoVdXMnd9i3ADSG7pyHR8BXlfVraraAfwCOKWCZS2mK9/Zavy+F9Tp73tvDdr0\nhT+4d3Ebce9+MgNHkwPHnE3uYN4fo762iq5FgPuB71Tz7yRwzGn0/qB3l64FeBZ4r/fvW4Dbq+06\ngOlAM+7YheAO5F/VV6/Dd+wt5A4UV933vci1dPr73isX25f+4M7ueA13xsFXvMeuAK7wfbiLvOdf\nBhqLvbYarwU4FVBgLbDa+3NWtV1H4Byn0csBoxv+f00Dmrzfyy+BYVV6HbcCrwLrgJ8AtX34Oo7E\nbd3tAt71/j240Gv7+P+t0GvpyvfdUoMYY4yJ5FAfwzDGGBORBQxjjDGRWMAwxhgTiQUMY4wxkVjA\nMMYYE4kFDGOMMZFYwDDGGBOJBQxjyiQiR3t7VPyniLwmIg+KyEdEZIWIbBCRE0WkXkTuE5E/eskD\nz/W99lkRecn7c4r3+Gki8rRv/4sHRUR690qNyWUL94wpk5fhswU3y2cz8CJuaoZ/AeYClwLrgfWq\n+oCIDAX+6B2vQFpVD4jIscDPVLVRRE4DHgMm46b/XgFcq6rLe/DSjCkq3tsFMKZKva6qLwOISDPw\nB1VVEXkZOBo3Gdxc305nA4DxuMFgoYhMA1LAJN85/6iqrd45V3vnsYBh+gwLGMZ0Tpvv32nfz2nc\n71UKOE9V/+R/kYjcArwNTMXtEj5Q4Jwp7Ptp+hgbwzCmMn4DXJUZhxCR93uPDwHeVNU08CncrTaN\nqQoWMIypjAVADbDW67Ja4D3+feDTIrIGOA53YyRjqoINehtjjInEWhjGGGMisYBhjDEmEgsYxhhj\nIrGAYYwxJhILGMYYYyKxgGGMMSYSCxjGGGMi+f8B+AR1Jxki6VgAAAAASUVORK5CYII=\n",
       "text/plain": [
-       "<matplotlib.figure.Figure at 0x7f7d7ddf7d68>"
+       "<matplotlib.figure.Figure at 0x7f6eee4d91d0>"
       ]
      },
      "metadata": {},
@@ -2091,14 +2100,12 @@
   {
    "cell_type": "code",
    "execution_count": 35,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x7f7d7dc8d630>"
+       "<matplotlib.legend.Legend at 0x7f6eee44a5c0>"
       ]
      },
      "execution_count": 35,
@@ -2107,9 +2114,9 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiAAAAGHCAYAAACJeOnXAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAAPYQAAD2EBqD+naQAAIABJREFUeJzs3Xl8VNX9//HXJ2EJYRWiiGBYZBcRQVFRFEEFtSqtW6MI\notS6FPyh1dZqVWjdv4ptLda2VFwgrVJFURAFFDcqSEBQQ2SPshp2EsKSnN8fd8BJSEIymZk7M3k/\nH4/7CDn3zr2fuQTynnvPPcecc4iIiIhEU5LfBYiIiEjNowAiIiIiUacAIiIiIlGnACIiIiJRpwAi\nIiIiUacAIiIiIlGnACIiIiJRpwAiIiIiUacAIiIiIlGnACIiEWFmD5lZsd91iEhsUgARiSIzO8nM\nppjZGjPbY2bfm9l7ZvarCB4zw8zuKKO9hZk9aGbdI3RoB/gSQMzsBTMrDloKzSzHzMaYWd1q7Pde\nM7s8nLWK1FSmuWBEosPM+gBzgLXAi8BG4HjgDOAE51zHCB13GnCic65dqfZewALgBufcSxE4bhJQ\nyzm3L9z7rsSxXwCuAW4CDGgMXA5cCExyzl0f4n53Aa85524MV60iNVUtvwsQqUHuA7YDpzrndgWv\nMLM0H+qxiOzULNU5V+CcKwaiHj6CHHDOZQZ9/5yZfQZkmNmdzrkf/CpMRHQLRiSa2gFflw4fAM65\nvNJtZjbEzD43s3wz22pmc83s/KD1l5nZ22a2LnCLYYWZ3R+48nBwmw+AS4DWQbcjVpnZucB8vNsk\nEwPtRWY2NOi1p5vZu2a2PVDDh4GrOME1PhR4bRczm2xmW4GPg9eV2r7YzP5sZpeb2dJA3V+Z2cAy\n3n8/M/sicKtquZndHIZ+JZ/gBa/SV4N+bWafmlmemRUEjntF6dqBVOCGoHP5r6D1x5nZv8xsY9D7\nGl7G+xoZWHfw73WBmf28Gu9JJC7pCohI9KwFzjCzE51zX1e0oZk9CDwIfAr8Hu9KwulAf2BWYLMb\ngF3AU8DuwLqxQEPgN4Ft/oh3+6El8P/wfvnuBr4BHghs/zyB0AB8Fjh+f2A68AXwEF5fjuHAHDM7\n2zn3RWD7g/dwXwO+Be7lxysrLmh9sL7Az4DxgfpHAVPMLN05ty1w/FOAGcD6wPuvFfiaV84+K6tt\n4Ou2Uu2jgDeBV4A6wM+BV83sJ865GYFthgATgM+BvwfaVgbqPSbQXgT8OVDnRcAEM2vonPtzYLtf\nAH8CXgWeAVKA7nh/t/+uxvsSiT/OOS1atERhAc7HCxL78YLFY8AFeP0kgrc7ATiA19egov3VLaPt\nObxf6rWD2qYBq8rYthdesBhaxroc4J3Sx8P7hftuUNuDgX28XMY+HgSKSrUVA3uANkFtJwXabwtq\neyvwPpoHtbULnL+i0scq49gvADuBZoGlHXAXXkBYfKRzCSQDS4D3S7XvAv5Vxuv/CXwPNCnVPhnY\nenD/wBvAEr9/FrVoiYVFt2BEosQ5Nws4E++TdnfgbmAmsM7MLg3a9Kd4VxHGHmF/ew/+2cwamFkz\nvFsMqUDnUOs0sx5AByDTzJodXPCurMwGzildCt5VlMp63zm35tCLnVuKFxbaBY6fBAwApjrnNgVt\ntwrvqkhlNQB+CCwrgCfxzs/g0huWOpdNgKPwrgr1rOSxfoYX9JJLnbP3gCZB+9kOtDKzU6vwPkQS\nkm7BiESRc24hcKWZ1QJOxgsbo4HXzKyHc24Z3i/iYiC7on2ZWVfgYeA8oFHwYfBuu4SqQ+BreU/G\nFJtZY+fcjqC21VXY/3dltG3D+6UPcAxQDy80lFZWW3n2AD/BC3OtgHsC+95TekMz+wleJ+EeeFd6\nDjpifxMzOxovZNwM/LKMTVzguACP44Wr+Wa2Ai+gTHbOfVa5tySSOBRARHzgnDsALAQWmtlyvFsG\nVwF/qMzrzawx8BHeJ+r7gVVAId5tlceoXgfzg6+9C/iynG12l/r+sF/qFSgqpz3cT+UUOec+OLRz\ns/eAZXhXawYHtffFuyr1IXArsAHvNtmNQEYljnPwfL2C93h1WZYAOOeWmVknvGA0CO/KyW1mNsY5\nN6bS70wkASiAiPjvYIfOFoGvK/F+qXUl8IurDP3wrhhc7pz79GCjmZ1Qxrblddosr31l4Osu59yc\ncraJpM14Yap9Ges6lNFWKc65jWY2DnjAzHo75+YHVv0ML0ANDARDAMzsprJ2U0bbD3h9Q5Irc76c\nc3vwOu2+FrgS9gZwn5k96nwYM0XEL+oDIhIlZtavnFWXBL4uC3ydiveL7gEzK++qQBHeFYPgR27r\nALeVsW0+Zd+SyQ98bVKqfSFeCPm1mdUv/aJIj1nivPFDZgGDzezYoOO2x7tqUB1/wQsbvw1qK8I7\n34c+kJlZG7yBy0rLp9T5CtT7X+AKMzux9AuCz5eZNS312gN4t9oMqF2ldyIS53QFRCR6/mJmqXif\neJfhPe55FnA13i2UiQDOuZVm9jDerZWPzex1YC9wGrDOOXcf3uOy24CXzOzPgf0PoexP6AuBq83s\nKbyRT3c7597GCxnbgVvMbDfeL9fPnXNrzGwE3mO4X5s3qug6vEd5zwN2UPYv53B6CG/U0s/M7Dm8\n/6tuB5bi9dMIiXNua+D93GpmnZxzOcA7wJ3ATDObDDTHC3LL8ToLB1sInG9mo/EeEV4duJLyW7yr\nUp+b2T/wHnNuindLrD9wMIS8Z2Yb8Z6C2oR3let24G3nXD4iNYnfj+Fo0VJTFrxfqP8Avsb7Jb4H\n73HXcUBaGdsPw7s9U4A3rsQcoH/Q+jPwfpHtxuvY+Qjeo75FwDlB26UCLwNbAutWBa37Cd4v9b2B\ndUOD1nXHu1WwOVDDKiAT6Be0zYOB1zUto/4H8UYjDW4rAv5UxrargAml2voF3v8evDFGhuM9yZJf\niXP9ArCjnHVt8R7n/VdQ2w14obAg8PczlLIfI+4IfBA450Wl9pGGNwbIGrxbSOvwOpneGLTNiMDr\nD57Tb4FHgQZ+/3xq0RLtRXPBiEjcMLM3gK7OuU5+1yIi1eN7HxDzZpecb2Y7zWyTmb1hZh1LbfOh\nlZzZssjMxvtVs4hEnpmllPq+A3Ax3hUEEYlzvl8BMbPpeJd1v8C7z/so0A3o4rze4gfns8jBG4r5\nYKe8Audc6UcBRSRBmNl6vH4xq4A2wC14HTV7OudWlv9KEYkHvndCdc5dHPy9md2Ad3+0F96ohQcV\nOM1eKVKTzMCbk+VYvD4qnwG/U/gQSQy+XwEpLfCoXQ5wknPum0DbB3i9xZOAjXhDHv/h4BUSERER\niS8xFUACYx5MAxo6584Nah+BN5Poerye+U/gPS54pS+FioiISLXEWgB5DhgInOWc21DBdufhDVTU\n3jl32BwUgUmgBvLj43AiIiJSOSl4/a5mOue2ROogvvcBOcjMnsXr4d63ovAR8DleZ9T2lD0J1kBg\nUngrFBERqVGuAyZHaucxEUAC4eNy4FznXG4lXnIK3oiP5QWVNQCvvPIKXbp0CUuNNcXo0aMZN26c\n32XEFZ2z0Oi8VZ3OWWh03qomOzubIUOGQOB3aaT4HkAC43lkAJcB+WbWPLBqh3Ou0MzaAdfiDQu9\nBW8K86eBuc65r8rZbSFAly5d6NmzZ0TrTzSNGzfWOasinbPQ6LxVnc5ZaHTeQhbRLgy+BxC8Z/sd\n3lTYwYYDL+ENmXw+cAdQH2/I6deAh6NXooiIiIST7wHEOVfhaKzOue/x5oQQERGRBOH7UOwiIiJS\n8yiASAkZGRl+lxB3dM5Co/NWdTpnodF5i00xNQ5IuJhZT2DhwoUL1fFIRBJKbm4ueXl5fpchcS4t\nLY309PQy12VlZdGrVy+AXs65rEjV4HsfEBERqZzc3Fy6dOlCQUGB36VInEtNTSU7O7vcEBINCiAi\nInEiLy+PgoICjXEk1XJwnI+8vDwFEBERqTyNcSSJQJ1QRUREJOoUQERERCTqFEBEREQk6hRARERE\nJOoUQERERCTqFEBERCQmvPjiiyQlJZGVVXLsq507d9K7d29SU1N57733GDNmDElJSYeW+vXr07p1\nay677DImTpzIvn37Dtv38OHDS7wmeElNTY3WW5QgegxXRERihpmV+H7Xrl1ccMEFfPXVV0ydOpUL\nL7yQefPmYWb87W9/o379+uzdu5d169Yxc+ZMbrzxRp555hneeecdWrZsWWJfKSkpTJgwgdIjgCcn\nJ0f8fcnhFEBERCQm7d69mwsvvJAlS5bwxhtvcOGFF5ZYf8UVV9C0adND399///1kZmZy/fXXc9VV\nV/HZZ5+V2L5WrVqaFyaG6BaMiIjEnPz8fAYOHMjixYt5/fXXGTRoUKVel5GRwYgRI/j888+ZPXt2\nhKuU6lAAERGRmLJ7924GDRrEwoULmTJlChdddFGVXn/99dfjnOO99947bN2WLVsOW3bt2hWu0qUK\ndAtGRERihnOOYcOGsWHDBqZMmcIll1xS5X1069YNgJUrV5Zo3717N0cfffRh2w8aNIjp06eHVrCE\nTAFERCQBFewvYFnesogfp3NaZ1Jrh/cpks2bN5OSkkKrVq1Cen2DBg0ADruyUa9ePd5+++3DOqGm\npaWFVqhUiwKISJzIzc0lLy/vsPa0tDRfZ7SU2LQsbxm9/t4r4sdZePNCerYI38R4Zsbzzz/P6NGj\nGThwIJ988gkdOnSo0j52794NQMOGDUu0Jycnc95554WtVqkeBRCROJCbm0unTl0oLCw4bF1KSio5\nOdkKIVJC57TOLLx5YVSOE25du3ZlxowZ9O/fnwsuuIBPP/30sEdqK/LVV18B0L59+7DXJuGjACIS\nB/Ly8gLh4xWgS9CabAoLh5CXl6cAIiWk1k4N65WJaDv11FOZOnUql1xyCRdccAEff/wxzZo1q9Rr\nX3rpJcyMgQMHRrhKqQ49BSMSV7oAPYOWLhVvLhLH+vfvT2ZmJsuXL2fQoEGHbq1UZPLkyUyYMIE+\nffrodkuM0xUQERGJGaU7iA4ePJh//OMf3HjjjVx22WXMmDHj0HavvfYaDRo0YN++fYdGQv300085\n5ZRTePXVVw/b94EDB5g0aVKZx/3Zz35GvXr1wv+GpFwKICIiEjNKD8UOcMMNN7B161buvvturr76\nak4++WTMjNtuuw3whlhPS0ujR48eTJw4kYyMDGrXrn3Yfvbu3cvQoUPLPG7fvn11GzPKFEBERCQm\nDBs2jGHDhpW57s477+TOO+889P3YsWOrtO8XXniBF154oVr1SXipD4iIiIhEnQKIiIiIRJ0CiIiI\niESdAoiIiIhEnQKIiIiIRJ0CiIiIiESdAoiIiIhEnQKIiIiIRJ0CiIiIiESdAoiIiIhEnQKIiIiI\nRJ0CiIiIxKU2bdpw4403+l2GhEiT0YmIJIDc3Fzy8vL8LoO0tLSQZ5V98cUXGT58OF988QU9e/Y8\nbH2/fv3YunUrS5YsASApKanM2XMrMmPGDObPn8+DDz4YUo0SPgogIiJxLjc3l06dulBYWOB3KaSk\npJKTkx1yCKkoUJRel5OTQ1JS1S7kT58+nfHjxyuAxAAFEBGROJeXlxcIH68AXXysJJvCwiHk5eWF\nHECqonbt2lV+jXMuApVUXkFBAampqb7WECvUB0REJGF0AXr6uEQ3/JTuA3LgwAHGjBlDx44dqVev\nHmlpafTt25fZs2cDMHz4cMaPHw94t2+SkpJITk4+9PqCggLuuusu0tPTSUlJoXPnzjz11FOHHbew\nsJBRo0Zx9NFH06hRIwYPHsz69etJSkpi7Nixh7Z76KGHSEpKIjs7m2uvvZamTZvSt29fAJYuXcrw\n4cM54YQTqFevHi1atOCmm25i69atJY51cB/Lly9nyJAhNGnShGOOOYYHHngAgO+++47BgwfTuHFj\nWrRowdNPPx2msxt5ugIiIiIxZceOHWzZsqVEm3OO/fv3l2grfUvmwQcf5LHHHuPmm2/mtNNOY+fO\nnXzxxRdkZWUxYMAAbrnlFtavX8+sWbOYNGnSYVdDLr30UubOncuIESM4+eSTmTlzJnfffTfr168v\nEUSGDRvGlClTGDp0KKeffjpz587lkksuOayeg99fddVVdOzYkUcfffTQMd9//31Wr17NjTfeyLHH\nHsvXX3/N888/zzfffMO8efMO28c111xD165defzxx3nnnXd4+OGHadq0Kc8//zwDBgzgiSeeYNKk\nSdx999307t2bs88+O5RTH13OuYRb8KK4W7hwoRNJBAsXLnSAg4UOXNDitetnvWY4+HNQ+u+7/J+P\naC/V+3mcOHGiM7MKl5NOOunQ9m3atHHDhw8/9H2PHj3cpZdeWuExfvWrX7mkpKTD2qdOnerMzD36\n6KMl2q+66iqXnJzsVq1a5ZxzLisry5mZu+uuu0psN3z4cJeUlOTGjBlzqO2hhx5yZuaGDBly2PEK\nCwsPa/v3v//tkpKS3CeffHLYPm699dZDbUVFRe744493ycnJ7sknnzzUvn37dpeamlrinJSlvJ+j\n0uuBni6Cv6t1C0ZERGKGmfHcc88xa9asw5bu3btX+NomTZrw9ddfs2LFiiofd8aMGdSqVYuRI0eW\naL/rrrsoLi5mxowZh7YzM2699dYS240cObLM/iVmxi9/+cvD2uvWrXvoz3v37mXLli2cfvrpOOfI\nyso6bB833XTToe+TkpI49dRTcc6VuAXVuHFjOnXqxKpVq6rwzv2jWzAiIhJTTjvttDIfwz3qqKMO\nuzUTbOzYsQwePJiOHTvSrVs3Bg0axPXXX89JJ510xGOuXbuW4447jvr165do79Kly6H14D1xlJSU\nRNu2bUts1759+3L3XXpbgG3btvHQQw/xn//8h82bNx9qNzN27Nhx2PalO/U2btyYlJQUmjZtelh7\n6X4ksUpXQEREJCH07duXlStX8sILL3DSSScxYcIEevbsyb/+9S9f66pXr95hbVdddRUTJkzgtttu\n44033uD9999n5syZOOcoLi4+bPvgzrIVtYH/T/pUlgKIiIgkjCZNmjBs2DAmTZrEd999R/fu3Xno\noYcOrS9vnJHWrVuzfv168vPzS7RnZ2cD3hM3B7crLi5m9erVJbZbvnx5pWvcvn07c+bM4d577+WB\nBx7g8ssvZ8CAAWVeKUlkCiAiIpIQSt96SE1NpX379uzdu/dQ28FbLDt37iyx7cUXX8yBAwd49tln\nS7SPGzeOpKQkBg0aBMDAgQNxzh16nPegv/zlL5UelfXglYvSVzrGjRtX5ZFd45n6gIiISMyozu2D\nrl270q9fP3r16kXTpk1ZsGABU6ZMYdSoUYe26dWrF845Ro4cycCBA0lOTuaaa67h0ksv5bzzzuO+\n++5j9erVhx7DnTZtGqNHjz50daJnz55cccUVPPPMM+Tl5XHGGWcwd+7cQ1dAKhMgGjZsyDnnnMMT\nTzzBvn37aNmyJe+99x5r1qyJm9sn4aAAIiKSMLLj/vhH+gUevN7MSnx/xx138NZbb/H++++zd+9e\nWrduzSOPPMKvf/3rQ9v87Gc/Y9SoUfz73/8+NBbINddcg5kxbdo0HnjgAf7zn/8wceJE2rRpw//9\n3/8xevToEjW8/PLLtGjRgszMTKZOncoFF1zAf/7zHzp27EhKSkql3mdmZiYjR45k/PjxOOcYOHAg\nM2bM4Ljjjqv0VZDytoubqyiRfMbXrwWNAyIJRuOAiHPlj9+wdu1al5KSenDsBl+XlJRUt3btWp/O\nkH8WLVrkzMxNnjzZ71KOKFbGAfH9CoiZ3Qv8FOgM7AE+A37jnPs2aJu6wNPANUBdYCZwm3Nu8+F7\nFBGpWdLT08nJyY772XDjRWFh4WFXOp555hmSk5M555xzfKoq/vgeQIC+wF+AL/DqeRR4z8y6OOf2\nBLZ5BrgIuALYCfwV+G/gtSIiNV56enrC/+KPFU888QQLFy7kvPPOo1atWkyfPp2ZM2fyy1/+kpYt\nW/pdXtzwPYA45y4O/t7MbgA2A72AT8ysEXAj8HPn3NzANsOBbDPr7ZybH+WSRUSkBuvTpw+zZs3i\nj3/8I7t37yY9PZ0xY8bwu9/9zu/S4orvAaQMTfDuPR18nqoXXp2zD27gnMsxs1zgTEABREREoub8\n88/n/PPP97uMuBdT44CY13X3GeAT59w3geZjgX3OuZ2lNt8UWCciIiJxJtaugIwHugJxMI+wSOzL\nzc0tt2NiTegsKCKxK2YCiJk9C1wM9HXOrQ9atRGoY2aNSl0FaR5YV67Ro0fTuHHjEm0ZGRlkZGSE\nqWqR2JWbm0unTl0oLCwoc31KSio5OdkKISI1WGZmJpmZmSXaypoMLxJiIoAEwsflwLnOudxSqxcC\nB4ABwBuB7TsB6cC8ivY7bty4MmdUFKkJ8vLyAuHjFaBLqbXZFBYOIS8vTwFEpAYr60N5VlYWvXr1\nivixfQ8gZjYeyAAuA/LNrHlg1Q7nXKFzbqeZTQCeNrNtwC7gz8CnegJGpDK64I3NJ4ni4ARpIqGI\nlZ8f3wMIcAveUy8flmofDrwU+PNooAiYgjcQ2bvA7VGqT0QkJqSlpZGamsqQIUP8LkXiXGpqKmlp\nab7W4HsAcc4d8Ukc59xeYGRgERGpkdLT08nOjo0RTyW+xUIndN8DiIiIVJ5GPJVEEVPjgIiIiEjN\noAAiIiIiUacAIiIiIlGnACIiIiJRpwAiIiIiUacAIiIiIlGnACIiIiJRpwAiIiIiUacAIiIiIlGn\nACIiIiJRpwAiIiIiUacAIiIiIlGnACIiIiJRpwAiIiIiUacAIiIiIlGnACIiIiJRpwAiIiIiUacA\nIiIiIlGnACIiIiJRpwAiIiIiUacAIiIiIlGnACIiIiJRpwAiIiIiUacAIiIiIlGnACIiIiJRpwAi\nIiIiUacAIiIiIlGnACIiIiJRpwAiIiIiUacAIiIiIlGnACIiIiJRpwAiIiIiUacAIiIiIlGnACIi\nIiJRpwAiIiIiUacAIiIiIlGnACIiIiJRpwAiIiIiUacAIiIiIlGnACIiIiJRpwAiIiIiUacAIiIi\nIlFXy+8CRCQx5ObmkpeXV+a6tLQ00tPTo1yRiMQyBRARqbbc3Fw6depCYWFBmetTUlLJyclWCBGR\nQxRARKTa8vLyAuHjFaBLqbXZFBYOIS8vTwFERA5RABGRMOoC9PS7CBGJA+qEKiIiIlGnACIiIiJR\npwAiIiIiUacAIiIiIlEXEwHEzPqa2Vtmts7Mis3sslLrXwi0By/T/apXREREqicmAghQH1gM3Aa4\ncraZATQHjg0sGdEpTURERMItJh7Ddc69C7wLYGZWzmZ7nXM/RK8qERERiZRYuQJSGf3MbJOZLTOz\n8WbW1O+CREREJDQxcQWkEmYA/wVWAycAjwLTzexM51x5t2xEREQkRsVFAHHOvRr07ddmthRYCfQD\nPvClKBGJOZoQTyR+xEUAKc05t9rM8oD2VBBARo8eTePGjUu0ZWRkkJGh/qsiiUYT4olUXWZmJpmZ\nmSXaduzYEZVjx2UAMbNWQDNgQ0XbjRs3jp49NS+FSE2gCfFEqq6sD+VZWVn06tUr4seOiQBiZvXx\nrmYcfAKmnZmdDGwNLA/i9QHZGNjuceBbYGb0qxWR2KYJ8UTiQUwEEOBUvFspLrA8FWh/EW9skO7A\nUKAJsB4veDzgnNsf/VJFRESkumIigDjn5lLxI8GDolWLiIiIRF48jQMiIiIiCUIBRERERKIupABi\nZu3CXYiIiIjUHKFeAVlhZh+Y2RAzSwlrRSIiIpLwQg0gPYElwNPARjN73sx6h68sERERSWQhBRDn\n3GLn3B3AccCNQAvgEzP7yszuNLOjw1mkiIiIJJZqPYbrnDsAvG5m7+CN1/Eo8H/AI2b2KvAb51yF\no5WKSM2QnZ19WFtNnJ+lvPlqauK5kJqtWgHEzE7FuwLycyAfL3xMAFrhjV76JqBbMyI12gYgiSFD\nhhy2pqbNz1LRfDU17VyIhBRAzOxOYDjQCZiON0rpdOdccWCT1WZ2A7AmDDWKSFzbDhRz+BwtNW9+\nlvLnq6l550Ik1CsgtwL/AiZWcItlM3BTiPsXkYSjOVp+pHMhEmoAuQDIDbriAYCZGXC8cy7XObcP\nby4XERERkRJCfQx3JZBWRntTYHXo5YiIiEhNEGoAsXLaGwCFIe5TREREaogq3YIxs6cDf3TAWDML\n7sqdDJwOLA5TbSIiIpKgqtoH5JTAVwNOAvYFrdsHfIn3KK6IiIhIuaoUQJxz5wGY2QvAHc65nRGp\nSkRERBJaSE/BOOeGh7sQERERqTkqHUDM7HXgBufczsCfy+Wc+1m1KxMREZGEVZUrIDvwOp8e/LOI\nJKDy5ioB2Lt3L3Xr1j2svax5XkREKlLpABJ820W3YEQSU0VzlXiSgaJoliQiCSrUuWDqAeacKwh8\n3xr4KfCNc+69MNYnIlFU/lwl4E379PsjrBMRqZxQh2J/E3gd+JuZNQHm4z2Gm2ZmdzrnngtXgSLi\nh7LmKsmuxDoRkcoJdSTUnsDHgT9fCWwEWuPNijsqDHWJiIhIAgs1gKQCuwJ/vhB4PTAx3f/wgoiI\niIhIuUINICuAwWZ2PDAQONjv4xhAg5OJiIhIhUINIGPxhlxfA3zunJsXaL8QWBSGukRERCSBhToS\n6hQz+wRogTf/y0GzgTfCUZiIiIgkrlCfgsE5txGv82lw2/xqVyQiIiIJL9RxQOoDvwUG4PX7KHEr\nxznXrvqliYiISKIK9QrIP4FzgZeBDfw4RLuIiIjIEYUaQC4CLnHOfRrOYkRERKRmCDWAbAO2hrMQ\nESl/IrhEnuytvPeWlpZGenp6lKsRkWgJNYD8HhhrZsMOzgcjItVz5IngEs0GIIkhQ4aUuTYlJZWc\nnGyFEJEEFWoAuQs4AdhkZmuA/cErnXOlJ4oQkSOo3ERwiWQ7UEzZ7zebwsIh5OXlKYCIJKhQA8jU\nsFYhIkFq2mRvZb1fEUl0oQ5ENibchYiIiEjNEepQ7JhZEzMbYWaPmlnTQFtPM2sZvvJEREQkEYU6\nEFl3YBawA2gD/APvqZifAenA0DDVJyIiIgko1CsgTwMTnXMdgMKg9unAOdWuSkRERBJaqAHkNOD5\nMtrXAceLFdlEAAAgAElEQVSGXo6IiIjUBKEGkL1AozLaOwI/hF6OiIiI1AShBpC3gAfMrHbge2dm\n6cDjwH/DUpmIiIgkrOoMRDYF72pHPWAu3q2XecB94SlNREKRV5DH9OXTmbZkGlwL1PkFHEiDXS1h\na3tY3wu+r+ddxxQR8Umo44DsAC4ws7OAk4EGQJZzblY4ixNJRJGa7+X7nd/z+w9+z+Slk9lXtI8T\nGp7gzVO9sznUSoWjv4bOb0C97VCcBJvg6a+f5rqG19G3dV8a1GlQreNHQnnnZO/evdStW7dS21ZX\neX9f0Zyrprwaol2HSDhVOYCYWRJwA94jt23w/otbDWw0M3POuXAWKJJIIjXfy7TvpvHku0/SoE4D\n/njeHxnWYxjf53xPr7t6AX/kx5FGHTRbDumToPVYZq2fxaTJk6iVVIszW51J15SucDywbr83Srpv\nKp4nBpKBoohXUdHfV7TmqjnSz4zmzJF4VaUAYmaG1//jYuBLYClgeGMpT8QLJYPDW6JI4gj/fC8O\nLoCHFj/EDT1u4JmBz9A4pTEA3/N9GdsbbOkIWy6HRWN55/53aNC6AbNXz2bWqllMXjkZbgL29oe1\n58GqAbDqfNjcrapvtZoqmifm4HkqvS788+WU//cVvblqKv6Z0Zw5Er+qegXkBrxxPgY45z4IXmFm\n/YGpZjbUOfdSmOoTSVDhmO/FwcBxcCbcdeJdPHnZk3ifESrPzOiU1olOaZ247bTbWLBwAb0v6w3t\nboR22XD+vVDrTth9DHzfynvQft3nsO4E2Nu4ivWGoqLzVHpdJOfLiYX5amKhBpHwqWoAyQAeKR0+\nAJxzc8zsMeA6QAFEJNJ6/xXOnATvwLWXXlvl8FGWZEuG9cD64fBJT6i1B47/DNp+AC3fhLOAlNuA\n2+CHzrCuN6w7HdZtgU1E466IiCSIqgaQ7sA9FayfAYwKvRwRqZT0T2DQ/4N518KCyZE7zoF6sHqA\nt9AFbAg0mwIt86Hl59ByPpyUCcn74QCw4QZYd54XSr7rA9vbRK42EYlrVQ0gTfE+55RnE3BU6OWI\nyBHV2Q2Dh8H3Z8D7dwARDCClOSCvLeT1hC8DUz7VKoRjH4eWD0HLVtBhOpzxZ2/dhlPgq47wNV63\nDhGRgKoGkGS8zznlKQphnyJSFQN+Bw02wiszoXin39XAgRT4vj1en9fAEzf1tni3bU58Ffq9ARcA\nK34FC34L314CLtnfmkXEd1UNCwZMNLPyhjCqW057xTs16wvcDfQCWgCDnXNvldpmLDACaAJ8Ctzq\nnFsRyvFE4tYxK+C0v8L7T3iDipHld0Vl29MMvrnSW+pMgK4j4NSdkHE5bE+HT++BRakVf5wRkYRW\n1QDyYiW2CaUDan1gMTABeL30SjP7DfArYCiwBu9j1kwz6+Kc2xfC8UTi08CnYVs7mD/S70oqb1+K\n96978UvQwsGZT8NFo+CchvAZsLAA9K9YpMapUgBxzg2PRBHOuXeBd+HQWCOl3QH8wTn3dmCboXj9\nTQYDr0aiJpGY0x444XPIfBOK6vhdTWg29ILXJ8GHY+DsEXD+XDjrcpg7FhbeDMW1j7wPEUkIoU5G\nFzVm1hZvnpnZB9ucczuBz4Ez/apLJLocnAvkngw5l/pdTPVtbQ9v/QL+DCw/Cy4eCbd3ha6v4fV0\nFZFEF/MBBC98OA5/+mZTYJ1I4mv7jTdE+kc34XXFShA7gDcfgue+9EZovfpqGHEGtF7md2UiEmF6\nYkUkHpzzpjdA2Io+Za4uayK2SE3OFhGbT4LJ70CbD+GCe2D4H+Eb4P3vYFvkR/8M9wSBkZpwUCSR\nxEMA2Yj3ka85Ja+CNAcWVfTC0aNH07hxyeGiMzIyyMjICHeNIpHTIsu7AvIqHH7140iTtsWZNf3g\nn/+DbiPh/PFw+1Xw+R3w0f0RG/o93BMERmrCQZFIyMzMJDMzs0Tbjh07onLsmA8gzrnVZrYRGAAs\nATCzRsDpwF8reu24cePo2VNzJ0icO2087GgGy7aUsbIyk7bFGZcES/vAsvFw5k1w9njo8SJ8MBay\nRoR9lt5wTxAY/gkHRSKnrA/lWVlZ9OrVK+LHjokAYmb18fr4H/x4187MTga2Oue+A54B7jezFXiP\n4f4Bb9ijN30oVyR6UrbBSZPho59A8WsVbBiOye1izH7go1/AovthwH3wk1uh97Mw8yewMhIHDPc5\nTMC/E5EwipVOqKfi3U5ZiNfh9Cm8EZbGADjnngD+AjyP9/RLPeAijQEiCa/HREg6AFn9/K7EP7ta\nwtSJ8PcFsOcouP5xuBZIW+13ZSJSDTERQJxzc51zSc655FLLjUHbPOScO845l+qcG6hRUCXxOej1\nd/jmCsiPTP+HuLL+VHjhI3h1FBwN3HoNDLoD6m31uzIRCUFMBBARKcNxX8DRy2BxRMb/i1MG3/T2\nen/NuQ1OeQFGtYfT/+xdKRKRuKEAIhKrTn4ZdrWAVQP8riT2HAA+vQH+vNybb2bgaLjtXugIGshM\nJD4ogIjEouR90C0TllynmWMrkt8cpv0dnl8EO5t6fUOuvx2O+crvykTkCBRARGJR+3ehfh58OdTv\nSuLDpu7w0m8hE2iyAW7p4U14l7LN78pEpBwKICKxqPvLsPFkb4RQqSSDHGD8qzDrUejxAozq4HXk\ntSK/ixORUhRARGJN7T3Q8R1Yeq3flcSnotrw2d3wl2/h25/Apb+Em6/35tIRkZgREwORiUiQDp96\nIeSbKyJ+qNJzkyTUXCW7W3jjh3xxC1x0E9wE92Xdxz/b/5OWjVqG5RDhnoMn7uf0EakCBRCRWNNl\njnf7ZdsJETxIgs0hU5Hvz4B/vgg9TuPzqz6n07OduK/vfdx55p3UrVU3xJ2G+/zVoL8PkQDdghGJ\nJbWAjh9H4epH8BwyC4OWP0T4uD5xSbAI3uj/Bjf3upkHPnyAE8efyLScaTgXymO75Z2/UM9huPcn\nEvt0BUQklrQD6hZAduRvv3hKz1eS2Jf7G9ZuyNMDn2ZEzxH8v3f/H5f9+zL6HN0HmgFlzfV3RJo/\nRiRUugIiEku6Aj+0hR+6+l1JQut6dFdmDpnJ1GumsjZ/LdwGXPAM1N3pd2kiNYYCiEissGJvJM9l\n/fyupEYwMy7vfDmv9XsNPgROew1GdoQzximIiESBAohIrGi1AlKBb/v6XUmNUje5LnwMPPtfWDEI\nLrgH7mwFF94Faev9Lk8kYakPiEis6PAlFADfd/O7kppp57HeY7uzH4bef4VT/wZ9tnkPqCx9CVbW\ngs3dvA6tIlJtCiAisaLDYliB5n7x266WMPsRmPsAtP8tdP8TnPc3uPBPkH805J4Fmww2A1uXwc7j\noSANML8rF4krCiAisaDhOmixFj71uxA55EAKLDsNlgG1PoDj90Db2dByPpy6ABoAXBfYti7sbOUt\nOw7ATmDnq7BjPWzsATtbooAiUpICiEgs6DAdig1Wair5mHSgLqw+E1b3DzRMgvpDoPFL0KgBNPoe\nGn/nfW2SBelAo6cg+XFv813HwuoBkJ0Gy4EDPr0PkRiiACISCzq+A993gD3f+l2JVFY+kH8irC89\nbsckYAjYPGh4LLRYCK3+5/0dd1/qve6L52Dek1DYJPp1i8QIBRARvyXvhXaz4KNLAAWQSIrqXCsu\n6cfbMjmXw+xHodmT0PseOPMVOPVNeP9xWHxDtQ9V3ntIS0sjPT292vsXiQQFEBG/tf4I6uTD8h7A\nq35Xk6BiZK6VLcfBDOCTqXDByzD4Ru/KyFsXQmEoO6z4faWkpJKTk60QIjFJAUTEb+3f9TopbtJ8\n8ZETPNdKl1LrpgO/j245u46G11+B7J/C5TfBTfPgZbzOq1VS0fvKprBwCHl5eQogEpMUQET81nYO\nrBqAnpKIhhibayX7Cm9skevPhpuAF7+DraXrq4yy3pdIbNOIOiJ+Ss2DFou9JySkZtrSCSY8APuB\nIbdDg41+VyQSFQogIn5q86H39dDjnVIj7Wrq3YKptQ+uuxhqF/hdkUjEKYCI+KntbMjr6D0pITXb\nDmDSnyFtGVxyG6AxYSSxKYCI+KntHF39kB9t6gjTnoceL0LPCX5XIxJRCiAifmn0PaR9q/4fUtKS\n62HhCBj0/6DJar+rEYkYBRARv7Sd431d08/XMiQGzXzam+Du8pvAiv2uRiQiFEBE/NJ2DmzoEZhJ\nVSTIvobw5gRo+wGcMtfvakQiQgFExBfO64Cq/h9SntUD4MshMOA1qOt3MSLhpwAi4oem30Hj7xVA\npGKzHoPae+FcvwsRCT8FEBE/tJsPxcmw9hy/K5FYtqslfHwZnA40W+N3NSJhpQAi4oe2C2Bdb+9e\nv0hF5l0Eu4Dz/uZ3JSJhpQAiEm2GF0BW6fFbqYQDdeAjoNv7cMxSv6sRCRsFEJFoOwZI3aH+H1J5\ni4FtLeG8B/2uRCRsFEBEoq0tsL8ufH+m35VIvCgG5o6ALm9Aiyy/qxEJCwUQkWhrB3x3MhxI8bsS\niSdLLoat7eCsJ/yuRCQsFEBEomh/8X5oDaw+ze9SJN4U14J5d0LX1zREuyQEBRCRKMrenu0NKrVK\nAURCsHg4FB4FZ47zuxKRalMAEYmiBXkLoBDY0MXvUiQe7U+F+bfDKROg3la/qxGpFgUQkSianzcf\n1uJdThcJxYLbvQnqTn3O70pEqkUBRCRK9uzfw5JtS0C376U68o+BL4fCaeMh6YDf1YiETAFEJErm\nfT+PfcX7YJXflUjcW3AbNFoPnRb5XYlIyBRARKJk9qrZHFXnKPjB70ok7m06GXL7wGmz/K5EJGQK\nICJRMmfNHE5LOw2c35VIQlhwG7T7Gpr5XYhIaBRARKJg596dLFi3wAsgIuHwzZWQ3xBO9bsQkdAo\ngIhEwUdrP6LIFSmASPgU1YVF50IPoPYev6sRqTIFEJEomL1qNumN02mV2srvUiSRfNEfUoAT3/e7\nEpEqUwARiYI5a+bQv21/zMzvUiSRbD/Ge6rqlDf9rkSkyhRARCJsc/5mlmxawoC2A/wuRRLRIqD1\nYmi63O9KRKpEAUQkwj5c8yEA/dv297cQSUzLgD0NocdEvysRqZK4CCBm9qCZFZdavvG7LpHKmLN6\nDp3TOnNcw+P8LkUS0QHgq4HQ40WwIr+rEam0uAggAV8BzYFjA8vZ/pYjUjmzV8+mfxtd/ZAIWnQZ\nNFoHJ6gzqsSPeAogB5xzPzjnNgcWTQUpMS93Ry4rtq7Q7ReJrPVdYfOJ0OMFvysRqbR4CiAdzGyd\nma00s1fM7Hi/CxI5ktmrZmMY/dr087sUSWgGi26EzlOhnj6bSXyIlwDyP+AGYCBwC9AW+MjM6vtZ\nlEh5li9fTlZWFq8tfI3OjTuzdtlasrKyyM7O9rs0SVRLhoAVw0mT/a5EpFJq+V1AZTjnZgZ9+5WZ\nzQfWAlcDuuYoMeXzzz+nT5+zKC4ugl8Di6HX6F5+lyWJLv8YWH6Jdxtm/q/8rkbkiOIigJTmnNth\nZt8C7SvabvTo0TRu3LhEW0ZGBhkZGZEsT2q4devWeeHjmAnQ4CZYNR44PbD2LuBD/4qTxLb4Bvj5\nT+GYpbDZ72IkHmRmZpKZmVmibceOHVE5dlwGEDNrAJwAvFTRduPGjaNnz57RKUqktHYb4UBdyL0B\nqBdobOJjQZLwll8MBc28R3Lfu9bvaiQOlPWhPCsri169In/VNi76gJjZk2Z2jpm1NrM+wBt4T79n\nHuGlIv5p+xHkngUH6h15W5FwKKoDS66D7q9A0gG/qxGpUFwEEKAVMBlvzL9/Az8AZzjntvhalUh5\nkoA2n8Cq8/2uRGqaL4dBg01wwv/8rkSkQnFxC8Y5p04bEl9aAnXzFUAk+jacApu6QY9poOlhJIbF\nyxUQkfjSDtjTGDaoD5JEm3mdUTvNhRS/axEpnwKISCS0A9acDS7Z70qkJlp6HSQVQze/CxEpnwKI\nSJjtKdrj9Vpada7fpUhNtftYWHEG9PC7EJHyKYCIhNk3+d9AMgog4q/Fl0IrWLN7jd+ViJRJAUQk\nzJbsXgI7gC0n+F2K1GTfngN74O3v3va7EpEyxcVTMCLxJGt3FqwAML9LkZrsQF34Ct456h2KiotI\nTlJ/JIktCiAiYbR622rW710fCCAiPlsMm0/bzPPvP88ZR59xqDktLY309HQfCxNRABEJqxkrZpBM\nMkWrivwuRWq8DbDOIM9x+99vh9d/XJOSkkpOTrZCiPhKfUBEwmjGihl0rt8Z9vpdich2wMHiq6FL\nXag7F1gIvEJhYQF5eXk+1yc1nQKISJgUHihkzuo5nNLwFL9LEfnRkhug1j7ouhzoCXTxuSARjwKI\nSJh8tPYjCvYXcEoDBRCJITube1MC9JjodyUiJSiAiITJjOUzaNmwJa1TWvtdikhJi4dB60/gqJV+\nVyJyiAKISJjMWDGDi9pfhJkev5UYs+ynsLchnPyS35WIHKIAIhIGq7etJmdLDhd1uMjvUkQOtz8V\nvr4aerwIVux3NSKAAohIWLyV8xZ1kutwfrvz/S5FpGyLh0GTtdA6y+9KRAAFEJGweGPZGwxoO4BG\ndRv5XYpI2XLPhq3t4GQNzS6xQQFEpJryCvL4OPdjBnce7HcpIhUw+HIYnDgL6vhdi4gCiEi1TcuZ\nhnOOyztd7ncpIhX7cijU2aOhQCQmKICIVNPUnKn0Ob4PzRs097sUkYptbwOre8HJfhciogAiUi35\n+/J5b+V7uv0i8ePLn0A72FCwwe9KpIZTABGphndXvEvhgUIFEIkf3wyAffDO9+/4XYnUcAogItXw\n+rLX6XZMN9o3be93KSKVs68+fANvffcWxU5jgoh/FEBEQpS/L583l73Jz0/8ud+liFTNQlhXsI6Z\nK2b6XYnUYAogIiGa9u008vfn8/NuCiASZ76DTo068dcFf/W7EqnBFEBEQpT5VSa9W/bmhKYn+F2K\nSJVd0/Yapi+fzsqtmqBO/KEAIhKCbXu2MWP5DK7tdq3fpYiEZGDLgRxV7yie++I5v0uRGkoBRCQE\n/83+L0WuiKtPvNrvUkRCkpKcwk2n3MSERRMo2F/gdzlSAymAiITgpS9f4rw259GiYQu/SxEJ2a2n\n3sqOwh1MWjLJ71KkBlIAEaminLwcPs79mBE9R/hdiki1tD2qLZd3vpyn5j2lR3Il6hRARKpowqIJ\nNK3XVIOPSUL4zVm/IWdLDm8ue9PvUqSGUQARqYJ9Rft48csXub779aTUSvG7HJFqO6PVGZzb+lwe\n+/QxnHN+lyM1iAKISBVMy5nG5vzNuv0iCeU3Z/2G+evmM3ftXL9LkRpEAUSkCp774jnOaHUG3Y7p\n5ncpImEzqP0gujfvzmOfPOZ3KVKDKICIVNKSTUuYvXo2o3qP8rsUkbAyM+7rex8zV87k09xP/S5H\naggFEJFKeuZ/z9CqUSuu7Hql36WIhN2VXa/k5OYn87s5v1NfEIkKBRCRSti0exOTlk5iZO+R1E6u\n7Xc5ImGXZEk83P9hPlr7Ee+tfM/vcqQGUAARqYRx/xtHneQ6/KLnL/wuRSRiLu5wMWcdf5augkhU\nKICIHMEP+T/w7PxnGdV7FEfVO8rvckQixsx4ZMAjZG3IIvOrTL/LkQSnACJyBE/Newoz484z7/S7\nFJGIO6f1OVzR5Qp+/d6v2bl3p9/lSAJTABGpwIZdG3h2/rOM7D2SZqnN/C5HJCqeHvg0O/buYOzc\nsX6XIglMAUSkAvfNuY+UWinc3eduv0sRiZr0xunc3/d+/vT5n1i6aanf5UiCUgARKcfC9QuZuHgi\nfzjvD+r7ITXOnWfeSadmnRg6dSj7ivb5XY4kIAUQkTIUFRdx+/Tb6Xp0V37RS0++SM1Tt1ZdXv7p\ny3y1+Sv+MPcPfpcjCUgBRKQMz/zvGeavm8/fL/07tZJq+V2OiC9OaXEKD5zzAI988gif5H7idzmS\nYBRARErJycvh/g/u547T76DP8X38LkfEV/f2vZezjj+Lq167ivW71vtdjiQQBRCRIPn78rnytStp\n3bg1Dw942O9yRHxXK6kWr131GsmWzBWvXsHeA3v9LkkShAKISIBzjlveuYVV21bx36v/S2rtVL9L\nEokJzRs05/VrXmfRhkVc9/p1HCg+4HdJkgAUQEQCHvzwQV5Z8gr/vPSfnHjMiX6XIxJTerfszatX\nvcrUZVMZ8dYIil2x3yVJnFMAEcHrdPqHj/7AYwMeI+OkDL/LEYlJl3W6jJd/+jIvffkSQ14fotsx\nUi3q3i81mnOOMXPHMGbuGO7pcw/3nHWP3yWJxLSMkzKonVybIa8PYcPuDUy5aopGCZaQ6AqI1Fi7\n9u5iyBtDGDN3DI8OeJTHzn8MM/O7LJGYd2XXK5k1dBZLNi3h5L+dzAerP/C7JIlDcRVAzOx2M1tt\nZnvM7H9mdprfNSWazMyaMQPm3DVzOfUfp/JWzltkXpHJb8/+bcjho6acs/D7zO8C4lDs/KydnX42\nX97yJR2adWDASwO49e1bySvI87usMunfaGyKmwBiZtcATwEPAqcAXwIzzSzN18ISTKL/Q/1689dk\n/DeDfi/2o1m9Ziy8eSE/7/bzau0z0c9Z5Mzzu4A4FFs/a60atWLW9bMYN3AcmV9l0uEvHRjz4ZiY\nCyL6Nxqb4iaAAKOB551zLznnlgG3AAXAjf6WJbGu8EAhU76Zwk8m/4Ruz3Xjs+8+Y8JlE/jkxk/o\n2Kyj3+WJxLXkpGTuOOMOlo9cztDuQ3n808dJH5fOda9fx9vfvq15ZKRccdEJ1cxqA72ARw62Oeec\nmc0CzvStMIlJm3ZvYunmpSzasIg5a+bw0dqPKNhfQO+WvZlw2QSGdB9CneQ6fpcpklCOrn80f7ro\nTzxw7gP8feHfmbR0EpOXTia1dip9ju/Dua3PpVeLXnQ5ugvpjdNJsnj6/CuREBcBBEgDkoFNpdo3\nAZ2iX05i2bV3F8u3Lsc5x/bC7Xyx/gucczgcQNT+7Fzg+3L+XOSKKNhfQP6+fPL357N7327y9+Xz\nQ8EPrN+1ng27N/Ddju/YsmcLAKm1U+mb3pcx/cZwacdL6ZQW7R+VL4HGpdq2R7kGkehqltqMe/ve\ny71972XppqW8u+JdPlz7IU9+9iQ79+4EvH+bxzc6nhYNW9CiQQua129Ow7oNaVCnAQ3qNKB+7frU\nr1OfWkm1qJVUi2RL9r4mJZf4s1F2v63S/bm2F25nwboFldoWqPR+D6qTXIdux3Qr95xI2eIlgFRV\nCkB2drbfdcSFBesWcMvbt3jf5MBpY2K/b29KrRTq1a5HvVr1aJLShKPrH0371Pac2fRM2h3VjvZH\ntadlo5YkJyUDkJ+bT1ZuVkRq2bFjB1lZP+57165dmCXhXP8KXjUdKP3z+WkI60J5TTT3V9G6rXFc\nu1/7+x6YVM1jrQai9//jgHoDGNB5AMWditm4eyOrt61m9fbVbNq9ibzNeeSszmFe4Tz27N9Dwf4C\nCvYXUFRcFN4icqD32N7h3WeQ4xoex7Rrp0Vs/9EW9LOREsnj2MFPl7EscAumALjCOfdWUPtEoLFz\n7qeltr+Wkv9KRUREpGquc85NjtTO4+IKiHNuv5ktBAYAbwGYdy1sAPDnMl4yE7gOWAMURqlMERGR\nRJACtMH7XRoxcXEFBMDMrgYm4j39Mh/vqZgrgc7OuR98LE1ERESqKC6ugAA4514NjPkxFmgOLAYG\nKnyIiIjEn7i5AiIiIiKJQw9ii4iISNQpgIiIiEjUxWUAMbOjzGySme0ws21m9k8zq3+E1/zCzD4I\nvKbYzBqFY7/xJMTzVtfM/mpmeWa2y8ymmNkxpbYpLrUUBToNx6WqTnpoZleZWXZg+y/N7KIythlr\nZuvNrMDM3jez9pF7B9EX7nNmZi+U8XM1PbLvIvqqct7MrGvg39/qwPkYVd19xqNwnzMze7CMn7Vv\nIvsuoq+K522EmX1kZlsDy/tlbV/d/9fiMoAAk4EueI/hXgKcAzx/hNfUA2YADwPldXwJZb/xJJT3\n90xg2ysC2x8H/LeM7YbhdQ4+FmgBTA1PydFV1UkPzawP3nn9B9ADeBOYamZdg7b5DfAr4GagN5Af\n2GdCjAcfiXMWMIMff6aOBTIi8gZ8UtXzBqQCK4HfABvCtM+4EolzFvAVJX/Wzg5XzbEghPN2Lt6/\n0X7AGcB3wHtm1iJon9X/f805F1cL0BkoBk4JahsIHACOrcTrzwWKgEbh3G+sL6G8P6ARsBf4aVBb\np8B+ege1FQOX+f0ew3Se/gf8Keh7wxt+8p5ytv838FaptnnA+KDv1wOjS53XPcDVfr/fGD5nLwCv\n+/3eYum8lXrtamBUOPcZD0uEztmDQJbf7y1Wz1tg+yRgBzAkqK3a/6/F4xWQM4FtzrlFQW2z8K5q\nnB6D+40Voby/XniPas8+2OCcywFyOXwSwL+a2Q9m9rmZDQ9f2dFjP056GPx+Hd55Km/SwzMD64PN\nPLi9mbXD+0QVvM+dwOcV7DNuROKcBelnZpvMbJmZjTezpmEq23chnreo7zOWRPj9dTCzdWa20sxe\nMbPjq7m/mBGm81YfqE1g/gQza0sY/l+LxwByLLA5uME5V4R3Yo6Nwf3GilDe37HAvsAPVrBNpV7z\ne+Bq4HxgCjDezH4VjqKjrKJJDys6RxVt3xwv5FVln/EkEucMvNsvQ4H+wD14Vy6nm5UzG1j8CeW8\n+bHPWBKp9/c/4Aa8K8K3AG2Bjyxx+v+F47w9Dqzjxw8OxxKG/9diZiAyM3sU7z5deRxe/wUJEgvn\nzTn3cNC3X5pZA+Bu4NlIHlcSl3Pu1aBvvzazpXj38vsBH/hSlCQk51zwcONfmdl8YC3eh6oX/Kkq\ndpjZb/HOxbnOuX3h3HfMBBDg/zjyX/YqYCNQ+imMZKBpYF2oIrXfSIvkedsI1DGzRqWugjSv4DXg\nXYa738xqO+f2H6G2WJKH1z+oean2it7vxiNsvxHvfmtzSn5aaA4sIv5F4pwdxv3/9u4t1IoqDOD4\n/ybN+o8AAAUqSURBVLNUtChDSohSSimzIoUM0i6GVBT1kIZYaJRJlEHQBbtR2UNCGfjgJaTSyMii\nh14qJMGXNBNMIdBMQQvBILxkihV1XD2sOTJn4zHdxz1ztv5/MJy915q99qyPvWd/M7PWmZR2RsQe\nYASnRwLSTNzqaLM3qaR/KaUDEbGN/Fk7HTQdt4h4jnwGcmJKaXOp6pTs13rNJZiU0t6U0rb/Wf4l\nD1YbFBFjSi+fSA7G+h5sQqvabakWx+178iDViZ0FEXElMLRorztjyONN2in5oNjezpseAl1uevht\nNy9bV16/cHtRTkppJ/nLWm7zPPK4m+7abButiNmxRMQlwGCOP5OhbTQZt8rb7E2q6l9xBnc4Z/hn\nLSJmAy+Tb3nSJak4Zfu1ukfnNrMAXwEbgLHAeOAnYHmp/mLgR+D6UtkQ4DpgJnnWxk3F8wtOtN12\nX5qM22Ly6PEJ5IFMa4FvSvX3AI8CV5O/tE8Ah4BX6+5vkzGaAhwmjz8YSZ6mvBe4sKj/EJhbWv9G\n8kyhZ8gzhOaQ78A8qrTO7KKNe4FryVOUtwP96u5vb4wZecDbW+Sd2TDyTm5D8dnsW3d/a4xb32Kf\nNZp8Pf7N4vnwE22z3ZcWxWwe+V8MDAPGAavIR/WD6+5vjXF7vvhO3kf+7exczimt0+P9Wu2BaTKY\ng4CPyNOC9pP/n8DAUv0w8imnW0plr5ETj46G5aETbbfdlybj1h9YQD6NdxD4DLioVH8nsLFo84/i\n8cy6+9rDOM0CfiZPKVtH14RsNbC0Yf3JwNZi/R/IRwyNbc4hT1s7TJ7xMaLufvbWmJFvBb6SfIT1\nF/kS4jucJj+izcat+H4eax+2+kTbPB2WUx0zYAV5Suqf5Bl+HwOX1d3PmuO28xgx66DhwLKn+zVv\nRidJkirXa8aASJKkM4cJiCRJqpwJiCRJqpwJiCRJqpwJiCRJqpwJiCRJqpwJiCRJqpwJiCRJqpwJ\niCRJqpwJiKSTEhEfRMSRiFh8jLpFRd3SOrZNUvswAZF0shL5nhlTI6J/Z2Hx+AHgl7o2TFL7MAGR\n1IxNwC5gUqlsEjn5OHrr7shejIgdEXE4IjZFxORSfZ+IeK9UvzUiniq/UUQsi4jPI+LZiNgdEXsi\nYmFEnNXiPkpqIRMQSc1IwFJgRqlsBrAMiFLZS8A04DFgFDAfWB4RNxf1fciJzGTgKuB14I2IuL/h\n/W4DLgcmkG8p/nCxSGpT3g1X0kmJiGXA+eSkYhdwBTmR2AJcCrwP7AceB/YBE1NK60uvfxcYkFKa\n1k37C4AhKaUppfe7FRieih1WRHwKdKSUHmxJJyW13Nl1b4Ck9pRS2hMRXwCPkM96fJlS2hdx9ATI\nCGAgsCpKhUBful6mebJoYygwAOhXri9sTl2Pln4FrjmF3ZFUMRMQST2xDFhIviQzq6Hu3OLv3cDu\nhrq/ASJiKjAPeBr4DjgIzAZuaFj/n4bnCS8hS23NBERST6wkn7HoAL5uqNtCTjSGpZTWdPP6ccDa\nlNKSzoKIGN6KDZXUu5iASGpaSulIRIwsHqeGukMR8TYwv5ixsoY8dmQ8cCCltBzYDkyPiDuAncB0\nYCywo8JuSKqBCYikHkkpHTpO3SsR8RvwAnkWy+/ARmBuscoSYDTwCfmyygpgEXBXK7dZUv2cBSNJ\nkirnIC5JklQ5ExBJklQ5ExBJklQ5ExBJklQ5ExBJklQ5ExBJklQ5ExBJklQ5ExBJklQ5ExBJklQ5\nExBJklQ5ExBJklQ5ExBJklS5/wD6ovxjH+G+1wAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAEWCAYAAABrDZDcAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzt3Xl8FPX9x/HXZzcJICDIISKnB6Iop6BIPUA8AH/gXW+p\nbbVardaqLVV/Ldrqg1Zbq2jriVrBg9afikA9gKJSUQQUUMCiHBJPRDkFkux+fn/MQFNMYEmyO8nO\n+/l47CO7c35mssl757sz3zF3R0RE4isRdQEiIhItBYGISMwpCEREYk5BICIScwoCEZGYUxCIiMSc\ngkAkA2Z2vZk9GHUdItmgIJDImNmRZva6ma01s6/M7F9m1qeay/yemc3YbtgjZvbb6izX3W919x9W\nZxmVMTM3s41mtsHMPjazP5pZMsN5+5tZcTbqkvhQEEgkzGx3YCIwGmgGtAFuArZEWVdFzKwgB6vp\n7u6NgGOAs4Dv52CdIoCCQKJzAIC7P+HuKXff5O4vufv8rROY2cVmtsjM1pvZQjPrFQ4fYWYflht+\najj8IOBe4Ijw0/UaM7sEOA/4eTjs+XDavc3saTNbZWbLzOzKcusdaWZ/N7OxZrYO+F44bGw4vmP4\nKX64mX1kZl+a2Q3l5m9gZo+a2ddh/T/P9FO7u38A/AvoUW55F5XbD0vN7Efh8IbAP4C9w23bEG5X\notw+Wm1m482sWThP/XC7Vof75y0za7XLvz3JKwoCicq/gVT4D3Owme1RfqSZnQmMBC4EdgeGAavD\n0R8CRwFNCI4ixppZa3dfBFwKzHT3Ru7e1N3vB8YBvw+HDTWzBPA8MI/gSGQg8FMzO7FcCScDfwea\nhvNX5Eigczj/r8IgAvg10BHYFzgeOD/TnWJmB4bb9kG5wV8A/xPuh4uAO8ysl7tvBAYDn4Tb1sjd\nPwF+ApxCcHSxN/A1cE+4rOHhfmsHNA/316ZM65P8pCCQSLj7OoJ/pA48AKwyswnlPp3+kOCf91se\n+MDdV4Tz/s3dP3H3tLs/BSwBDtuF1fcBWrr7ze5e4u5LwxrOLjfNTHd/NlxHZf8obwqPZOYRhEr3\ncPh3gVvd/Wt3LwbuyqCmuWa2EVgETAf+vHWEu09y9w/D/fAK8BJBWFTmUuAGdy929y0EgXpG2MRV\nShAA+4dHYnPC34XEmIJAIuPui9z9e+7eFjiE4NPrn8LR7Qg++X+LmV1oZu+ETRtrwnlb7MKqOxA0\np6wpt4zrgfJNJCszWM5n5Z5/AzQKn++93fyZLKtXOP9ZwOFAw60jwiOmN8Iv1NcAQ9jx9nYAnim3\nbYuAFMH2PQa8CDxpZp+Y2e/NrDCD+iSPKQikVnD3xcAjBP/UIfjnud/205lZB4JP71cAzd29KfAu\nYFsXVdHit3u9ElgWNh1tfTR29yE7mGdXfAq0Lfe6XSYzhZ/4xwMzgV8BmFk94GngdqBVuL2T2fH2\nrgQGb7d99d39Y3cvdfeb3L0L0I+gyenCKmyj5BEFgUTCzA40s2vMrG34uh1wDvBGOMmDwLVmdqgF\n9g9DoCHBP79V4XwX8Z/wAPgcaGtmRdsN27fc61nAejP7RfjFbtLMDqnuqavljAd+aWZ7mFkbgtDa\nFaOAi81sL6AIqEewvWVmNhg4ody0nwPNzaxJuWH3AreE+wsza2lmJ4fPB5hZVwtOT11H0FSU3vVN\nlHyiIJCorCdoAnkzbBt/g+CT/TUQfA8A3AI8Hk77LNDM3RcCfyD41Pw50JXgLJutpgHvAZ+Z2Zfh\nsIeALmFTybPuniL4JNwDWAZ8SRA85f+ZVsfNQHG47CkEXzpnfFqsuy8AXgWuc/f1wJUE4fI1cC4w\nody0i4EngKXh9u0N3BlO85KZrSfYt4eHs+wV1rOOoMnoFYLmIokx041pRLLLzC4Dznb3Y6KuRaQi\nOiIQqWFm1trMvhOez9+Z4CjnmajrEqlMLq6YFImbIuA+YB9gDfAk5U4HFalt1DQkIhJzahoSEYm5\nOtE01KJFC+/YsWPUZYiI1Clz5sz50t1b7my6OhEEHTt2ZPbs2VGXISJSp5jZikymU9OQiEjMKQhE\nRGJOQSAiEnN14jsCEan7SktLKS4uZvPmzVGXknfq169P27ZtKSysWkeyCgIRyYni4mIaN25Mx44d\nMbOdzyAZcXdWr15NcXEx++yzT5WWoaYhEcmJzZs307x5c4VADTMzmjdvXq0jLQWBiOSMQiA7qrtf\nFQQiIjGnIBCR2GjUqNG255MnT+aAAw5gxYoVjBw5kjZt2tCjRw86derEaaedxsKFC7dN279/fzp3\n7kyPHj3o0aMHZ5xxRhTlZ42+LJas6ThiUoXDl486KceViPy3qVOncuWVV/Liiy/SoUMHAK6++mqu\nvfZaAJ566imOPfZYFixYQMuWQQ8N48aNo3fv3pHVnE06IhCRWHn11Ve5+OKLmThxIvvt963bYgNw\n1llnccIJJ/D444/nuLpo6IhARHLvHyPgswU1u8y9usLgUTucZMuWLZxyyilMnz6dAw88cIfT9urV\ni8WLF297fd5559GgQQMAjj/+eG677bbq11xLKAhEJDYKCwvp168fDz30EHfeeecOp93+Xi353DSk\nIBCR3NvJJ/dsSSQSjB8/noEDB3Lrrbdy/fXXVzrt22+/nbf/+Len7whEJFZ22203Jk2axLhx43jo\noYcqnObpp5/mpZde4pxzzslxddHQEYGIxE6zZs144YUXOProo7edFXTHHXcwduxYNm7cyCGHHMK0\nadO2jYP//o6gRYsWTJkyJZLas0FBICKxsWHDhm3P27Vrx7JlywAYNmwYI0eOrHS+6dOnZ7myaKlp\nSEQk5nREILWGLkATiYaOCEREYk5BICIScwoCEZGYUxCIiMScviwWkUhUdnJAVWVyUkGjRo3+6xTS\nRx55hNmzZ3P33Xdz7733sttuu3HhhRdWOO/06dMpKiqiX79+NVZzbZG1IDCzdsBfgVaAA/e7+51m\n1gx4CugILAe+6+5fZ6sOEZFMXHrppTscP336dBo1alQjQVBWVkZBQe35HJ7NpqEy4Bp37wL0BS43\nsy7ACGCqu3cCpoavRUQiNXLkSG6//XYA7rrrLrp06UK3bt04++yzWb58Offeey933HEHPXr04LXX\nXmP58uUce+yxdOvWjYEDB/LRRx8B8OGHH9K3b1+6du3KjTfeuO1mONOnT+eoo45i2LBhdOnSBYBT\nTjmFQw89lIMPPpj7779/Wy2NGjXiuuuu4+CDD+a4445j1qxZ9O/fn3333ZcJEybU+LZnLZLc/VPg\n0/D5ejNbBLQBTgb6h5M9CkwHfpGtOkREttq0aRM9evTY9vqrr75i2LBh35pu1KhRLFu2jHr16rFm\nzRqaNm3KpZdeSqNGjbbdvGbo0KEMHz6c4cOHM2bMGK688kqeffZZrrrqKq666irOOecc7r333v9a\n7ty5c3n33XfZZ599ABgzZgzNmjVj06ZN9OnTh9NPP53mzZuzceNGjj32WG677TZOPfVUbrzxRl5+\n+WUWLlzI8OHDK6y5OnLyZbGZdQR6Am8CrcKQAPiMoOlIRCTrGjRowDvvvLPtcfPNN1c4Xbdu3Tjv\nvPMYO3ZspU04M2fO5NxzzwXgggsuYMaMGduGn3nmmQDbxm912GGHbQsBCI48unfvTt++fVm5ciVL\nliwBoKioiEGDBgHQtWtXjjnmGAoLC+natSvLly+v+g6oRNaDwMwaAU8DP3X3deXHedDht1cy3yVm\nNtvMZq9atSrbZYqIbDNp0iQuv/xy5s6dS58+fSgrK6uR5TZs2HDb8+nTpzNlyhRmzpzJvHnz6Nmz\nJ5s3bwaC+yaYGRB0nV2vXr1tz2uqlvKyGgRmVkgQAuPc/f/CwZ+bWetwfGvgi4rmdff73b23u/cu\n3wOgiEg2pdNpVq5cyYABA/jd737H2rVr2bBhA40bN2b9+vXbpuvXrx9PPvkkENy05qijjgKgb9++\nPP300wDbxldk7dq17LHHHuy2224sXryYN954I4tbtWPZPGvIgIeARe7+x3KjJgDDgVHhz+eyVYOI\n1F61tQ+pVCrF+eefz9q1a3F3rrzySpo2bcrQoUM544wzeO655xg9ejSjR4/moosu4rbbbqNly5Y8\n/PDDAPzpT3/i/PPP55ZbbmHQoEE0adKkwvUMGjSIe++9l4MOOojOnTvTt2/fXG7mf7Htb8dWYws2\nOxJ4DVgApMPB1xN8TzAeaA+sIDh99KsdLat3794+e/bsrNQp2bOrncip07n8tmjRIg466KCoy8i6\nb775hgYNGmBmPPnkkzzxxBM891z2P+9WtH/NbI677/Q2a9k8a2gGYJWMHpit9YqIRGnOnDlcccUV\nuDtNmzZlzJgxUZe0U7XnigYRkTxw1FFHMW/evKjL2CXqa0hEciZbTdFxV939qiAQkZyoX78+q1ev\nVhjUMHdn9erV1K9fv8rLUNOQiORE27ZtKS4uRtcF1bz69evTtm3bKs+vIBCRnCgsLPyvq2ql9lDT\nkIhIzCkIRERiTkEgIhJzCgIRkZhTEIiIxJyCQEQk5hQEIiIxpyAQEYk5BYGISMwpCEREYk5BICIS\ncwoCEZGYUxCIiMScgkBEJOYUBCIiMacgEBGJOQWBiEjMKQhERGJOQSAiEnMKAhGRmFMQiIjEnIJA\nRCTmFAQiIjGnIBARiTkFgYhIzCkIRERiTkEgIhJzCgIRkZhTEIiIxJyCQEQk5hQEIiIxpyAQEYk5\nBYGISMxlLQjMbIyZfWFm75YbNtLMPjazd8LHkGytX0REMpPNI4JHgEEVDL/D3XuEj8lZXL+IiGQg\na0Hg7q8CX2Vr+SIiUjOi+I7gJ2Y2P2w62iOC9YuISDkFOV7fX4DfAB7+/APw/YomNLNLgEsA2rdv\nn6v6RLbpOGJShcOXjzqpRpZTlWWJZENOjwjc/XN3T7l7GngAOGwH097v7r3dvXfLli1zV6SISMzk\nNAjMrHW5l6cC71Y2rYiI5EbWmobM7AmgP9DCzIqBXwP9zawHQdPQcuBH2Vq/iIhkJmtB4O7nVDD4\noWytT0REqkZXFouIxJyCQEQk5hQEIiIxpyAQEYm5XF9QJlJjdnShVkUqu3hrV5cjkm90RCAiEnMK\nAhGRmFMQiIjEnIJARCTmFAQiIjGnIBARibmMgsDM/s/MTjIzBYeISJ7J9B/7n4FzgSVmNsrMOmex\nJhERyaGMLihz9ynAFDNrApwTPl9JcHOZse5emsUaRWqELhwTqVjGTT1m1hz4HvBD4G3gTqAX8HJW\nKhMRkZzI6IjAzJ4BOgOPAUPd/dNw1FNmNjtbxYmISPZl2tfQA+4+ufwAM6vn7lvcvXcW6hIRkRzJ\ntGnotxUMm1mThYiISDR2eERgZnsBbYAGZtYTsHDU7sBuWa5NRERyYGdNQycSfEHcFvhjueHrgeuz\nVJOIiOTQDoPA3R8FHjWz09396RzVJCIiObSzpqHz3X0s0NHMfrb9eHf/YwWziYhIHbKzpqGG4c9G\n2S5ERESisbOmofvCnzflphypa3S1bvVUtv8qu61mtpcj8ZRpp3O/N7PdzazQzKaa2SozOz/bxYmI\nSPZleh3BCe6+DvgfYDmwP3BdtooSEZHcyTQItjYhnQT8zd3XZqkeERHJsUy7mJhoZouBTcBlZtYS\n2Jy9skREJFcyOiJw9xFAP6B32OX0RuDkbBYmIiK5kekRAcCBBNcTlJ/nrzVcj8SVO3vyNS1tDQ3Z\nzBYKWUMjPvEWUVcmkvcy7Yb6MWA/4B0gFQ52FARSHek0fDgN5j0Oy15lVv1V35ok5QZ/ag+tu0Ob\nQ4PH3j2hni5tEakpmR4R9Aa6uLtnsxiJkWWvwYvXw2fzoUEz6HQCv5pTj8+8GRtoQBGltLB1tLMv\nuKoN8MnbsGhCMK8lYM+DuaVgT+amOzHXO7HM9+I/fSKKyK7INAjeBfYCPt3ZhJKfaurCsSQpmDIS\nZtwBTdrDqffBwadBQRF/nVXxOq46M7woauNq+GQuFL8FK2cxNPk65xVMBeArb8Tb6U7bgmF+el82\n0qBGas5HugBNyss0CFoAC81sFrBl60B3H5aVqiQv1aOEuwtHw4w50Gs4DBoFRbvQm3nD5tDp+OAB\ndB/xPJ3sY3olltDTPqBXYgkDC98GIO3GB743C3xf5qeDx0LvwBaKsrFpInVapkEwMptFSP4roIz7\nCu+gf3IeDLkdDru42st0Evzb2/HvVDue5FgAdmcDPRMf0jOxhENsGUcn5nN68jUAyjyYfn56n20B\nsdjbU7pL50yI5J+M/gLc/RUz6wB0cvcpZrYbkMxuaZI/nJsLHqF/ch4jSn/IqBoIgcqsoxGvpLvz\nSrr7tnXvxVd0Syyla2IZ3WwpJyZnc7ZNB2Cj12Nmusu2eT7yVlmrTaS2yvSsoYuBS4BmBGcPtQHu\nBQZmrzTJF+clp3JuwTTuKRvGk6ljGZXTtRuf0ZzP0s15Kd0nHOa0tVV0t6UcnlhE/8Q7HBc2KS1K\nt2Ni6ggmpvuywvfKaaUiUcn0mPhy4DDgTQB3X2Jme2atKskb+9nH3FgwlldS3bi97LtRlxMyin1P\nin1PJqX7Ak5H+4wBiXcYknyT6wrHcx3jmZfel6dSA3gu1U9fPEteyzQItrh7iVlwel54UZlOJZUd\nSpDmD4V/YRNFXFv6Izzjrq1yzVjurXk41ZqHU4NpzWpOSr7B6cnXuLXwIa4vGMeEVD8eTx3Lu75v\n1MWK1LhMg+AVM7ue4Cb2xwM/Bp7f0QxmNoagt9Iv3P2QcFgz4CmgI0Evpt9196+rVrrUduckp9Ej\nsZQrSn7CKvaIupyMfUpzHkydxIOpIfS0DzgnOY1TkzM4t2Aas9MHwMIUHHgSJPQ1meSHTD+ijQBW\nAQuAHwGTgRt3Ms8jwKAKljPV3TsBU8PXkoeasIFrC8bzeqoLE9N9oy6nioy3vRM/L/sRh2+5h5tK\nL2BPvobxF8DoQ+HN+6FkY9RFilRbpp3OpYFngR+7+xnu/sDOrjJ291eBr7YbfDLwaPj8UeCUXaxX\n6oifFfyNxnzDTWUXkg9X/K6jIQ+nBtO/5A4481Fo2AL+cR38sQtM/U1wsZtIHbWzm9cb8GvgCsLQ\nMLMUMNrdb67C+lq5+9arkz8DKj1Xz8wuIThTifbt21dhVRKVtraKc5PTeCJ1LO/7t393dfn2lmkS\ndHwsAVxNL/s3F6cmceKrf2DTq6N5LHUCD5QNYTVNqr2eqK781RXH8bSzI4Krge8Afdy9mbs3Aw4H\nvmNmV1dnxeERRaVHFe5+v7v3dvfeLVu2rM6qJMd+nHyONMY9ZfndU/lcP4DLSq/mhJLf8XL6UC5O\nTmRGvau4oWAsLVkTdXkiGdtZEFwAnOPuy7YOcPelwPnAhVVY3+dm1hog/PlFFZYhtVgbVnFm8hWe\nTA3gM5pHXU5OfOBt+WnpFRxfchuT04dzUfIFXqt3FSMKnmB39B2C1H47C4JCd/9y+4HuvgoorML6\nJgDDw+fDgeeqsAypxS4teJ40xl/K4tcN1VLfm2tKL2Ngye1MSvflkuREXql3NT9ITqKI0qjLE6nU\nzoKgpIrjMLMngJlAZzMrNrMfAKOA481sCXBc+FryRBM2cEbyVZ5JHRmbo4GKrPC9uKb0Mk4quZX5\n6X3538JxTC26lmGJ19HlN1Ib7ew6gu5mtq6C4QbU39GM7n5OJaPULUWeOic5jQZWwsOp7c8ajqdF\n3oHhpSM4MrWAXxY8zl1Fd3Nueir/W3oRS7xt1OWJbLPDIwJ3T7r77hU8Grt7VZqGJE8VUMaFBS8x\nI3VwhWcKxdmMdFeGltzCL0t/QGdbyeSiX/LLgnE0ZFPUpYkAmV9QJrJDJyZms7d9xZjU4KhLqZXS\nJHgiNZBjt9zO31NH86OCSUytdy0nJd5AzUUSNQWB1Ihzk1NZmW7JP9M9oi6lVvua3fll2cWcuuUm\nvvQm3FN0F38tHEUH+yzq0iTGdEcOqbZ29jnfSb7HH0rPqMUdy9Uub3snhpX8lguSL3NNwXheKvoF\nf0kN5S9lw2rlXdR29SJAXYBWt+ivVqrtzOQrpN34e+qYqEupU9IkeDR1IgO33M4L6T78tOD/eKHo\nFxyVmB91aRIzCgKplgRpzky+yivpbnwa41NGq2MVe3BV6RWcV/JL0iR4rGgUdxfeRatvddUlkh0K\nAqmWoxPzaG1f8VRqQNSl1Hn/SndlcMkobi89k+MSc5ha71q+n/wHBZRFXZrkOQWBVMsZyVdZ7Y2Z\nmu4VdSl5oYRC7k6dyvElv+etdGd+VfgY04qu4YzkKyRJRV2e5CkFgVRZI77huMRcJqX6UqrzDmrU\nSm/FRaU/56KS61hLQ24vvI+Xi66Dtx6ELeujLk/yjIJAquy4xFzqWykTUkdEXUqeMv6Z7snQklu4\nuORnbKQ+TLoG/nAQTLoWVsyEdDrqIiUP6GOcVNmw5Ot87M2Z4wdEXUqeM15O9+blkkNZfnkreOsB\nmPvX4GejvaDzIIYmGvFG+qA6dUtQqT0UBFIlTVnPUYkFPJQarGsHcsagXZ/gMeR2WPISvPcMLHia\n0UVBc9GydCvmeifeTndibroTpMogqT9z2TG9Q6RKhiRnUWgpnk/1y/q66vIdzbKm/u7Q9YzgkSpj\n6I1/oW9iIX0S73N0Yj6nJ2cAsPHmm5iX3o+5HgTD2+n9+ZrdIy5eahsFgVTJsOTrfJhuzXveIepS\nJFnAAt+XBal9eSD1P4DTzr6gly2hV2IJPRMfcGnieQoKgu8TlqVbMcc7MyF1BK+lu+qIThQEsuta\n8RWH2WLuLDuNfLgxff4xVnorVnornksfCUB9ttDNltIrEYTDcYk5nJF8lWJvwQNlJ/FE6lhKqnSv\nKckHCgLZZUOSb5Iw5/m0zhaqKzZTj1l+ELNSB0EKiijl+MQcLix4iZsKH+WSgon8rvRsJqT7oXCP\nHx0Tyi4blHyLxel2LPW9oy5FqqiEQial+3JWyf9ybsn1fOlNuKvoHsYU3kZLvo66PMkxBYHskmas\no7e9z4vp3lGXIjXCeD19CKeW3MzNpRdwRGIhE+vdwKH2ftSFSQ4pCGSXHJecQ9Kcl1J9oi5FalCa\nBGNSgzml5GY2eT2eLPpteI9liQMFgeySExOzKfYWOlsoT73v7RlW8lvmeif+VHgP5yanRl2S5ICC\nQDLWkE0cmVjAC6k+6AvF/LWOhlxYMoJ/pntwa+FDnJZ4NeqSJMsUBJKxAYl3qGdlvKhmoby3hSIu\nK/0pM1IH8/vC+xmQeDvqkiSLdPqoZOzE5Ft86burb6EI5fIq6xIK+VHpz3iy6DeMLhzNKSU384G3\nzWjeyurULSxrJx0RSEaKKKV/Yh4vpw4lrbdNbGykAT8suZZN1OP+wj/SmG+iLkmyQH/RkpF+iXdp\nbJt4Ma1mobj5nGb8uOQq2tkqfl94H+BRlyQ1TEEgGTkxMZv13oDX0wdHXYpE4C0/kNvLvsvg5Fuc\nnngt6nKkhikIZOfSKY5PzuGf6R7qjybGHkidxJvpAxlZ+ChtbVXU5UgNUhDIzn30Bi1snc4Wirk0\nCa4pvQyA2wrURJRPFASyc4snssULmZ7uHnUlErFib8mtZedyRHIhp6mJKG8oCGTH3GHxRGakD2Ej\nDaKuRmqBJ1MDmJPuxA2F42jChqjLkRqgIJAd+/xdWPMRL6mTOQk5CW4o/QFN2MgvCp6IuhypAQoC\n2bHFkwFjaqpX1JVILbLY2/NwahBnJ6fTxZZHXY5Uk4JAdmzxRGh3OF/SJOpKpJYZXXYqa2nI9QXj\n0BfHdZuCQCq35iP4bD4cqG4B5NvW0ZA7y07jyOR79E/Mi7ocqQYFgVRu8eTgp4JAKjEudRxL03tx\nfcE4kqSiLkeqSEEglVs8EVoeCM33i7oSqaVKKeB3ZedwQOJjTk+qu+q6SkEgFfvmK1jxuo4GZKde\nTPfmnfR+XFnwDIWURV2OVIGCQCq25CXwlIJAMmDcUXYGbe1Lzki+EnUxUgWRBIGZLTezBWb2jpnN\njqIG2YnFE6Hx3tC6Z9SVSB3wSrobc9P7c0XBsxRRGnU5souiPCIY4O493F1XKtU2pZvgg6lw4BBI\n6KBRMmH8sexM2thqvpucHnUxsov0Vy7ftnQ6lH6jZiHZJTPSh/BW+gAuL3iOepREXY7sgqiCwIEp\nZjbHzC6paAIzu8TMZpvZ7FWr1OVtrnQcMYmnHruXdd6ATg+sp+OISTm9PaLUZcFRQWv7irOS/4y6\nGNkFUQXBke7eAxgMXG5mR28/gbvf7+693b13y5Ytc19hTCVIc1xyDv9M96RUt7SWXTQz3YXZ6QO4\npGASBTqDqM6IJAjc/ePw5xfAM8BhUdQh39bb3qe5refl1KFRlyJ1kvHnsmG0tS8Zlng96mIkQzkP\nAjNraGaNtz4HTgDezXUdUrEhyTfZ7IVMS+tsIamaaemeLEq357KC5zHSUZcjGYjiiKAVMMPM5gGz\ngEnu/kIEdcj20mkGJ2cxPd2Db6gfdTVSZxl/KRtGp8THnJCYE3UxkoGcB4G7L3X37uHjYHe/Jdc1\nSCVWvkErW8Pk1OFRVyJ13KT04axI78llBc+hnklrP50+Kv/x3rNs8UKmqllIqilFkvtSQ+mRWEq/\nxHtRlyM7oSCQQDoNiyYwPd1dt6SUGvF06ig+96Zcnnwu6lJkJxQEElj5Jqz/lElqFpIasoUiHiwb\nwneS79HdPoi6HNkBBYEEFj4LyXpMTeuWlFJzHk8NZI035McFE6IuRXZAQSBBs9DCCbD/cWoWkhq1\nkQY8mjqRE5Oz6WTFUZcjlVAQCCx/DdZ/AoecFnUlkoceLjuRjV6PHxfou4LaSkEgMP8pKGqsTuYk\nK9bQmHGp44Irjb9aGnU5UgEFQdyVfBM0C3U5GQrVLCTZ8UDZEMoogBl/iroUqYCCIO7enwwl66H7\nWVFXInlsFXswPnUMvPM4rP046nJkOwqCuJv/FOzeBjocGXUlkufuSw0FT8Pro6MuRbajIIizDauC\nO5F1PVN3IpOsK/aW0O0smPNI8N6TWkN//XG2YHxwg/puahaSHDnqZ1C2Gd74c9SVSDkKgrhyh9kP\nQ9s+0Kr94jkHAAAJk0lEQVRL1NVIXLToFJyY8NaDsGlN1NVISEEQVyteh9VL4NDvRV2JxM1R18CW\ndTDrgagrkZCCIK7mPAz1msDBuohMcqx1N+h0IrxxD2xeG3U1goIgnjauhoXPBaeMFu0WdTUSRwN+\nCZu+hpn3RF2JoCCIp3fGQapEzUISnb17Bt8VzLwHNn4ZdTWxpyCIm1QpvHkfdPgOtDo46mokzgbc\nAKXfwIw7oq4k9hQEcbPwOVhXDP1+EnUlEnctO0P3c4MvjXW1caQUBHHiHlzV2bxT8GWdSNT6/yK4\n2nj6rVFXEmsKgjhZ/hp8+g4ccbmuJJbaoWl7OPxH8PY4+Hhu1NXElv4bxIU7TB8FjfaC7mdHXY3I\nfxzzc2jYAv7xi+B9KjmnIIiLZa/Ain8FF/Oou2mpTeo3gYG/huJZMH981NXEkoIgDtxh2i1BL6O9\nLoy6GpFv63FecErpy7/SRWYRUBDEweJJwaeto66BwvpRVyPybYkEnPQH2PhFEAaSUwqCfFe6GV68\nHloepKMBqd3aHApHXBF0U710etTVxIqCIN/NHA1rVsDgUZAsjLoakR0bcD002w8m/AS2rI+6mthQ\nEOSz1R/Ca3+Eg4bCvv2jrkZk5wobwCl/hrXFMPFqnUWUIwqCfJVOwbM/Do4CBv8+6mpEMte+b3Bk\nsOBvQTORZJ2CIF+9PhpWvgFDbofd9466GpFdc+Q1sN+xwbUFutAs6xQE+WjZazD1ZjhoWHA/YpG6\nJpGA0x6ARq3g8bPg6xVRV5TXFAT55usVMP5CaL4/nHwPmEVdkUjVNGwB5/8dUltg3JnqrjqLFAT5\nZP3nMPb04PuBsx+H+rtHXZFI9bTsHLyX16yAR04K3uNS4xQE+WLDF/DoUFj3CZz7FLTYP+qKRGpG\nxyPhvL/Bmo/g4cHB2XBSoxQE+eCzd+GBgcEfynnjocMRUVckUrP2ORoueAY2r4EHBsAHU6KuKK8o\nCOoyd5j7GDx0AqRL4aLJwacnkXzUvi9cPC3oM2vs6TD5OijZGHVVeUFBUFd9sSj4Y5hwBezdAy7+\nJ7TpFXVVItm1R0f44VQ4/DKYdT+M7h18GEqnoq6sTlMQ1CXusOJ1+Pv34c9HwMpZMPg2GD4Rdm8d\ndXUiuVG0W9BlykUvBO/7CVfA3b3h9bvhm6+irq5OKohipWY2CLgTSAIPuvuoKOqoE7asD/7hfzgN\n/v0CrP4AihoH9xw+8mrYrVnUFYpEo8MRwdHBoufhjT/DSzfAlF9D+yOg8+CgKanVIVBQL+pKa72c\nB4GZJYF7gOOBYuAtM5vg7gtzXUvGtvZ34g7s4Pm2flF29tyhrARKNgRtnCUboWQ9fPM1rP8E1n0K\na1fC5+/C18uDWZNF0KFf8M//4FOhqGF2t1mkLjCDLsOCx2fvwrtPw/v/CHrcBUgUwp4HBU1Ke3SA\nJu2gQTNosAc0aBrcFCdZFIRFsug/zxMFsboGJ4ojgsOAD9x9KYCZPQmcDNR8ELxwPcx5OHhe1X/c\nUShqFHwh1roH9DwfWvcMPv3on79I5fY6JHgc92tYsxI+ngOfzIXP3wu+U/v3i8HFabvMwlDI4Gc2\nnD026G4ji6IIgjbAynKvi4HDt5/IzC4BLglfbjCz96uxzhZAHboscR3wCfBWtldUx/ZLTmnfVK7K\n+8Z+V8OV1D41/765cWB15u6QyUSRfEeQCXe/H7i/JpZlZrPdvXdNLCufaL9UTvumcto3laur+yaK\ns4Y+BtqVe902HCYiIhGIIgjeAjqZ2T5mVgScDUyIoA4RESGCpiF3LzOzK4AXCU4fHePu72V5tTXS\nxJSHtF8qp31TOe2bytXJfWOuW8GJiMSariwWEYk5BYGISMzlRRCYWTMze9nMloQ/96hkukFm9r6Z\nfWBmI8oNH2lmH5vZO+FjSO6qz47KtrXceDOzu8Lx882sV6bz1nXV3DfLzWxB+D6ZndvKsyuD/XKg\nmc00sy1mdu2uzFvXVXPf1P73jLvX+Qfwe2BE+HwE8LsKpkkCHwL7AkXAPKBLOG4kcG3U21GD+6PS\nbS03zRDgHwSXQ/YF3sx03rr8qM6+CcctB1pEvR0R7Zc9gT7ALeX/XvSeqXzf1JX3TF4cERB0UfFo\n+PxR4JQKptnWtYW7lwBbu7bIR5ls68nAXz3wBtDUzFpnOG9dVp19k892ul/c/Qt3fwso3dV567jq\n7Js6IV+CoJW7fxo+/wxoVcE0FXVt0abc65+EzQBjKmtaqkN2tq07miaTeeuy6uwbCDqgmmJmc8Ju\nUPJFdX7ves/sWK1/z9TaLia2Z2ZTgL0qGHVD+Rfu7ma2q+fE/gX4DcEv7DfAH4DvV6VOyXtHuvvH\nZrYn8LKZLXb3V6MuSmq1Wv+eqTNB4O7HVTbOzD43s9bu/ml4CP9FBZNV2rWFu39eblkPABNrpurI\nZNKNR2XTFGYwb11WnX2Du2/9+YWZPUPQbFCr/qirqDpdv+R7tzHV2r668J7Jl6ahCcDw8Plw4LkK\npqm0a4vt2n9PBd7NYq25kEk3HhOAC8MzZPoCa8PmtXzvAqTK+8bMGppZYwAzawicQN1/r2xVnd+7\n3jOVqDPvmai/ra6JB9AcmAosAaYAzcLhewOTy003BPg3wRkAN5Qb/hiwAJhP8AtuHfU21cA++da2\nApcCl4bPjeAGQR+G2957Z/spXx5V3TcEZ43MCx/v5du+yWC/7EXQPr4OWBM+313vmcr3TV15z6iL\nCRGRmMuXpiEREakiBYGISMwpCEREYk5BICIScwoCEZGYUxCIlGNmbmZjy70uMLNVZlbXLzIUqZSC\nQOS/bQQOMbMG4evjya+rZEW+RUEg8m2TgZPC5+cAT2wdEV4pOsbMZpnZ22Z2cji8o5m9ZmZzw0e/\ncHh/M5tuZn83s8VmNs7MLOdbJLIDCgKRb3sSONvM6gPdgDfLjbsBmObuhwEDgNvCrgO+AI53917A\nWcBd5ebpCfwU6EJwpel3sr8JIpmrM53OieSKu883s44ERwOTtxt9AjCs3F2o6gPtgU+Au82sB5AC\nDig3zyx3LwYws3eAjsCMbNUvsqsUBCIVmwDcDvQn6MtqKwNOd/f3y09sZiOBz4HuBEfam8uN3lLu\neQr93Ukto6YhkYqNAW5y9wXbDX+R4CZGBmBmPcPhTYBP3T0NXEBwe0OROkFBIFIBdy9297sqGPUb\ngns2zDez98LXAH8GhpvZPOBAgrOPROoE9T4qIhJzOiIQEYk5BYGISMwpCEREYk5BICIScwoCEZGY\nUxCIiMScgkBEJOb+H/MP8RDX50XfAAAAAElFTkSuQmCC\n",
       "text/plain": [
-       "<matplotlib.figure.Figure at 0x7f7d7dd0a588>"
+       "<matplotlib.figure.Figure at 0x7f6eee437208>"
       ]
      },
      "metadata": {},
@@ -2143,9 +2150,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.0"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/examples/jupyter/pincell.ipynb
+++ b/examples/jupyter/pincell.ipynb
@@ -240,7 +240,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "So far you've seen the \"hard\" way to create a material. The \"easy\" way is to just pass strings to `add_nuclide()` and `add_element()` -- they are implicitly coverted to `Nuclide` and `Element` objects. For example, we could have created our UO2 material as follows:"
+    "So far you've seen the \"hard\" way to create a material. The \"easy\" way is to just pass strings to `add_nuclide()` and `add_element()` -- they are implicitly converted to `Nuclide` and `Element` objects. For example, we could have created our UO2 material as follows:"
    ]
   },
   {
@@ -509,12 +509,12 @@
     "At this point, we have three materials defined, exported to XML, and ready to be used in our model. To finish our model, we need to define the geometric arrangement of materials. OpenMC represents physical volumes using constructive solid geometry (CSG), also known as combinatorial geometry. The object that allows us to assign a material to a region of space is called a `Cell` (same concept in MCNP, for those familiar). In order to define a region that we can assign to a cell, we must first define surfaces which bound the region. A *surface* is a locus of zeros of a function of Cartesian coordinates $x$, $y$, and $z$, e.g.\n",
     "\n",
     "- A plane perpendicular to the x axis: $x - x_0 = 0$\n",
-    "- A cylinder perpendicular to the z axis: $(x - x_0)^2 + (y - y_0)^2 - R^2 = 0$\n",
+    "- A cylinder parallel to the z axis: $(x - x_0)^2 + (y - y_0)^2 - R^2 = 0$\n",
     "- A sphere: $(x - x_0)^2 + (y - y_0)^2 + (z - z_0)^2 - R^2 = 0$\n",
     "\n",
-    "Between those three classes of surfaces (planes, cylinders, spheres), one can construct a wide variety of models. It is also possible to define cones and general second-order surfaces (torii are not currently supported).\n",
+    "Between those three classes of surfaces (planes, cylinders, spheres), one can construct a wide variety of models. It is also possible to define cones and general second-order surfaces (tori are not currently supported).\n",
     "\n",
-    "Note that defining a surface is not sufficient to specify a volume -- in order to define an actual volume, one must reference the half-space of a surface. A surface *half-space* is the region whose points satisfy a positive of negative inequality of the surface equation. For example, for a sphere of radius one centered at the origin, the surface equation is $f(x,y,z) = x^2 + y^2 + z^2 - 1 = 0$. Thus, we say that the negative half-space of the sphere, is defined as the collection of points satisfying $f(x,y,z) < 0$, which one can reason is the inside of the sphere. Conversely, the positive half-space of the sphere would correspond to all points outside of the sphere.\n",
+    "Note that defining a surface is not sufficient to specify a volume -- in order to define an actual volume, one must reference the half-space of a surface. A surface *half-space* is the region whose points satisfy a positive or negative inequality of the surface equation. For example, for a sphere of radius one centered at the origin, the surface equation is $f(x,y,z) = x^2 + y^2 + z^2 - 1 = 0$. Thus, we say that the negative half-space of the sphere, is defined as the collection of points satisfying $f(x,y,z) < 0$, which one can reason is the inside of the sphere. Conversely, the positive half-space of the sphere would correspond to all points outside of the sphere.\n",
     "\n",
     "Let's go ahead and create a sphere and confirm that what we've told you is true."
    ]
@@ -792,7 +792,7 @@
     "\n",
     "We now have enough knowledge to create our pin-cell. We need three surfaces to define the fuel and clad:\n",
     "\n",
-    "1. The outer surface of the fuel -- a cylinder perpendicular to the z axis\n",
+    "1. The outer surface of the fuel -- a cylinder parallel to the z axis\n",
     "2. The inner surface of the clad -- same as above\n",
     "3. The outer surface of the clad -- same as above\n",
     "\n",

--- a/examples/jupyter/post-processing.ipynb
+++ b/examples/jupyter/post-processing.ipynb
@@ -131,7 +131,6 @@
     "clad_outer_radius = openmc.ZCylinder(x0=0.0, y0=0.0, R=0.45720)\n",
     "\n",
     "# Create boundary planes to surround the geometry\n",
-    "# Use both reflective and vacuum boundaries to make life interesting\n",
     "min_x = openmc.XPlane(x0=-0.63, boundary_type='reflective')\n",
     "max_x = openmc.XPlane(x0=+0.63, boundary_type='reflective')\n",
     "min_y = openmc.YPlane(y0=-0.63, boundary_type='reflective')\n",
@@ -292,7 +291,7 @@
     "plot.origin = [0, 0, 0]\n",
     "plot.width = [1.26, 1.26]\n",
     "plot.pixels = [250, 250]\n",
-    "plot.color = 'mat'\n",
+    "plot.color_by = 'material'\n",
     "\n",
     "# Instantiate a Plots collection and export to \"plots.xml\"\n",
     "plot_file = openmc.Plots([plot])\n",
@@ -686,8 +685,7 @@
       "Tally\n",
       "\tID             =\t10000\n",
       "\tName           =\tflux\n",
-      "\tFilters        =\t\n",
-      "                \t\tMeshFilter\t[10000]\n",
+      "\tFilters        =\tMeshFilter\t[10000]\n",
       "\tNuclides       =\ttotal \n",
       "\tScores         =\t['flux', 'fission']\n",
       "\tEstimator      =\ttracklength\n",
@@ -704,7 +702,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The statepoint file actually stores the sum and sum-of-squares for each tally bin from which the mean and variance can be calculated as described [here](http://mit-crpg.github.io/openmc/methods/tallies.html#variance). The sum and sum-of-squares can be accessed using the ``sum`` and ``sum_sq`` properties:"
+    "The statepoint file actually stores the sum and sum-of-squares for each tally bin from which the mean and variance can be calculated as described [here](http://openmc.readthedocs.io/en/latest/methods/tallies.html#variance). The sum and sum-of-squares can be accessed using the ``sum`` and ``sum_sq`` properties:"
    ]
   },
   {
@@ -821,8 +819,7 @@
       "Tally\n",
       "\tID             =\t10001\n",
       "\tName           =\tflux\n",
-      "\tFilters        =\t\n",
-      "                \t\tMeshFilter\t[10000]\n",
+      "\tFilters        =\tMeshFilter\t[10000]\n",
       "\tNuclides       =\ttotal \n",
       "\tScores         =\t['flux']\n",
       "\tEstimator      =\ttracklength\n",
@@ -1043,7 +1040,7 @@
     }
    ],
    "source": [
-    "# Create log-spaced energy bins from 1 keV to 100 MeV\n",
+    "# Create log-spaced energy bins from 1 keV to 10 MeV\n",
     "energy_bins = np.logspace(3,7)\n",
     "\n",
     "# Calculate pdf for source energies\n",

--- a/examples/jupyter/search.ipynb
+++ b/examples/jupyter/search.ipynb
@@ -37,7 +37,7 @@
     "\n",
     "To perform the search we will use the `openmc.search_for_keff` function.  This function requires a different function be defined which creates an parametrized model to analyze. This model is required to be stored in an `openmc.model.Model` object. The first parameter of this function will be modified during the search process for our critical eigenvalue.\n",
     "\n",
-    "Our model will be a pin-cell from the [Multi-Group Mode Part II](./mg-mode-part-ii.rst) assembly, except this time the entire model building process will be contained within a function, and the Boron concentration will be parametrized."
+    "Our model will be a pin-cell from the [Multi-Group Mode Part II](http://openmc.readthedocs.io/en/latest/examples/mg-mode-part-ii.html) assembly, except this time the entire model building process will be contained within a function, and the Boron concentration will be parametrized."
    ]
   },
   {

--- a/examples/jupyter/tally-arithmetic.ipynb
+++ b/examples/jupyter/tally-arithmetic.ipynb
@@ -115,7 +115,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now let's move on to the geometry. Our problem will have three regions for the fuel, the clad, and the surrounding coolant. The first step is to create the bounding surfaces -- in this case two cylinders and six reflective planes."
+    "Now let's move on to the geometry. Our problem will have three regions for the fuel, the clad, and the surrounding coolant. The first step is to create the bounding surfaces -- in this case two cylinders and six planes."
    ]
   },
   {
@@ -293,7 +293,7 @@
     "plot.origin = [0, 0, 0]\n",
     "plot.width = [1.26, 1.26]\n",
     "plot.pixels = [250, 250]\n",
-    "plot.color = 'mat'\n",
+    "plot.color_by = 'material'\n",
     "\n",
     "# Instantiate a Plots collection and export to \"plots.xml\"\n",
     "plot_file = openmc.Plots([plot])\n",
@@ -412,7 +412,7 @@
     "tally.nuclides = [o16, h1]\n",
     "tallies_file.append(tally)\n",
     "\n",
-    "# Instantiate a tally mesh                                                                                                                                                                  \n",
+    "# Instantiate a tally mesh\n",
     "mesh = openmc.Mesh(mesh_id=1)\n",
     "mesh.type = 'regular'\n",
     "mesh.dimension = [1, 1, 1]\n",


### PR DESCRIPTION
This PR continues to fix the typos and expired links I found in example notebooks of basic usage when I read them.

One special thing to note: in _**In [29]**_ of the [Pandas Dataframs](http://openmc.readthedocs.io/en/latest/examples/pandas-dataframes.html) notebook, the variable _data_ was intended to contain 10 values, but in the output there is only 1 value printed. I found the problem is in the argument `filter_bins`:

`filter_bins=[(i,) for i in range(10)]`

Instead using the following line will make it work as expected:

`filter_bins=[tuple(i for i in range(10))]`

But it's a forced type change, so I think there might be a better way of fixing it but I didn't find it.