### PR TITLE
Update correlation used for U weight fractions based on enrichment

### DIFF
--- a/openmc/element.py
+++ b/openmc/element.py
@@ -124,6 +124,15 @@ class Element(object):
             is a tuple consisting of an openmc.Nuclide instance and the natural
             abundance of the isotope.
 
+        Notes
+        -----
+        When the `enrichment` argument is specified, a correlation from
+        `ORNL/CSD/TM-244 <https://doi.org/10.2172/5561567>`_ is used to
+        calculate the weight fractions of U234, U235, U236, and U238. Namely,
+        the weight fraction of U234 and U236 are taken to be 0.89% and 0.46%,
+        respectively, of the U235 weight fraction. The remainder of the isotopic
+        weight is assigned to U238.
+
         """
 
         # Get the nuclides present in nature
@@ -217,9 +226,10 @@ class Element(object):
         if enrichment is not None:
 
             # Calculate the mass fractions of isotopes
-            abundances['U234'] = 0.008 * enrichment
+            abundances['U234'] = 0.0089 * enrichment
             abundances['U235'] = enrichment
-            abundances['U238'] = 100.0 - 1.008 * enrichment
+            abundances['U236'] = 0.0046 * enrichment
+            abundances['U238'] = 100.0 - 1.0135 * enrichment
 
             # Convert the mass fractions to mole fractions
             for nuclide in abundances.keys():

--- a/tests/test_enrichment/test_enrichment.py
+++ b/tests/test_enrichment/test_enrichment.py
@@ -32,6 +32,6 @@ if __name__ == '__main__':
     u234_to_u235 = densities['U234'][1] / densities['U235'][1]
     assert np.isclose(u234_to_u235, 0.0089, rtol=1.e-8)
 
-    # Compute the ratio of U234/U235
+    # Compute the ratio of U236/U235
     u236_to_u235 = densities['U236'][1] / densities['U235'][1]
     assert np.isclose(u236_to_u235, 0.0046, rtol=1.e-8)

--- a/tests/test_enrichment/test_enrichment.py
+++ b/tests/test_enrichment/test_enrichment.py
@@ -33,5 +33,5 @@ if __name__ == '__main__':
     assert np.isclose(u234_to_u235, 0.0089, rtol=1.e-8)
 
     # Compute the ratio of U234/U235
-    u234_to_u235 = densities['U236'][1] / densities['U235'][1]
-    assert np.isclose(u234_to_u235, 0.0046, rtol=1.e-8)
+    u236_to_u235 = densities['U236'][1] / densities['U235'][1]
+    assert np.isclose(u236_to_u235, 0.0046, rtol=1.e-8)

--- a/tests/test_enrichment/test_enrichment.py
+++ b/tests/test_enrichment/test_enrichment.py
@@ -21,7 +21,7 @@ if __name__ == '__main__':
 
     sum_densities = 0.
     for nuc in densities.keys():
-        assert nuc in ('U234', 'U235', 'U238')
+        assert nuc in ('U234', 'U235', 'U236', 'U238')
         sum_densities += densities[nuc][1]
 
     # Compute the weight percent U235
@@ -30,4 +30,8 @@ if __name__ == '__main__':
 
     # Compute the ratio of U234/U235
     u234_to_u235 = densities['U234'][1] / densities['U235'][1]
-    assert np.isclose(u234_to_u235, 0.008, rtol=1.e-8)
+    assert np.isclose(u234_to_u235, 0.0089, rtol=1.e-8)
+
+    # Compute the ratio of U234/U235
+    u234_to_u235 = densities['U236'][1] / densities['U235'][1]
+    assert np.isclose(u234_to_u235, 0.0046, rtol=1.e-8)


### PR DESCRIPTION
This pull request adopts a correlation used to calculate U isotope weight fractions as a function of enrichment from [ORNL/CSD/TM-244](https://doi.org/10.2172/5561567). This correlation is used in SCALE and VERA. @samuelshaner Requesting your review since you put in the original enrichment capability.