### PR TITLE
Make sure autogenerated filter IDs are unique

### DIFF
--- a/openmc/capi/filter.py
+++ b/openmc/capi/filter.py
@@ -45,8 +45,6 @@ _dll.openmc_filter_set_type.errcheck = _error_handler
 _dll.openmc_get_filter_index.argtypes = [c_int32, POINTER(c_int32)]
 _dll.openmc_get_filter_index.restype = c_int
 _dll.openmc_get_filter_index.errcheck = _error_handler
-_dll.openmc_get_free_filter_id.argtypes = [POINTER(c_int32)]
-_dll.openmc_get_free_filter_id.restype = None
 _dll.openmc_material_filter_get_bins.argtypes = [
     c_int32, POINTER(POINTER(c_int32)), POINTER(c_int32)]
 _dll.openmc_material_filter_get_bins.restype = c_int
@@ -255,12 +253,4 @@ class _FilterMapping(Mapping):
     def __repr__(self):
         return repr(dict(self))
 
-
 filters = _FilterMapping()
-
-
-def get_free_filter_id():
-    """Returns an ID number that has not been used by any other filters."""
-    id_ = c_int32()
-    _dll.openmc_get_free_filter_id(id_)
-    return id_.value

--- a/openmc/capi/filter.py
+++ b/openmc/capi/filter.py
@@ -45,6 +45,8 @@ _dll.openmc_filter_set_type.errcheck = _error_handler
 _dll.openmc_get_filter_index.argtypes = [c_int32, POINTER(c_int32)]
 _dll.openmc_get_filter_index.restype = c_int
 _dll.openmc_get_filter_index.errcheck = _error_handler
+_dll.openmc_get_free_filter_id.argtypes = [POINTER(c_int32)]
+_dll.openmc_get_free_filter_id.restype = None
 _dll.openmc_material_filter_get_bins.argtypes = [
     c_int32, POINTER(POINTER(c_int32)), POINTER(c_int32)]
 _dll.openmc_material_filter_get_bins.restype = c_int
@@ -253,4 +255,12 @@ class _FilterMapping(Mapping):
     def __repr__(self):
         return repr(dict(self))
 
+
 filters = _FilterMapping()
+
+
+def get_free_filter_id():
+    """Returns an ID number that has not been used by any other filters."""
+    id_ = c_int32()
+    _dll.openmc_get_free_filter_id(id_)
+    return id_.value

--- a/src/api.F90
+++ b/src/api.F90
@@ -51,7 +51,7 @@ module openmc_api
   public :: openmc_get_cell_index
   public :: openmc_get_keff
   public :: openmc_get_filter_index
-  public :: openmc_get_free_filter_id
+  public :: openmc_get_filter_next_id
   public :: openmc_get_material_index
   public :: openmc_get_nuclide_index
   public :: openmc_get_tally_index

--- a/src/api.F90
+++ b/src/api.F90
@@ -51,6 +51,7 @@ module openmc_api
   public :: openmc_get_cell_index
   public :: openmc_get_keff
   public :: openmc_get_filter_index
+  public :: openmc_get_free_filter_id
   public :: openmc_get_material_index
   public :: openmc_get_nuclide_index
   public :: openmc_get_tally_index

--- a/src/cmfd_input.F90
+++ b/src/cmfd_input.F90
@@ -382,7 +382,7 @@ contains
     ! Set up mesh filter
     i_filt = i_filt_start
     err = openmc_filter_set_type(i_filt, C_CHAR_'mesh' // C_NULL_CHAR)
-    call openmc_get_free_filter_id(filt_id)
+    call openmc_get_filter_next_id(filt_id)
     err = openmc_filter_set_id(i_filt, filt_id)
     err = openmc_mesh_filter_set_mesh(i_filt, i_start)
 
@@ -390,7 +390,7 @@ contains
       ! Read and set incoming energy mesh filter
       i_filt = i_filt + 1
       err = openmc_filter_set_type(i_filt, C_CHAR_'energy' // C_NULL_CHAR)
-      call openmc_get_free_filter_id(filt_id)
+      call openmc_get_filter_next_id(filt_id)
       err = openmc_filter_set_id(i_filt, filt_id)
 
       ! Get energies and set bins
@@ -402,7 +402,7 @@ contains
       ! Read and set outgoing energy mesh filter
       i_filt = i_filt + 1
       err = openmc_filter_set_type(i_filt, C_CHAR_'energyout' // C_NULL_CHAR)
-      call openmc_get_free_filter_id(filt_id)
+      call openmc_get_filter_next_id(filt_id)
       err = openmc_filter_set_id(i_filt, filt_id)
       err = openmc_energy_filter_set_bins(i_filt, ng, energies)
     end if
@@ -411,7 +411,7 @@ contains
     ! tallies use this filter and we need to change the dimension
     i_filt = i_filt + 1
     err = openmc_filter_set_type(i_filt, C_CHAR_'mesh' // C_NULL_CHAR)
-    call openmc_get_free_filter_id(filt_id)
+    call openmc_get_filter_next_id(filt_id)
     err = openmc_filter_set_id(i_filt, filt_id)
     err = openmc_mesh_filter_set_mesh(i_filt, i_start)
 

--- a/src/cmfd_input.F90
+++ b/src/cmfd_input.F90
@@ -261,7 +261,8 @@ contains
     integer :: i_filt_start, i_filt_end
     integer(C_INT32_T), allocatable :: filter_indices(:)
     integer(C_INT) :: err
-    integer :: i_filt      ! index in filters array
+    integer :: i_filt     ! index in filters array
+    integer :: filt_id
     integer :: iarray3(3) ! temp integer array
     real(8) :: rarray3(3) ! temp double array
     real(C_DOUBLE), allocatable :: energies(:)
@@ -381,14 +382,16 @@ contains
     ! Set up mesh filter
     i_filt = i_filt_start
     err = openmc_filter_set_type(i_filt, C_CHAR_'mesh' // C_NULL_CHAR)
-    err = openmc_filter_set_id(i_filt, i_filt)
+    call openmc_get_free_filter_id(filt_id)
+    err = openmc_filter_set_id(i_filt, filt_id)
     err = openmc_mesh_filter_set_mesh(i_filt, i_start)
 
     if (energy_filters) then
       ! Read and set incoming energy mesh filter
       i_filt = i_filt + 1
       err = openmc_filter_set_type(i_filt, C_CHAR_'energy' // C_NULL_CHAR)
-      err = openmc_filter_set_id(i_filt, i_filt)
+      call openmc_get_free_filter_id(filt_id)
+      err = openmc_filter_set_id(i_filt, filt_id)
 
       ! Get energies and set bins
       ng = node_word_count(node_mesh, "energy")
@@ -399,7 +402,8 @@ contains
       ! Read and set outgoing energy mesh filter
       i_filt = i_filt + 1
       err = openmc_filter_set_type(i_filt, C_CHAR_'energyout' // C_NULL_CHAR)
-      err = openmc_filter_set_id(i_filt, i_filt)
+      call openmc_get_free_filter_id(filt_id)
+      err = openmc_filter_set_id(i_filt, filt_id)
       err = openmc_energy_filter_set_bins(i_filt, ng, energies)
     end if
 
@@ -407,7 +411,8 @@ contains
     ! tallies use this filter and we need to change the dimension
     i_filt = i_filt + 1
     err = openmc_filter_set_type(i_filt, C_CHAR_'mesh' // C_NULL_CHAR)
-    err = openmc_filter_set_id(i_filt, i_filt)
+    call openmc_get_free_filter_id(filt_id)
+    err = openmc_filter_set_id(i_filt, filt_id)
     err = openmc_mesh_filter_set_mesh(i_filt, i_start)
 
     ! We need to increase the dimension by one since we also need

--- a/src/input_xml.F90
+++ b/src/input_xml.F90
@@ -3146,7 +3146,9 @@ contains
               filters(i_filt_start) % obj % n_bins = product(m % dimension + 1)
 
               ! Set ID
-              err = openmc_filter_set_id(i_filt_start, i_filt_start)
+              call openmc_get_free_filter_id(filter_id)
+              err = openmc_filter_set_id(i_filt_start, filter_id)
+
 
               ! Add surface filter
               allocate(SurfaceFilter :: filters(i_filt_end) % obj)
@@ -3167,7 +3169,8 @@ contains
                 filt % current = .true.
 
                 ! Set ID
-                err = openmc_filter_set_id(i_filt_end, i_filt_end)
+                call openmc_get_free_filter_id(filter_id)
+                err = openmc_filter_set_id(i_filt_end, filter_id)
               end select
 
               ! Copy filter indices to resized array

--- a/src/input_xml.F90
+++ b/src/input_xml.F90
@@ -3146,7 +3146,7 @@ contains
               filters(i_filt_start) % obj % n_bins = product(m % dimension + 1)
 
               ! Set ID
-              call openmc_get_free_filter_id(filter_id)
+              call openmc_get_filter_next_id(filter_id)
               err = openmc_filter_set_id(i_filt_start, filter_id)
 
 
@@ -3169,7 +3169,7 @@ contains
                 filt % current = .true.
 
                 ! Set ID
-                call openmc_get_free_filter_id(filter_id)
+                call openmc_get_filter_next_id(filter_id)
                 err = openmc_filter_set_id(i_filt_end, filter_id)
               end select
 

--- a/src/tallies/tally_filter_header.F90
+++ b/src/tallies/tally_filter_header.F90
@@ -19,6 +19,7 @@ module tally_filter_header
   public :: openmc_filter_get_id
   public :: openmc_filter_set_id
   public :: openmc_get_filter_index
+  public :: openmc_get_free_filter_id
 
 !===============================================================================
 ! TALLYFILTERMATCH stores every valid bin and weight for a filter
@@ -122,6 +123,10 @@ module tally_filter_header
   ! Dictionary that maps user IDs to indices in 'filters'
   type(DictIntInt), public :: filter_dict
 
+  ! The largest filter ID that has been specified in the system.  This is useful
+  ! in case the code needs to find an ID for a new filter.
+  integer :: largest_filter_id
+
 contains
 
 !===============================================================================
@@ -140,6 +145,7 @@ contains
     n_filters = 0
     if (allocated(filters)) deallocate(filters)
     call filter_dict % clear()
+    largest_filter_id = 0
   end subroutine free_memory_tally_filter
 
 !===============================================================================
@@ -205,6 +211,7 @@ contains
       if (allocated(filters(index) % obj)) then
         filters(index) % obj % id = id
         call filter_dict % set(id, index)
+        if (id > largest_filter_id) largest_filter_id = id
 
         err = 0
       else
@@ -237,5 +244,13 @@ contains
       call set_errmsg("Memory has not been allocated for filters.")
     end if
   end function openmc_get_filter_index
+
+
+  subroutine openmc_get_free_filter_id(id) bind(C)
+    ! Returns an ID number that has not been used by any other filters.
+    integer(C_INT32_T), intent(out) :: id
+
+    id = largest_filter_id + 1
+  end subroutine openmc_get_free_filter_id
 
 end module tally_filter_header

--- a/src/tallies/tally_filter_header.F90
+++ b/src/tallies/tally_filter_header.F90
@@ -19,7 +19,7 @@ module tally_filter_header
   public :: openmc_filter_get_id
   public :: openmc_filter_set_id
   public :: openmc_get_filter_index
-  public :: openmc_get_free_filter_id
+  public :: openmc_get_filter_next_id
 
 !===============================================================================
 ! TALLYFILTERMATCH stores every valid bin and weight for a filter
@@ -246,11 +246,11 @@ contains
   end function openmc_get_filter_index
 
 
-  subroutine openmc_get_free_filter_id(id) bind(C)
+  subroutine openmc_get_filter_next_id(id) bind(C)
     ! Returns an ID number that has not been used by any other filters.
     integer(C_INT32_T), intent(out) :: id
 
     id = largest_filter_id + 1
-  end subroutine openmc_get_free_filter_id
+  end subroutine openmc_get_filter_next_id
 
 end module tally_filter_header


### PR DESCRIPTION
There are a few spots in the code where we would extend the array of filters and then assign those filters with an id number equal to their index.  This is done without checking whether or not that id is available or already taken by another filter so we can sometimes get id collisions.  Note that the tally-arithmetic.ipynb example demonstrates this bug.

This PR adds an API function that can find an unused filter id.  It does this by keeping track of the largest filter id number that has been previously assigned and suggesting an id number that is 1 larger.