### PR TITLE
Prevent strange behavior with IAND intrinsic in gcc 7.2

### DIFF
--- a/src/random_lcg.F90
+++ b/src/random_lcg.F90
@@ -17,7 +17,7 @@ module random_lcg
   integer(C_INT64_T), parameter :: prn_add = 1_8                    ! additive factor, c
   integer,            parameter :: prn_bits = 63                    ! number of bits, M
   integer(C_INT64_T), parameter :: prn_mod = ibset(0_8, prn_bits)   ! 2^M
-  integer(C_INT64_T), parameter :: prn_mask = not(prn_mod)          ! 2^M - 1
+  integer(C_INT64_T)            :: prn_mask = not(prn_mod)          ! 2^M - 1
   integer(C_INT64_T), parameter :: prn_stride = 152917_8            ! stride between particles
   real(C_DOUBLE),     parameter :: prn_norm = 2._8**(-prn_bits)     ! 2^(-M)
 


### PR DESCRIPTION
@cjosey pointed out to me recently that the OpenMC tests fail with gcc 7.2. I was able to track down the cause to a change in the result of the [IAND](https://gcc.gnu.org/onlinedocs/gfortran/IAND.html) intrinsic function as it is used in our random_lcg.F90 module. It turns out we are actually relying on the fact that when the product of two 64-bit integers overflows, it *usually* wraps around and ends up being a negative number. However, strictly speaking that is an undefined behavior per the Fortran standard, so the result could be anything. When I tried submitting a [bug report to gcc](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=83235) arguing that IAND should be well-behaved even when one of the arguments is the result of an expression that is undefined, they rejected it as invalid code.

For the time being, I've figured out that if one of the constants we use in random_lcg.F90 doesn't have the parameter attribute, the desired behavior is obtained. This at least will cause our test suite to pass when using gcc 7.2. Longer term, it would be wise to just rewrite our LCG algorithm in C/C++ (ahem @smharper), where we can use unsigned integers that have well-defined overflow behavior.