### PR TITLE
Fix pandas issue related to MultiIndex conversion

### DIFF
--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -1664,8 +1664,10 @@ class Tally(IDManagerMixin):
                     new_column.extend(['']*delta_len)
                     columns[i] = tuple(new_column)
 
-            # Create and set a MultiIndex for the DataFrame's columns
-            df.columns = pd.MultiIndex.from_tuples(columns)
+            # Create and set a MultiIndex for the DataFrame's columns, but only
+            # if any column actually is multi-level (e.g., a mesh filter)
+            if any(len(c) > 1 for c in columns):
+                df.columns = pd.MultiIndex.from_tuples(columns)
 
         # Modify the df.to_string method so that it prints formatted strings.
         # Credit to http://stackoverflow.com/users/3657742/chrisb for this trick

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ kwargs = {
     # Required dependencies
     'install_requires': [
         'six', 'numpy>=1.9', 'h5py', 'scipy', 'ipython', 'matplotlib',
-        'pandas<0.21.0', 'lxml', 'uncertainties'
+        'pandas', 'lxml', 'uncertainties'
     ],
 
     # Optional dependencies


### PR DESCRIPTION
This PR fixes OpenMC to be compatible with the latest release of Pandas, 0.21. Namely, a [backwards-incompatible API change](https://pandas.pydata.org/pandas-docs/stable/whatsnew.html#multiindex-constructor-with-a-single-level) was made in pandas that broke a few of our regression tests which I've circumvented by added some extra logic in `Tally.get_pandas_dataframe` that has to do with multi-level indices on the columns (which we use for things like mesh filters and distribcells).