### PR TITLE
Fix Python API docs on RTD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,10 @@ addons:
     packages:
     - gfortran
     - g++
+    - mpich
+    - libmpich-dev
 cache:
   directories:
-  - $HOME/mpich_install
   - $HOME/hdf5_install
   - $HOME/phdf5_install
   - $HOME/nndc_hdf5
@@ -32,10 +33,10 @@ before_install:
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION six numpy scipy h5py=2.5 pandas
   - source activate test-environment
 
-  # Install GCC, MPICH, HDF5, PHDF5
+  # Install GCC, HDF5, PHDF5
   - ./tests/travis_install.sh
   - export FC=gfortran
-  - export MPI_DIR=$HOME/mpich_install
+  - export MPI_DIR=/usr
   - export PHDF5_DIR=$HOME/phdf5_install
   - export HDF5_DIR=$HOME/hdf5_install
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,8 +25,9 @@ except ImportError:
 
 
 MOCK_MODULES = ['numpy', 'numpy.polynomial', 'numpy.polynomial.polynomial',
-                'h5py', 'pandas', 'uncertainties', 'openmoc',
-                'openmc.data.reconstruct']
+                'scipy', 'scipy.sparse', 'scipy.interpolate', 'scipy.integrate',
+                'scipy.optimize', 'scipy.special', 'h5py', 'pandas',
+                'uncertainties', 'openmoc', 'openmc.data.reconstruct']
 sys.modules.update((mod_name, MagicMock()) for mod_name in MOCK_MODULES)
 
 import numpy as np

--- a/src/input_xml.F90
+++ b/src/input_xml.F90
@@ -3362,6 +3362,15 @@ contains
       ! =======================================================================
       ! READ DATA FOR FILTERS
 
+      ! Check if user is using old XML format and throw an error if so
+      if (check_for_node(node_tal, "filter")) then
+        call fatal_error("Tally filters must be specified independently of &
+             &tallies in a <filter> element. The <tally> element itself should &
+             &have a list of filters that apply, e.g., <filters>1 2</filters> &
+             &where 1 and 2 are the IDs of filters specified outside of &
+             &<tally>.")
+      end if
+
       ! Determine number of filters
       if (check_for_node(node_tal, "filters")) then
         n_filter = node_word_count(node_tal, "filters")

--- a/tests/travis_install.sh
+++ b/tests/travis_install.sh
@@ -2,24 +2,13 @@
 
 set -ev
 
-# Build MPICH
-if [[ ! -e $HOME/mpich_install/bin/mpiexec ]]; then
-    wget -q http://www.mpich.org/static/downloads/3.2/mpich-3.2.tar.gz
-    tar -xzvf mpich-3.2.tar.gz >/dev/null 2>&1
-    cd mpich-3.2
-    ./configure --prefix=$HOME/mpich_install -q
-    make -j 2 &> /dev/null
-    make install &> /dev/null
-    cd ..
-fi
-
 # Build PHDF5
 if [[ ! -e $HOME/phdf5_install/bin/h5pfc ]]; then
     wget -q https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.1/src/hdf5-1.10.1.tar.bz2
     tar -xjf hdf5-1.10.1.tar.bz2
     mv hdf5-1.10.1 phdf5-1.10.1
     cd phdf5-1.10.1
-    CC=$HOME/mpich_install/bin/mpicc FC=$HOME/mpich_install/bin/mpif90 \
+    CC=/usr/bin/mpicc FC=/usr/bin/mpif90 \
       ./configure --prefix=$HOME/phdf5_install -q \
       --enable-fortran --enable-parallel
     make -j 2 &> /dev/null

--- a/tests/travis_install.sh
+++ b/tests/travis_install.sh
@@ -4,13 +4,13 @@ set -ev
 
 # Build PHDF5
 if [[ ! -e $HOME/phdf5_install/bin/h5pfc ]]; then
-    wget -q https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.1/src/hdf5-1.10.1.tar.bz2
-    tar -xjf hdf5-1.10.1.tar.bz2
-    mv hdf5-1.10.1 phdf5-1.10.1
-    cd phdf5-1.10.1
+    wget -q https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/hdf5-1.8.19/src/hdf5-1.8.19.tar.bz2
+    tar -xjf hdf5-1.8.19.tar.bz2
+    mv hdf5-1.8.19 phdf5-1.8.19
+    cd phdf5-1.8.19
     CC=/usr/bin/mpicc FC=/usr/bin/mpif90 \
       ./configure --prefix=$HOME/phdf5_install -q \
-      --enable-fortran --enable-parallel
+      --enable-fortran --enable-fortran2003 --enable-parallel
     make -j 2 &> /dev/null
     make install &> /dev/null
     cd ..
@@ -18,10 +18,10 @@ fi
 
 # Build HDF5
 if [[ ! -e $HOME/hdf5_install/bin/h5fc ]]; then
-    tar -xjf hdf5-1.10.1.tar.bz2
-    cd hdf5-1.10.1
+    tar -xjf hdf5-1.8.19.tar.bz2
+    cd hdf5-1.8.19
     CC=gcc FC=gfortran ./configure --prefix=$HOME/hdf5_install -q \
-                                   --enable-fortran
+      --enable-fortran --enable-fortran2003
     make -j 2 &> /dev/null
     make install &> /dev/null
     cd ..

--- a/tests/travis_install.sh
+++ b/tests/travis_install.sh
@@ -4,36 +4,36 @@ set -ev
 
 # Build MPICH
 if [[ ! -e $HOME/mpich_install/bin/mpiexec ]]; then
-    wget -q http://www.mpich.org/static/downloads/3.1.3/mpich-3.1.3.tar.gz
-    tar -xzvf mpich-3.1.3.tar.gz >/dev/null 2>&1
-    cd mpich-3.1.3
+    wget -q http://www.mpich.org/static/downloads/3.2/mpich-3.2.tar.gz
+    tar -xzvf mpich-3.2.tar.gz >/dev/null 2>&1
+    cd mpich-3.2
     ./configure --prefix=$HOME/mpich_install -q
-    make -j 2 >/dev/null 2>&1
-    make install >/dev/null 2>&1
+    make -j 2 &> /dev/null
+    make install &> /dev/null
     cd ..
 fi
 
 # Build PHDF5
 if [[ ! -e $HOME/phdf5_install/bin/h5pfc ]]; then
-    wget -q http://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8.15/src/hdf5-1.8.15.tar.gz
-    tar -xzvf hdf5-1.8.15.tar.gz >/dev/null 2>&1
-    mv hdf5-1.8.15 phdf5-1.8.15; cd phdf5-1.8.15
+    wget -q https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.1/src/hdf5-1.10.1.tar.bz2
+    tar -xjf hdf5-1.10.1.tar.bz2
+    mv hdf5-1.10.1 phdf5-1.10.1
+    cd phdf5-1.10.1
     CC=$HOME/mpich_install/bin/mpicc FC=$HOME/mpich_install/bin/mpif90 \
-       ./configure \
-       --prefix=$HOME/phdf5_install -q --enable-fortran \
-       --enable-fortran2003 --enable-parallel
-    make -j 2 >/dev/null 2>&1
-    make install >/dev/null 2>&1
+      ./configure --prefix=$HOME/phdf5_install -q \
+      --enable-fortran --enable-parallel
+    make -j 2 &> /dev/null
+    make install &> /dev/null
     cd ..
 fi
 
 # Build HDF5
 if [[ ! -e $HOME/hdf5_install/bin/h5fc ]]; then
-    tar -xzvf hdf5-1.8.15.tar.gz >/dev/null 2>&1
-    cd hdf5-1.8.15
+    tar -xjf hdf5-1.10.1.tar.bz2
+    cd hdf5-1.10.1
     CC=gcc FC=gfortran ./configure --prefix=$HOME/hdf5_install -q \
-                                   --enable-fortran --enable-fortran2003
-    make -j 2 >/dev/null 2>&1
-    make install >/dev/null 2>&1
+                                   --enable-fortran
+    make -j 2 &> /dev/null
+    make install &> /dev/null
     cd ..
 fi


### PR DESCRIPTION
My pull request #892 broke documentation builds because I made scipy a required dependency but didn't list it in the mock modules for sphinx. This PR should fix that.