### PR TITLE
Simplify handling of energy in tally module

### DIFF
--- a/src/physics.F90
+++ b/src/physics.F90
@@ -33,11 +33,6 @@ contains
 
     type(Particle), intent(inout) :: p
 
-    ! Store pre-collision particle properties
-    p % last_wgt = p % wgt
-    p % last_E   = p % E
-    p % last_uvw = p % coord(1) % uvw
-
     ! Add to collision counter for particle
     p % n_collision = p % n_collision + 1
 

--- a/src/tally.F90
+++ b/src/tally.F90
@@ -100,6 +100,9 @@ contains
     real(8) :: score                ! analog tally score
     real(8) :: E                    ! particle energy
 
+    ! Pre-collision energy of particle
+    E = p % last_E
+
     i = 0
     SCORE_LOOP: do q = 1, t % n_user_score_bins
       i = i + 1
@@ -159,14 +162,6 @@ contains
 
 
       case (SCORE_INVERSE_VELOCITY)
-
-        ! make sure the correct energy is used
-        if (t % estimator == ESTIMATOR_TRACKLENGTH) then
-          E = p % E
-        else
-          E = p % last_E
-        end if
-
         if (t % estimator == ESTIMATOR_ANALOG) then
           ! All events score to an inverse velocity bin. We actually use a
           ! collision estimator in place of an analog one since there is no way
@@ -256,7 +251,7 @@ contains
           ! Get yield and apply to score
           associate (rxn => nuclides(p % event_nuclide) % reactions(m))
             score = p % last_wgt * flux &
-                 * rxn % products(1) % yield % evaluate(p % last_E)
+                 * rxn % products(1) % yield % evaluate(E)
           end associate
         end if
 
@@ -283,7 +278,7 @@ contains
           ! Get yield and apply to score
           associate (rxn => nuclides(p % event_nuclide) % reactions(m))
             score = p % last_wgt * flux &
-                 * rxn % products(1) % yield % evaluate(p % last_E)
+                 * rxn % products(1) % yield % evaluate(E)
           end associate
         end if
 
@@ -310,7 +305,7 @@ contains
           ! Get yield and apply to score
           associate (rxn => nuclides(p%event_nuclide)%reactions(m))
             score = p % last_wgt * flux &
-                 * rxn % products(1) % yield % evaluate(p % last_E)
+                 * rxn % products(1) % yield % evaluate(E)
           end associate
         end if
 
@@ -413,13 +408,6 @@ contains
 
 
       case (SCORE_PROMPT_NU_FISSION)
-        ! make sure the correct energy is used
-        if (t % estimator == ESTIMATOR_TRACKLENGTH) then
-          E = p % E
-        else
-          E = p % last_E
-        end if
-
         if (t % estimator == ESTIMATOR_ANALOG) then
           if (survival_biasing .or. p % fission) then
             if (t % find_filter(FILTER_ENERGYOUT) > 0) then
@@ -481,16 +469,7 @@ contains
           end if
         end if
 
-
       case (SCORE_DELAYED_NU_FISSION)
-
-        ! make sure the correct energy is used
-        if (t % estimator == ESTIMATOR_TRACKLENGTH) then
-          E = p % E
-        else
-          E = p % last_E
-        end if
-
         ! Set the delayedgroup filter index and the number of delayed group bins
         dg_filter = t % find_filter(FILTER_DELAYEDGROUP)
 
@@ -682,14 +661,6 @@ contains
         end if
 
       case (SCORE_DECAY_RATE)
-
-        ! make sure the correct energy is used
-        if (t % estimator == ESTIMATOR_TRACKLENGTH) then
-          E = p % E
-        else
-          E = p % last_E
-        end if
-
         ! Set the delayedgroup filter index
         dg_filter = t % find_filter(FILTER_DELAYEDGROUP)
 
@@ -1065,7 +1036,7 @@ contains
               if (micro_xs(p % event_nuclide) % absorption > ZERO .and. &
                    allocated(nuc % fission_q_prompt)) then
                 score = p % absorb_wgt &
-                     * nuc % fission_q_prompt % evaluate(p % last_E) &
+                     * nuc % fission_q_prompt % evaluate(E) &
                      * micro_xs(p % event_nuclide) % fission &
                      / micro_xs(p % event_nuclide) % absorption * flux
               end if
@@ -1079,7 +1050,7 @@ contains
             associate (nuc => nuclides(p % event_nuclide))
               if (allocated(nuc % fission_q_prompt)) then
                 score = p % last_wgt &
-                     * nuc % fission_q_prompt % evaluate(p % last_E) &
+                     * nuc % fission_q_prompt % evaluate(E) &
                      * micro_xs(p % event_nuclide) % fission &
                      / micro_xs(p % event_nuclide) % absorption * flux
               end if
@@ -1087,12 +1058,6 @@ contains
           end if
 
         else
-          if (t % estimator == ESTIMATOR_COLLISION) then
-            E = p % last_E
-          else
-            E = p % E
-          end if
-
           if (i_nuclide > 0) then
             if (allocated(nuclides(i_nuclide) % fission_q_prompt)) then
               score = micro_xs(i_nuclide) % fission * atom_density * flux &
@@ -1125,7 +1090,7 @@ contains
               if (micro_xs(p % event_nuclide) % absorption > ZERO .and. &
                    allocated(nuc % fission_q_recov)) then
                 score = p % absorb_wgt &
-                     * nuc % fission_q_recov % evaluate(p % last_E) &
+                     * nuc % fission_q_recov % evaluate(E) &
                      * micro_xs(p % event_nuclide) % fission &
                      / micro_xs(p % event_nuclide) % absorption * flux
               end if
@@ -1139,7 +1104,7 @@ contains
             associate (nuc => nuclides(p % event_nuclide))
               if (allocated(nuc % fission_q_recov)) then
                 score = p % last_wgt &
-                     * nuc % fission_q_recov % evaluate(p % last_E) &
+                     * nuc % fission_q_recov % evaluate(E) &
                      * micro_xs(p % event_nuclide) % fission &
                      / micro_xs(p % event_nuclide) % absorption * flux
               end if
@@ -1147,12 +1112,6 @@ contains
           end if
 
         else
-          if (t % estimator == ESTIMATOR_COLLISION) then
-            E = p % last_E
-          else
-            E = p % E
-          end if
-
           if (i_nuclide > 0) then
             if (allocated(nuclides(i_nuclide) % fission_q_recov)) then
               score = micro_xs(i_nuclide) % fission * atom_density * flux &

--- a/src/tally_filter.F90
+++ b/src/tally_filter.F90
@@ -1035,12 +1035,8 @@ contains
         weight = ONE
 
       else
-        ! Make sure the correct energy is used.
-        if (estimator == ESTIMATOR_TRACKLENGTH) then
-          E = p % E
-        else
-          E = p % last_E
-        end if
+        ! Pre-collision energy of particle
+        E = p % last_E
 
         ! Check if energy of the particle is within energy bins.
         if (E < this % bins(1) .or. E > this % bins(n + 1)) then
@@ -1383,12 +1379,8 @@ contains
       if (current_bin == NO_BIN_FOUND) then
         n = size(this % energy)
 
-        ! Make sure the correct energy is used.
-        if (estimator == ESTIMATOR_TRACKLENGTH) then
-          E = p % E
-        else
-          E = p % last_E
-        end if
+        ! Get pre-collision energy of particle
+        E = p % last_E
 
         ! Check if energy of the particle is within energy bins.
         if (E < this % energy(1) .or. E > this % energy(n)) then

--- a/src/tracking.F90
+++ b/src/tracking.F90
@@ -68,6 +68,12 @@ contains
     if (active_tallies % size() > 0) call zero_flux_derivs()
 
     EVENT_LOOP: do
+      ! Store pre-collision particle properties
+      p % last_wgt = p % wgt
+      p % last_E   = p % E
+      p % last_uvw = p % coord(1) % uvw
+      p % last_xyz = p % coord(1) % xyz
+
       ! If the cell hasn't been determined based on the particle's location,
       ! initiate a search for the current cell. This generally happens at the
       ! beginning of the history and again for any secondary particles
@@ -132,7 +138,6 @@ contains
         call score_tracklength_tally(p, distance)
       end if
 
-
       ! Score track-length estimate of k-eff
       if (run_mode == MODE_EIGENVALUE) then
         global_tally_tracklength = global_tally_tracklength + p % wgt * &
@@ -153,11 +158,6 @@ contains
           p % last_cell(j) = p % coord(j) % cell
         end do
         p % last_n_coord = p % n_coord
-
-        ! Update last_ data. This is needed to use the same filters in
-        ! surface tallies as the ones implemented for regular tallies
-        p % last_uvw = p % coord(p % n_coord) % uvw
-        p % last_E = p % E
 
         p % coord(p % n_coord) % cell = NONE
         if (any(lattice_translation /= 0)) then
@@ -236,9 +236,6 @@ contains
         ! Score flux derivative accumulators for differential tallies.
         if (active_tallies % size() > 0) call score_collision_derivative(p)
       end if
-
-      ! Save coordinates for tallying purposes
-      p % last_xyz = p % coord(1) % xyz
 
       ! If particle has too many events, display warning and kill it
       n_event = n_event + 1


### PR DESCRIPTION
I realized when reviewing #893 that we could simplify how we choose energies in the tally module by just updating the `last_E` attribute of the particle at the top of the event loop in `tracking.F90`.