### PR TITLE
Allow builds that do not dynamically link libopenmc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ option(debug    "Compile with debug flags"                       OFF)
 option(optimize "Turn on all compiler optimization flags"        OFF)
 option(coverage "Compile with coverage analysis flags"           OFF)
 option(mpif08   "Use Fortran 2008 MPI interface"                 OFF)
+option(linkbin  "Dynamically link the executable to libopenmc"   OFF)
 
 # Maximum number of nested coordinates levels
 set(maxcoord 10 CACHE STRING "Maximum number of nested coordinate levels")
@@ -400,11 +401,18 @@ set(LIBOPENMC_FORTRAN_SRC
 )
 add_library(libopenmc SHARED ${LIBOPENMC_FORTRAN_SRC})
 set_target_properties(libopenmc PROPERTIES OUTPUT_NAME openmc)
-add_executable(${program} src/main.F90)
+if(linkbin)
+  add_executable(${program} src/main.F90)
+else()
+  add_executable(${program} src/main.F90 ${LIBOPENMC_FORTRAN_SRC})
+endif()
 set_property(TARGET ${program} libopenmc pugixml_fortran
   PROPERTY LINKER_LANGUAGE Fortran)
 
 target_include_directories(libopenmc PUBLIC ${HDF5_INCLUDE_DIRS})
+if(NOT linkbin)
+  target_include_directories(${program} PUBLIC ${HDF5_INCLUDE_DIRS})
+endif()
 
 # set compile flags via target_compile_options
 target_compile_options(${program} PUBLIC ${f90flags})
@@ -418,8 +426,14 @@ endforeach()
 
 # target_link_libraries treats any arguments starting with - but not -l as
 # linker flags. Thus, we can pass both linker flags and libraries together.
-target_link_libraries(libopenmc ${ldflags} ${HDF5_LIBRARIES} pugixml_fortran faddeeva)
-target_link_libraries(${program} ${ldflags} libopenmc)
+target_link_libraries(libopenmc ${ldflags} ${HDF5_LIBRARIES} pugixml_fortran
+                      faddeeva)
+if(linkbin)
+  target_link_libraries(${program} ${ldflags} libopenmc)
+else()
+  target_link_libraries(${program} ${ldflags} ${HDF5_LIBRARIES} pugixml_fortran
+                        faddeeva)
+endif()
 
 #===============================================================================
 # Python package
@@ -436,6 +450,7 @@ add_custom_command(TARGET libopenmc POST_BUILD
 #===============================================================================
 
 install(TARGETS ${program} RUNTIME DESTINATION bin)
+install(TARGETS libopenmc LIBRARY DESTINATION lib)
 install(DIRECTORY src/relaxng DESTINATION share/openmc)
 install(FILES man/man1/openmc.1 DESTINATION share/man/man1)
 install(FILES LICENSE DESTINATION "share/doc/${program}" RENAME copyright)

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -240,6 +240,11 @@ coverage
 maxcoord
   Maximum number of nested coordinate levels in geometry. Defaults to 10.
 
+linkbin
+  Dynamically link the executable to the openmc shared library. Turning this on
+  will reduce compile time, but the LD_LIBRARY_PATH (or the equivalent on
+  non-linux systems) must be set, and some error messages will be less helpful.
+
 To set any of these options (e.g. turning on debug mode), the following form
 should be used:
 
@@ -318,6 +323,11 @@ OpenMC locally by specifying an install prefix when running cmake:
 
 The ``CMAKE_INSTALL_PREFIX`` variable can be changed to any path for which you
 have write-access.
+
+If the linkbin option was toggled on during the cmake process, then the
+LD_LIBRARY_PATH environment variable must be modified to include the location of
+libopenmc.so (/usr/local/lib by default, elsewhere if the
+``CMAKE_INSTALL_PREFIX`` was used).
 
 Compiling on Windows 10
 -----------------------


### PR DESCRIPTION
@bforget pointed out that the instructions in our docs are currently insufficient for a clean install.  The hanging point is that the linker has a hard time finding libopenmc.so.  At first, I thought we could just fix that by copying the library to /usr/local/lib, but it turns out that directory surprisingly isn't covered by ldd by default.

This PR makes it so that by default our executable is built without dynamically linking to libopenmc.so.  Unfortunately, this means that every object has to be compiled twice (as far as I can tell, CMake doesn't allow us to use the same object file for multiple targets).  But it makes it so that our users don't have to know about LD_LIBRARY_PATH (and I don't have to know about its equivalents on OSX/Windows) in order to get a basic install running.

Another benefit: error messages for things like segfaults are much more helpful when the executable isn't dynamically linked to libopenmc.  For example:
```
Program received signal SIGFPE: Floating-point exception - erroneous arithmetic operation.

Backtrace for this error:
#0  0x7F8BF721EC07
#1  0x7F8BF721DE00
#2  0x7F8BF566E4AF
#3  0x7F8BF85D8F46
#4  0x7F8BF8378B74
#5  0x7F8BF85DAEFF
#6  0x7F8BF85ADD82
#7  0x7F8BF607F99E
#8  0x7F8BF85ABEB9
#9  0x40110C in MAIN__ at main.F90:30
Floating point exception (core dumped)
```
vs
```
Program received signal SIGFPE: Floating-point exception - erroneous arithmetic operation.

Backtrace for this error:
#0  0x7F2840574C07
#1  0x7F2840573E00
#2  0x7F283E9C44AF
#3  0x6DC243 in __surface_header_MOD_z_cylinder_distance at surface_header.F90:614
#4  0x4825C6 in __geometry_MOD_distance_to_boundary at geometry.F90:796 (discriminator 16)
#5  0x6DE156 in __tracking_MOD_transport at tracking.F90:128
#6  0x6B1C60 in openmc_run._omp_fn.4 at simulation.F90:96 (discriminator 1)
#7  0x7F283F3D599E
#8  0x6B01E9 in openmc_run at simulation.F90:88
#9  0x40663C in MAIN__ at main.F90:30
Floating point exception (core dumped)
```