### PR TITLE
Remove false warnings when one tally filter is used in multiple tallies

### DIFF
--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -3514,7 +3514,7 @@ class Tallies(cv.CheckedList):
                 if f not in already_written:
                     root_element.append(f.to_xml_element())
                     already_written[f] = f.id
-                else:
+                elif f.id != already_written[f]:
                     # Set the IDs of identical filters with different
                     # user-defined IDs to the same value
                     f.id = already_written[f]


### PR DESCRIPTION
If a user adds the same filter to multiple different tallies, then they will get a bunch of false warnings like,
```
/home/smharper/openmc/openmc/mixin.py:61: IDWarning: Another Mesh instance already exists with id=1.
  warn(msg, IDWarning)
```

This happens because we try to check for the case where a user specifies two filters (with two different IDs) that have the exact same type and bins.  However, this check will be triggered even when you compare one filter against itself (which happens when one filter appears in multiple tallies).  This PR provides a quick one-line fix.

To see this error in action, simply add a second tally to the examples/python/pincell inputs that uses the same filters as the first.  For example:
```Python
tally2 = openmc.Tally()
tally2.filters = [energy_filter, mesh_filter]
tally2.scores = ['absorption']
```