### PR TITLE
Update XML pincell example

### DIFF
--- a/examples/xml/pincell/settings.xml
+++ b/examples/xml/pincell/settings.xml
@@ -22,10 +22,11 @@
   <!-- To assess convergence of the source distribution, we need to define the
        bounds for a mesh over which the Shannon entropy should be
        calculated. The extent in the z direction is made arbitrarily large. -->
-  <entropy>
+  <mesh id="1">
     <lower_left>-0.39218 -0.39218 -1.e50</lower_left>
     <upper_right>0.39218  0.39218  1.e50</upper_right>
     <dimension>10 10 1</dimension>
-  </entropy>
+  </mesh>
+  <entropy_mesh>1</entropy_mesh>
 
 </settings>

--- a/examples/xml/pincell/tallies.xml
+++ b/examples/xml/pincell/tallies.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <tallies>
 
-  <mesh id="1" type="regular">
+  <mesh id="2" type="regular">
     <dimension>100 100 1</dimension>
     <lower_left>-0.62992 -0.62992 -1.e50</lower_left>
     <upper_right>0.62992  0.62992  1.e50</upper_right>


### PR DESCRIPTION
Trivial change in one of our example problems to use `<entropy_mesh>` rather than the older `<entropy>`  element.