### PR TITLE
Changing parentheses into square brackets for creating materials_file

### DIFF
--- a/examples/jupyter/mgxs-part-ii.ipynb
+++ b/examples/jupyter/mgxs-part-ii.ipynb
@@ -131,7 +131,7 @@
    "outputs": [],
    "source": [
     "# Instantiate a Materials collection\n",
-    "materials_file = openmc.Materials((fuel, water, zircaloy))\n",
+    "materials_file = openmc.Materials([fuel, water, zircaloy])\n",
     "\n",
     "# Export to \"materials.xml\"\n",
     "materials_file.export_to_xml()"

--- a/examples/jupyter/mgxs-part-iii.ipynb
+++ b/examples/jupyter/mgxs-part-iii.ipynb
@@ -134,7 +134,7 @@
    "outputs": [],
    "source": [
     "# Instantiate a Materials object\n",
-    "materials_file = openmc.Materials((fuel, water, zircaloy))\n",
+    "materials_file = openmc.Materials([fuel, water, zircaloy])\n",
     "\n",
     "# Export to \"materials.xml\"\n",
     "materials_file.export_to_xml()"

--- a/examples/jupyter/pandas-dataframes.ipynb
+++ b/examples/jupyter/pandas-dataframes.ipynb
@@ -79,7 +79,7 @@
    "outputs": [],
    "source": [
     "# Instantiate a Materials collection\n",
-    "materials_file = openmc.Materials((fuel, water, zircaloy))\n",
+    "materials_file = openmc.Materials([fuel, water, zircaloy])\n",
     "\n",
     "# Export to \"materials.xml\"\n",
     "materials_file.export_to_xml()"

--- a/examples/jupyter/post-processing.ipynb
+++ b/examples/jupyter/post-processing.ipynb
@@ -105,7 +105,7 @@
    "outputs": [],
    "source": [
     "# Instantiate a Materials collection\n",
-    "materials_file = openmc.Materials((fuel, water, zircaloy))\n",
+    "materials_file = openmc.Materials([fuel, water, zircaloy])\n",
     "\n",
     "# Export to \"materials.xml\"\n",
     "materials_file.export_to_xml()"

--- a/examples/jupyter/search.ipynb
+++ b/examples/jupyter/search.ipynb
@@ -71,7 +71,7 @@
     "    water.add_element('B', ppm_Boron * 1E-6)\n",
     "    \n",
     "    # Instantiate a Materials object\n",
-    "    materials = openmc.Materials((fuel, zircaloy, water))\n",
+    "    materials = openmc.Materials([fuel, zircaloy, water])\n",
     "    \n",
     "    # Create cylinders for the fuel and clad\n",
     "    fuel_outer_radius = openmc.ZCylinder(R=0.39218)\n",

--- a/examples/jupyter/tally-arithmetic.ipynb
+++ b/examples/jupyter/tally-arithmetic.ipynb
@@ -105,7 +105,7 @@
    "outputs": [],
    "source": [
     "# Instantiate a Materials collection\n",
-    "materials_file = openmc.Materials((fuel, water, zircaloy))\n",
+    "materials_file = openmc.Materials([fuel, water, zircaloy])\n",
     "\n",
     "# Export to \"materials.xml\"\n",
     "materials_file.export_to_xml()"


### PR DESCRIPTION
I found this bracket issue when testing with simple problem models. Using parentheses, the input in python api will become non-iterable if there is only one material. So I think using a list will be more general.