### PR TITLE
Make sure libopenmc.so gets installed with correct RPATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,9 +281,29 @@ target_link_libraries(pugixml_fortran pugixml)
 # RPATH information
 #===============================================================================
 
+# This block of code ensures that dynamic libraries can be found via the RPATH
+# whether the executable is the original one from the build directory or the
+# installed one in CMAKE_INSTALL_PREFIX. Ref:
+# https://cmake.org/Wiki/CMake_RPATH_handling#Always_full_RPATH
+
+# use, i.e. don't skip the full RPATH for the build tree
+set(CMAKE_SKIP_BUILD_RPATH  FALSE)
+
+# when building, don't use the install RPATH already
+# (but later on when installing)
+set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+
+set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+
 # add the automatically determined parts of the RPATH
 # which point to directories outside the build tree to the install RPATH
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+# the RPATH to be used when installing, but only if it's not a system directory
+list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
+if("${isSystemDir}" STREQUAL "-1")
+   set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+endif()
 
 #===============================================================================
 # Build faddeeva library
@@ -435,7 +455,9 @@ add_custom_command(TARGET libopenmc POST_BUILD
 # Install executable, scripts, manpage, license
 #===============================================================================
 
-install(TARGETS ${program} RUNTIME DESTINATION bin)
+install(TARGETS ${program} libopenmc
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib)
 install(DIRECTORY src/relaxng DESTINATION share/openmc)
 install(FILES man/man1/openmc.1 DESTINATION share/man/man1)
 install(FILES LICENSE DESTINATION "share/doc/${program}" RENAME copyright)


### PR DESCRIPTION
@smharper Thanks for raising the issue about libopenmc.so not being found on installation. This PR proposes an alternative fix to what you have in #932. There were really two problems: 1) the target for libopenmc wasn't actually given to an [install](https://cmake.org/cmake/help/latest/command/install.html) command and 2) even if it was, the openmc executable wouldn't know how to find it. The first problem was very easy to fix. The second problem is best handled by using an [rpath](https://en.wikipedia.org/wiki/Rpath) which places in the executable information about where to find a shared library. For this I just adopted the [recipe](https://cmake.org/Wiki/CMake_RPATH_handling#Always_full_RPATH) suggested on the CMake wiki.

TODO:
- [x] Check that this works on macOS