### PR TITLE
Bugfix for generating thermal scattering data using NJOY

### DIFF
--- a/openmc/data/njoy.py
+++ b/openmc/data/njoy.py
@@ -358,7 +358,7 @@ def make_ace_thermal(filename, filename_thermal, temperatures=None,
 
         # Determine whether elastic is incoherent (0) or coherent (1)
         file_obj = StringIO(ev_thermal.section[7, 2])
-        elastic_type = endf.get_head_record(file_obj)[2]
+        elastic_type = endf.get_head_record(file_obj)[2] - 1
     else:
         elastic = 0
         mt_elastic = 0


### PR DESCRIPTION
In ENDF file 7 MT=2, the LTHR parameter indicates whether elastic data is coherent (1) or incoherent (2). NJOY in turn requires that the user specifies (ACER, card 9) this same parameter but it expects 0 for coherent and 1 for incoherent. We were incorrectly passing the LTHR parameter directly instead of subtracting one. This PR fixes that.