### PR TITLE
openmc-update-inputs: Replace ZAID notation

### DIFF
--- a/openmc/data/neutron.py
+++ b/openmc/data/neutron.py
@@ -34,7 +34,7 @@ from openmc.mixin import EqualityMixin
 _RESONANCE_ENERGY_GRID = np.logspace(-3, 3, 61)
 
 
-def get_metadata(zaid, metastable_scheme='nndc'):
+def _get_metadata(zaid, metastable_scheme='nndc'):
     """Return basic identifying data for a nuclide with a given ZAID.
 
     Parameters

--- a/openmc/data/neutron.py
+++ b/openmc/data/neutron.py
@@ -677,7 +677,7 @@ class IncidentNeutron(EqualityMixin):
         # If mass number hasn't been specified, make an educated guess
         zaid, xs = ace.name.split('.')
         name, element, Z, mass_number, metastable = \
-            get_metadata(int(zaid), metastable_scheme)
+            _get_metadata(int(zaid), metastable_scheme)
 
         # Assign temperature to the running list
         kTs = [ace.temperature*EV_PER_MEV]

--- a/openmc/data/neutron.py
+++ b/openmc/data/neutron.py
@@ -34,7 +34,7 @@ from openmc.mixin import EqualityMixin
 _RESONANCE_ENERGY_GRID = np.logspace(-3, 3, 61)
 
 
-def _get_metadata(zaid, metastable_scheme='nndc'):
+def get_metadata(zaid, metastable_scheme='nndc'):
     """Return basic identifying data for a nuclide with a given ZAID.
 
     Parameters
@@ -677,7 +677,7 @@ class IncidentNeutron(EqualityMixin):
         # If mass number hasn't been specified, make an educated guess
         zaid, xs = ace.name.split('.')
         name, element, Z, mass_number, metastable = \
-            _get_metadata(int(zaid), metastable_scheme)
+            get_metadata(int(zaid), metastable_scheme)
 
         # Assign temperature to the running list
         kTs = [ace.temperature*EV_PER_MEV]

--- a/scripts/openmc-update-inputs
+++ b/scripts/openmc-update-inputs
@@ -11,7 +11,6 @@ from itertools import chain
 from random import randint
 from shutil import move
 import xml.etree.ElementTree as ET
-import re
 
 import openmc.data
 
@@ -239,12 +238,6 @@ def update_geometry(geometry_root):
 
     return was_updated
 
-def replace_zaid(name):
-    """Replace a nuclide name in the ZAID notation with the correct name."""
-    zaid = int(name.strip())
-    name = openmc.data.neutron.get_metadata(zaid)[0]
-    return name
-
 def update_materials(root):
     """Update the given XML materials tree. Return True if changes were made."""
     was_updated = False
@@ -254,9 +247,11 @@ def update_materials(root):
             if 'name' in nuclide.attrib:
                 nucname = nuclide.attrib['name']
                 nucname = nucname.replace('-', '')
-                s = re.search("\s*(?<![A-z])\d{4,6}\s*", nucname)
-                if s:
-                    nucname = replace_zaid(s.group(0))
+                # If a nuclide name is in the ZAID notation (e.g., a number),
+                # convert it to the proper nuclide name.
+                if nucname.strip().isnumeric():
+                    nucname = \
+                      openmc.data.neutron._get_metadata(int(nucname))[0]
                 nucname = nucname.replace('Nat', '0')
                 if nucname.endswith('m'):
                     nucname = nucname[:-1] + '_m1'

--- a/scripts/openmc-update-inputs
+++ b/scripts/openmc-update-inputs
@@ -11,6 +11,7 @@ from itertools import chain
 from random import randint
 from shutil import move
 import xml.etree.ElementTree as ET
+import re
 
 import openmc.data
 
@@ -238,6 +239,18 @@ def update_geometry(geometry_root):
 
     return was_updated
 
+def replace_zaid(name):
+    """Replace a nuclide name in the ZAID notation with the correct name."""
+    # TODO: Account for metastable and any other special cases
+    name = name.strip()
+    z = int(name[:-3])
+    a = int(name[-3:])  # Strips leading 0s
+    symbol = openmc.data.ATOMIC_SYMBOL[z]
+    name = str(symbol).title() + str(a)
+    return name
+    
+
+
 def update_materials(root):
     """Update the given XML materials tree. Return True if changes were made."""
     was_updated = False
@@ -247,6 +260,9 @@ def update_materials(root):
             if 'name' in nuclide.attrib:
                 nucname = nuclide.attrib['name']
                 nucname = nucname.replace('-', '')
+                s = re.search("\s*(?<![A-z])\d{4,6}\s*", nucname)
+                if s:
+                    nucname = replace_zaid(s.group(0))
                 nucname = nucname.replace('Nat', '0')
                 if nucname.endswith('m'):
                     nucname = nucname[:-1] + '_m1'

--- a/scripts/openmc-update-inputs
+++ b/scripts/openmc-update-inputs
@@ -241,15 +241,9 @@ def update_geometry(geometry_root):
 
 def replace_zaid(name):
     """Replace a nuclide name in the ZAID notation with the correct name."""
-    # TODO: Account for metastable and any other special cases
-    name = name.strip()
-    z = int(name[:-3])
-    a = int(name[-3:])  # Strips leading 0s
-    symbol = openmc.data.ATOMIC_SYMBOL[z]
-    name = str(symbol).title() + str(a)
+    zaid = int(name.strip())
+    name = openmc.data.neutron.get_metadata(zaid)[0]
     return name
-    
-
 
 def update_materials(root):
     """Update the given XML materials tree. Return True if changes were made."""


### PR DESCRIPTION
The function `update_materials()` in the script `openmc-update-inputs` can't yet update nuclide names in the ZAID format (e.g., 92235 for U-235).

I've been working with some older models only available in XML, and I found the following change to be useful for my own purposes. I'm aware of the existence of some special cases, such as metastable nuclides, that have special naming conventions not accounted for in the new `replace_zaid()` function. However, I don't know enough about this area to implement the special cases myself.