### PR TITLE
Make sure Travis checks results of regression and unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ script:
   - if [[ $OPENMC_CONFIG == "check_source" ]]; then
       ./check_source.py;
     else
-      ./run_tests.py -C $OPENMC_CONFIG -j 2;
+      ./run_tests.py -C $OPENMC_CONFIG -j 2 &&
       pytest --cov=../openmc unit_tests/;
     fi
   - cd ..

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ kwargs = {
     # Required dependencies
     'install_requires': [
         'six', 'numpy>=1.9', 'h5py', 'scipy', 'ipython', 'matplotlib',
-        'pandas>=0.17.0', 'lxml', 'uncertainties'
+        'pandas<0.21.0', 'lxml', 'uncertainties'
     ],
 
     # Optional dependencies


### PR DESCRIPTION
Apparently when you have multiple lines in the `script:` portion of .travis.yml, the status of the build is inferred only from the status of the last command (see travis-ci/travis-ci#1066). It turns out that our regression suite is actually failing with the latest version of pandas (0.21) that was released a little more than a week ago but we didn't see that because the unit tests passed and so we still got the green check mark. This PR makes sure that the Travis build will check the results of both the regression and unit test suites; it also makes the pandas dependency <0.21 for the time being until I can get the regression tests fixed.