### PR TITLE
Run CI Tests in Parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ addons:
 cache:
   directories:
   - $HOME/nndc_hdf5
+env:
+  - OPENMC_CONFIG="^hdf5-debug$|^omp-hdf5-debug$"
+  - OPENMC_CONFIG="^mpi-hdf5-debug$|^phdf5-debug$"
 
 before_install:
   # ============== Handle Python third-party packages ==============

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,13 @@ cache:
   directories:
   - $HOME/nndc_hdf5
 env:
+  - OPENMC_CONFIG="check_source"
   - OPENMC_CONFIG="^hdf5-debug$|^omp-hdf5-debug$"
   - OPENMC_CONFIG="^mpi-hdf5-debug$|^phdf5-debug$"
+matrix:
+  exclude:
+    - python: "2.7"
+      env: OPENMC_CONFIG="check_source"
 
 before_install:
   # ============== Handle Python third-party packages ==============
@@ -35,13 +40,15 @@ before_install:
   - source activate test-environment
 
   # Install GCC, HDF5, PHDF5
-  - sudo add-apt-repository ppa:nschloe/hdf5-backports -y
-  - sudo apt-get update -q
-  - sudo apt-get install libhdf5-serial-dev libhdf5-mpich-dev -y
-  - export FC=gfortran
-  - export MPI_DIR=/usr
-  - export PHDF5_DIR=/usr
-  - export HDF5_DIR=/usr
+  - if [[ $OPENMC_CONFIG != "check_source" ]]; then
+      sudo add-apt-repository ppa:nschloe/hdf5-backports -y;
+      sudo apt-get update -q;
+      sudo apt-get install libhdf5-serial-dev libhdf5-mpich-dev -y;
+      export FC=gfortran;
+      export MPI_DIR=/usr;
+      export PHDF5_DIR=/usr;
+      export HDF5_DIR=/usr;
+    fi
 
 install: true
 
@@ -58,5 +65,9 @@ before_script:
 script:
   - cd tests
   - export OMP_NUM_THREADS=2
-  - ./travis.sh
+  - if [[ $OPENMC_CONFIG == "check_source" ]]; then
+      ./check_source.py;
+    else
+      ./run_tests.py -C $OPENMC_CONFIG -j 2;
+    fi
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,10 @@ cache:
   - $HOME/nndc_hdf5
 env:
   - OPENMC_CONFIG="check_source"
-  - OPENMC_CONFIG="^hdf5-debug$|^omp-hdf5-debug$"
-  - OPENMC_CONFIG="^mpi-hdf5-debug$|^phdf5-debug$"
+  - OPENMC_CONFIG="^hdf5-debug$"
+  - OPENMC_CONFIG="^omp-hdf5-debug$"
+  - OPENMC_CONFIG="^mpi-hdf5-debug$"
+  - OPENMC_CONFIG="^phdf5-debug$"
 
 # We aren't testing the check_source script so just run it with Python 3.
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ env:
   - OPENMC_CONFIG="check_source"
   - OPENMC_CONFIG="^hdf5-debug$|^omp-hdf5-debug$"
   - OPENMC_CONFIG="^mpi-hdf5-debug$|^phdf5-debug$"
+
+# We aren't testing the check_source script so just run it with Python 3.
 matrix:
   exclude:
     - python: "2.7"
@@ -36,11 +38,9 @@ before_install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION six numpy scipy h5py=2.5 pandas
-  - source activate test-environment
-
-  # Install GCC, HDF5, PHDF5
   - if [[ $OPENMC_CONFIG != "check_source" ]]; then
+      conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION six numpy scipy h5py=2.5 pandas;
+      source activate test-environment;
       sudo add-apt-repository ppa:nschloe/hdf5-backports -y;
       sudo apt-get update -q;
       sudo apt-get install libhdf5-serial-dev libhdf5-mpich-dev -y;
@@ -53,14 +53,15 @@ before_install:
 install: true
 
 before_script:
-  - if [[ ! -e $HOME/nndc_hdf5/cross_sections.xml ]]; then
-      wget https://anl.box.com/shared/static/a6sw2cep34wlz6b9i9jwiotaqoayxcxt.xz -O - | tar -C $HOME -xvJ;
+  - if [[ $OPENMC_CONFIG != "check_source" ]]; then
+      if [[ ! -e $HOME/nndc_hdf5/cross_sections.xml ]]; then
+        wget https://anl.box.com/shared/static/a6sw2cep34wlz6b9i9jwiotaqoayxcxt.xz -O - | tar -C $HOME -xvJ;
+      fi;
+      export OPENMC_CROSS_SECTIONS=$HOME/nndc_hdf5/cross_sections.xml;
+      git clone --branch=master git://github.com/smharper/windowed_multipole_library.git wmp_lib;
+      tar xzvf wmp_lib/multipole_lib.tar.gz;
+      export OPENMC_MULTIPOLE_LIBRARY=$PWD/multipole_lib;
     fi
-  - export OPENMC_CROSS_SECTIONS=$HOME/nndc_hdf5/cross_sections.xml
-
-  - git clone --branch=master git://github.com/smharper/windowed_multipole_library.git wmp_lib
-  - tar xzvf wmp_lib/multipole_lib.tar.gz
-  - export OPENMC_MULTIPOLE_LIBRARY=$PWD/multipole_lib
 
 script:
   - cd tests

--- a/tests/travis.sh
+++ b/tests/travis.sh
@@ -4,8 +4,4 @@ set -ev
 
 # Run all debug tests
 ./check_source.py
-if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-  ./run_tests.py -C "^hdf5-debug$|^omp-hdf5-debug|^mpi-hdf5-debug|^phdf5-debug$" -j 2
-else
-  ./run_tests.py -C "^hdf5-debug$" -j 2
-fi
+./run_tests.py -C $OPENMC_CONFIG -j 2

--- a/tests/travis.sh
+++ b/tests/travis.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-set -ev
-
-# Run all debug tests
-./check_source.py
-./run_tests.py -C $OPENMC_CONFIG -j 2


### PR DESCRIPTION
Travis CI allows multiple jobs be run simultaneously using the "build matrix".  See [here](https://docs.travis-ci.com/user/speeding-up-the-build/#Parallelizing-your-builds-across-virtual-machines) and [here](https://docs.travis-ci.com/user/customizing-the-build/#Build-Matrix).  This PR takes advantage of this feature by splitting our test suite into two groups.  (We could run all 4 build configurations on separate jobs, but it doesn't seem necessary.)  The test suite now takes about 13 minutes.  This PR also splits off the check_source.py script onto a separate job.  That job should finish very quickly (~1 min), and we can still see regression test results even if the check_source fails.