### PR TITLE
Hotfix generating 0K data from NJOY

### DIFF
--- a/openmc/data/neutron.py
+++ b/openmc/data/neutron.py
@@ -866,12 +866,13 @@ class IncidentNeutron(EqualityMixin):
                 data.fission_energy = FissionEnergyRelease.from_endf(ev, data)
 
             # Add 0K elastic scattering cross section
-            pendf = Evaluation(pendf_file)
-            file_obj = StringIO(pendf.section[3, 2])
-            get_head_record(file_obj)
-            params, xs = get_tab1_record(file_obj)
-            data.energy['0K'] = xs.x
-            data[2].xs['0K'] = xs
+            if '0K' not in data.energy:
+                pendf = Evaluation(pendf_file)
+                file_obj = StringIO(pendf.section[3, 2])
+                get_head_record(file_obj)
+                params, xs = get_tab1_record(file_obj)
+                data.energy['0K'] = xs.x
+                data[2].xs['0K'] = xs
 
         finally:
             # Get rid of temporary files

--- a/openmc/data/neutron.py
+++ b/openmc/data/neutron.py
@@ -824,7 +824,7 @@ class IncidentNeutron(EqualityMixin):
         return data
 
     @classmethod
-    def from_njoy(cls, filename, temperatures=None, error=0.001, **kwargs):
+    def from_njoy(cls, filename, temperatures=None, **kwargs):
         """Generate incident neutron data by running NJOY.
 
         Parameters
@@ -834,8 +834,6 @@ class IncidentNeutron(EqualityMixin):
         temperatures : iterable of float
             Temperatures in Kelvin to produce data at. If omitted, data is
             produced at room temperature (293.6 K)
-        error : float, optional
-            Fractional error tolerance for NJOY processing.
         **kwargs
             Keyword arguments passed to :func:`openmc.data.njoy.make_ace`
 
@@ -853,7 +851,7 @@ class IncidentNeutron(EqualityMixin):
             ace_file = os.path.join(tmpdir, 'ace')
             xsdir_file = os.path.join(tmpdir, 'xsdir')
             pendf_file = os.path.join(tmpdir, 'pendf')
-            make_ace(filename, temperatures, error, ace_file, xsdir_file,
+            make_ace(filename, temperatures, ace_file, xsdir_file,
                      pendf_file, **kwargs)
 
             # Create instance from ACE tables within library

--- a/openmc/data/neutron.py
+++ b/openmc/data/neutron.py
@@ -824,7 +824,7 @@ class IncidentNeutron(EqualityMixin):
         return data
 
     @classmethod
-    def from_njoy(cls, filename, temperatures=None, **kwargs):
+    def from_njoy(cls, filename, temperatures=None, error=0.001, **kwargs):
         """Generate incident neutron data by running NJOY.
 
         Parameters
@@ -834,6 +834,8 @@ class IncidentNeutron(EqualityMixin):
         temperatures : iterable of float
             Temperatures in Kelvin to produce data at. If omitted, data is
             produced at room temperature (293.6 K)
+        error : float, optional
+            Fractional error tolerance for NJOY processing.
         **kwargs
             Keyword arguments passed to :func:`openmc.data.njoy.make_ace`
 
@@ -851,7 +853,7 @@ class IncidentNeutron(EqualityMixin):
             ace_file = os.path.join(tmpdir, 'ace')
             xsdir_file = os.path.join(tmpdir, 'xsdir')
             pendf_file = os.path.join(tmpdir, 'pendf')
-            make_ace(filename, temperatures, ace_file, xsdir_file,
+            make_ace(filename, temperatures, error, ace_file, xsdir_file,
                      pendf_file, **kwargs)
 
             # Create instance from ACE tables within library

--- a/openmc/data/njoy.py
+++ b/openmc/data/njoy.py
@@ -95,7 +95,7 @@ _ACE_TEMPLATE_ACER = """acer /
 /
 """
 
-_ACE_TEMPLATE_THERMR = """
+_ACE_THERMAL_TEMPLATE_THERMR = """
 thermr / %%%%%%%%%%%%%%%% Add thermal scattering data (free gas) %%%%%%%%%%%%%%%
 0 {nthermr1_in} {nthermr1}
 0 {mat} 12 {num_temp} 1 0 {iform} 1 221 1/
@@ -118,7 +118,8 @@ _ACE_THERMAL_TEMPLATE_ACER = """acer /
 """
 
 
-def run(commands, tapein, tapeout, stdout=False, njoy_exec='njoy'):
+def run(commands, tapein, tapeout, print_commands=False, stdout=False,
+        njoy_exec='njoy'):
     """Run NJOY with given commands
 
     Parameters
@@ -129,6 +130,8 @@ def run(commands, tapein, tapeout, stdout=False, njoy_exec='njoy'):
         Dictionary mapping tape numbers to paths for any input files
     tapeout : dict
         Dictionary mapping tape numbers to paths for any output files
+    print_commands : bool, optional
+        Whether to display input commands when running NJOY
     stdout : bool, optional
         Whether to display output when running NJOY
     njoy_exec : str, optional
@@ -140,6 +143,11 @@ def run(commands, tapein, tapeout, stdout=False, njoy_exec='njoy'):
         Return code of NJOY process
 
     """
+
+    if print_commands:
+        # If user requested showing commands, print to screen
+        print("NJOY INPUTS:")
+        print(commands)
 
     # Create temporary directory -- it would be preferable to use
     # TemporaryDirectory(), but it is only available in Python 3.2
@@ -223,13 +231,13 @@ def make_ace(filename, temperatures=None, ace='ace', xsdir='xsdir', pendf=None,
     error : float, optional
         Fractional error tolerance for NJOY processing
     broadr : bool, optional
-        Indicating whether to Doppler broaden XS in running NJOY
+        Indicating whether to Doppler broaden XS when running NJOY
     heatr : bool, optional
-        Indicating whether to add heating kerma in running NJOY
+        Indicating whether to add heating kerma when running NJOY
     purr : bool, optional
-        Indicating whether to add probability table in running NJOY
+        Indicating whether to add probability table when running NJOY
     acer : bool, optional
-        Indicating whether to generate ACE file in running NJOY 
+        Indicating whether to generate ACE file when running NJOY 
     **kwargs
         Keyword arguments passed to :func:`openmc.data.njoy.run`
 
@@ -272,14 +280,14 @@ def make_ace(filename, temperatures=None, ace='ace', xsdir='xsdir', pendf=None,
 
     # heatr
     if heatr:
-        nheatr_in = nlast + 1
+        nheatr_in = nlast
         nheatr = nheatr_in + 1
         commands += _ACE_TEMPLATE_HEATR
         nlast = nheatr
       
     # purr
     if purr:
-        npurr_in = nlast + 1
+        npurr_in = nlast
         npurr = npurr_in + 1
         commands += _ACE_TEMPLATE_PURR
         nlast = npurr
@@ -300,7 +308,6 @@ def make_ace(filename, temperatures=None, ace='ace', xsdir='xsdir', pendf=None,
             # Indicate tapes to save for each ACER run
             tapeout[nace] = fname.format(ace, temperature)
             tapeout[ndir] = fname.format(xsdir, temperature)
-
     commands += 'stop\n'
     retcode = run(commands, tapein, tapeout, **kwargs)
 
@@ -431,10 +438,10 @@ def make_ace_thermal(filename, filename_thermal, temperatures=None,
 
     # thermr
     nthermr1_in = nlast
-    nthermr1 = nthermr_in + 1
+    nthermr1 = nthermr1_in + 1
     nthermr2_in = nthermr1
     nthermr2 = nthermr2_in + 1
-    commands += _ACE_TEMPLATE_THERMR
+    commands += _ACE_THERMAL_TEMPLATE_THERMR
     nlast = nthermr2
 
     commands = commands.format(**locals())
@@ -452,7 +459,6 @@ def make_ace_thermal(filename, filename_thermal, temperatures=None,
         # Indicate tapes to save for each ACER run
         tapeout[nace] = fname.format(ace, temperature)
         tapeout[ndir] = fname.format(xsdir, temperature)
-
     commands += 'stop\n'
     retcode = run(commands, tapein, tapeout, **kwargs)
 

--- a/openmc/data/njoy.py
+++ b/openmc/data/njoy.py
@@ -228,8 +228,8 @@ def make_pendf(filename, pendf='pendf', error=0.001, stdout=False):
     return run(commands, tapein, tapeout, stdout)
 
 
-def make_ace(filename, temperatures=None, error=0.001, ace='ace', xsdir='xsdir',
-             pendf=None, **kwargs):
+def make_ace(filename, temperatures=None, ace='ace', xsdir='xsdir',
+             pendf=None, error=0.001, **kwargs):
     """Generate incident neutron ACE file from an ENDF file
 
     Parameters
@@ -239,14 +239,14 @@ def make_ace(filename, temperatures=None, error=0.001, ace='ace', xsdir='xsdir',
     temperatures : iterable of float, optional
         Temperatures in Kelvin to produce ACE files at. If omitted, data is
         produced at room temperature (293.6 K).
-    error : float, optional
-        Fractional error tolerance for NJOY processing.
     ace : str, optional
         Path of ACE file to write
     xsdir : str, optional
         Path of xsdir file to write
     pendf : str, optional
         Path of pendf file to write. If omitted, the pendf file is not saved.
+    error : float, optional
+        Fractional error tolerance for NJOY processing.
     **kwargs
         Keyword arguments passed to :func:`openmc.data.njoy.run`
 
@@ -315,8 +315,8 @@ def make_ace(filename, temperatures=None, error=0.001, ace='ace', xsdir='xsdir',
     return retcode
 
 
-def make_ace_thermal(filename, filename_thermal, temperatures=None, error=0.001,
-                     ace='ace', xsdir='xsdir', **kwargs):
+def make_ace_thermal(filename, filename_thermal, temperatures=None,
+                     ace='ace', xsdir='xsdir', error=0.001, **kwargs):
     """Generate thermal scattering ACE file from ENDF files
 
     Parameters
@@ -328,12 +328,12 @@ def make_ace_thermal(filename, filename_thermal, temperatures=None, error=0.001,
     temperatures : iterable of float, optional
         Temperatures in Kelvin to produce data at. If omitted, data is produced
         at all temperatures given in the ENDF thermal scattering sublibrary.
-    error : float, optional
-        Fractional error tolerance for NJOY processing.
     ace : str, optional
         Path of ACE file to write
     xsdir : str, optional
         Path of xsdir file to write
+    error : float, optional
+        Fractional error tolerance for NJOY processing.
     **kwargs
         Keyword arguments passed to :func:`openmc.data.njoy.run`
 

--- a/openmc/data/njoy.py
+++ b/openmc/data/njoy.py
@@ -68,14 +68,14 @@ reconr / %%%%%%%%%%%%%%%%%%% Reconstruct XS for neutrons %%%%%%%%%%%%%%%%%%%%%%%
 20 21
 '{library} PENDF for {zsymam}'/
 {mat} 2/
-0.001 0.0 0.003/ err tempr errmax
+{error}/ err
 '{library}: {zsymam}'/
 'Processed by NJOY'/
 0/
 broadr / %%%%%%%%%%%%%%%%%%%%%%% Doppler broaden XS %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 20 21 22
 {mat} {num_temp} 0 0 0. /
-0.001 1.0e6 0.003 /
+{error}/ errthn
 {temps}
 0/
 heatr / %%%%%%%%%%%%%%%%%%%%%%%%% Add heating kerma %%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -104,26 +104,26 @@ reconr / %%%%%%%%%%%%%%%%%%% Reconstruct XS for neutrons %%%%%%%%%%%%%%%%%%%%%%%
 20 22
 '{library} PENDF for {zsymam}'/
 {mat} 2/
-0.001 0. 0.001/ err tempr errmax
+{error}/ err
 '{library}: PENDF for {zsymam}'/
 'Processed by NJOY'/
 0/
 broadr / %%%%%%%%%%%%%%%%%%%%%%% Doppler broaden XS %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 20 22 23
 {mat} {num_temp} 0 0 0./
-0.001 2.0e+6 0.001/ errthn thnmax errmax
+{error}/ errthn
 {temps}
 0/
 thermr / %%%%%%%%%%%%%%%% Add thermal scattering data (free gas) %%%%%%%%%%%%%%%
 0 23 62
 0 {mat} 12 {num_temp} 1 0 {iform} 1 221 1/
 {temps}
-0.001 {energy_max}
+{error} {energy_max}
 thermr / %%%%%%%%%%%%%%%% Add thermal scattering data (bound) %%%%%%%%%%%%%%%%%%
 60 62 27
 {mat_thermal} {mat} 16 {num_temp} {inelastic} {elastic} {iform} {natom} 222 1/
 {temps}
-0.001 {energy_max}
+{error} {energy_max}
 """
 
 _ACE_THERMAL_TEMPLATE_ACER = """acer /
@@ -195,7 +195,7 @@ def run(commands, tapein, tapeout, stdout=False, njoy_exec='njoy'):
     return njoy.returncode
 
 
-def make_pendf(filename, pendf='pendf', stdout=False):
+def make_pendf(filename, pendf='pendf', error=0.001, stdout=False):
     """Generate ACE file from an ENDF file
 
     Parameters
@@ -204,6 +204,8 @@ def make_pendf(filename, pendf='pendf', stdout=False):
         Path to ENDF file
     pendf : str, optional
         Path of pointwise ENDF file to write
+    error : float, optional
+        Fractional error tolerance for NJOY processing.
     stdout : bool
         Whether to display NJOY standard output
 
@@ -226,7 +228,7 @@ def make_pendf(filename, pendf='pendf', stdout=False):
     return run(commands, tapein, tapeout, stdout)
 
 
-def make_ace(filename, temperatures=None, ace='ace', xsdir='xsdir',
+def make_ace(filename, temperatures=None, error=0.001, ace='ace', xsdir='xsdir',
              pendf=None, **kwargs):
     """Generate incident neutron ACE file from an ENDF file
 
@@ -237,6 +239,8 @@ def make_ace(filename, temperatures=None, ace='ace', xsdir='xsdir',
     temperatures : iterable of float, optional
         Temperatures in Kelvin to produce ACE files at. If omitted, data is
         produced at room temperature (293.6 K).
+    error : float, optional
+        Fractional error tolerance for NJOY processing.
     ace : str, optional
         Path of ACE file to write
     xsdir : str, optional
@@ -311,7 +315,7 @@ def make_ace(filename, temperatures=None, ace='ace', xsdir='xsdir',
     return retcode
 
 
-def make_ace_thermal(filename, filename_thermal, temperatures=None,
+def make_ace_thermal(filename, filename_thermal, temperatures=None, error=0.001,
                      ace='ace', xsdir='xsdir', **kwargs):
     """Generate thermal scattering ACE file from ENDF files
 
@@ -324,6 +328,8 @@ def make_ace_thermal(filename, filename_thermal, temperatures=None,
     temperatures : iterable of float, optional
         Temperatures in Kelvin to produce data at. If omitted, data is produced
         at all temperatures given in the ENDF thermal scattering sublibrary.
+    error : float, optional
+        Fractional error tolerance for NJOY processing.
     ace : str, optional
         Path of ACE file to write
     xsdir : str, optional

--- a/openmc/data/thermal.py
+++ b/openmc/data/thermal.py
@@ -588,7 +588,8 @@ class ThermalScattering(EqualityMixin):
         return table
 
     @classmethod
-    def from_njoy(cls, filename, filename_thermal, temperatures=None, **kwargs):
+    def from_njoy(cls, filename, filename_thermal, temperatures=None,
+                  error=0.001, **kwargs):
         """Generate incident neutron data by running NJOY.
 
         Parameters
@@ -601,6 +602,8 @@ class ThermalScattering(EqualityMixin):
             Temperatures in Kelvin to produce data at. If omitted, data is
             produced at all temperatures in the ENDF thermal scattering
             sublibrary.
+        error : float, optional
+            Fractional error tolerance for NJOY processing.
         **kwargs
             Keyword arguments passed to :func:`openmc.data.njoy.make_ace_thermal`
 
@@ -617,7 +620,7 @@ class ThermalScattering(EqualityMixin):
             # Run NJOY to create an ACE library
             ace_file = os.path.join(tmpdir, 'ace')
             xsdir_file = os.path.join(tmpdir, 'xsdir')
-            make_ace_thermal(filename, filename_thermal, temperatures,
+            make_ace_thermal(filename, filename_thermal, temperatures, error,
                              ace_file, xsdir_file, **kwargs)
 
             # Create instance from ACE tables within library

--- a/openmc/data/thermal.py
+++ b/openmc/data/thermal.py
@@ -588,8 +588,7 @@ class ThermalScattering(EqualityMixin):
         return table
 
     @classmethod
-    def from_njoy(cls, filename, filename_thermal, temperatures=None,
-                  error=0.001, **kwargs):
+    def from_njoy(cls, filename, filename_thermal, temperatures=None, **kwargs):
         """Generate incident neutron data by running NJOY.
 
         Parameters
@@ -602,8 +601,6 @@ class ThermalScattering(EqualityMixin):
             Temperatures in Kelvin to produce data at. If omitted, data is
             produced at all temperatures in the ENDF thermal scattering
             sublibrary.
-        error : float, optional
-            Fractional error tolerance for NJOY processing.
         **kwargs
             Keyword arguments passed to :func:`openmc.data.njoy.make_ace_thermal`
 
@@ -620,7 +617,7 @@ class ThermalScattering(EqualityMixin):
             # Run NJOY to create an ACE library
             ace_file = os.path.join(tmpdir, 'ace')
             xsdir_file = os.path.join(tmpdir, 'xsdir')
-            make_ace_thermal(filename, filename_thermal, temperatures, error,
+            make_ace_thermal(filename, filename_thermal, temperatures,
                              ace_file, xsdir_file, **kwargs)
 
             # Create instance from ACE tables within library


### PR DESCRIPTION
1) A tiny bug in generating 0K data from NJOY
``` py
import urllib.request
import openmc.data

url = 'https://t2.lanl.gov/nis/data/data/ENDFB-VII.1-neutron/Fe/56'
filename, headers = urllib.request.urlretrieve(url, 'fe56.endf')
fe56_njoy = openmc.data.IncidentNeutron.from_njoy('fe56.endf', temperatures=[0.])
fe56_njoy.export_to_hdf5('fe56.h5')
fe56_hdf5 = openmc.data.IncidentNeutron.from_hdf5('fe56.h5')
fe56_hdf5[1].xs['0K']([1e6])
IndexError: index 3334 is out of bounds for axis 1 with size 2869
```
It is caused by the action [to add 0K elastic scattering cross section from PENDF](https://github.com/mit-crpg/openmc/blob/develop/openmc/data/neutron.py#L868) after running njoy, which overwrites the existing '0K' energy grid. This can be fixed by adding a line above the block
```
# Add 0K elastic scattering cross section
if '0K' not in data.energy:
  ...
```

2. [Not implemented] The error tolerance in reconstruction is currently fixed as 0.001. The users may want a different error in some cases. Should we add a parameter in the APIs to make it possible? I mean to set the `err` card in input file. For the `tempr` and `errmax`, we may remove them to use the default values in njoy. The same changes can be made on `broadr`. The `thnmax` (upper limit for broadening) 1.0e6 in the template is recommended to be removed too as the default upper limit for broadening [has been changed since NJOY2012.75](https://github.com/njoy/NJOY2016/blob/master/src/broadr.f90#L107). But I'm not sure why the values like `thnmax` and `errmax` are different in sab case so the changes are not made yet. I'll push the new commit after @paulromano gives more suggestions.