### PR TITLE
Remove troublesome mesh_id assignment

### DIFF
--- a/examples/python/pincell/build-xml.py
+++ b/examples/python/pincell/build-xml.py
@@ -119,7 +119,7 @@ settings_file.export_to_xml()
 ###############################################################################
 
 # Instantiate a tally mesh
-mesh = openmc.Mesh(mesh_id=1)
+mesh = openmc.Mesh()
 mesh.type = 'regular'
 mesh.dimension = [100, 100, 1]
 mesh.lower_left = [-0.62992, -0.62992, -1.e50]


### PR DESCRIPTION
Trying to instantiate a Mesh object with `mesh_id=1` after we already created a Mesh object which by default assigned itself a `mesh_id` of 1.