### PR TITLE
Use 'earliest' libver with h5py for backwards-compatibility

### DIFF
--- a/openmc/data/fission_energy.py
+++ b/openmc/data/fission_energy.py
@@ -107,7 +107,7 @@ def write_compact_458_library(endf_files, output_name='fission_Q_data.h5',
 
     """
     # Open the output file.
-    out = h5py.File(output_name, 'w', libver='latest')
+    out = h5py.File(output_name, 'w', libver='earliest')
 
     # Write comments, if given.  This commented out comment is the one used for
     # the library distributed with OpenMC.

--- a/openmc/data/neutron.py
+++ b/openmc/data/neutron.py
@@ -478,7 +478,7 @@ class IncidentNeutron(EqualityMixin):
             mts = new_mts
         return mts
 
-    def export_to_hdf5(self, path, mode='a'):
+    def export_to_hdf5(self, path, mode='a', libver='earliest'):
         """Export incident neutron data to an HDF5 file.
 
         Parameters
@@ -488,6 +488,9 @@ class IncidentNeutron(EqualityMixin):
         mode : {'r', r+', 'w', 'x', 'a'}
             Mode that is used to open the HDF5 file. This is the second argument
             to the :class:`h5py.File` constructor.
+        libver : {'earliest', 'latest'}
+            Compatibility mode for the HDF5 file. 'latest' will produce files
+            that are less backwards compatible but have performance benefits.
 
         """
         # If data come from ENDF, don't allow exporting to HDF5
@@ -496,7 +499,7 @@ class IncidentNeutron(EqualityMixin):
                                       'originated from an ENDF file.')
 
         # Open file and write version
-        f = h5py.File(path, mode, libver='earliest')
+        f = h5py.File(path, mode, libver=libver)
         f.attrs['version'] = np.array(HDF5_VERSION)
 
         # Write basic data

--- a/openmc/data/neutron.py
+++ b/openmc/data/neutron.py
@@ -496,7 +496,7 @@ class IncidentNeutron(EqualityMixin):
                                       'originated from an ENDF file.')
 
         # Open file and write version
-        f = h5py.File(path, mode, libver='latest')
+        f = h5py.File(path, mode, libver='earliest')
         f.attrs['version'] = np.array(HDF5_VERSION)
 
         # Write basic data

--- a/openmc/data/thermal.py
+++ b/openmc/data/thermal.py
@@ -245,7 +245,7 @@ class ThermalScattering(EqualityMixin):
     def temperatures(self):
         return ["{}K".format(int(round(kT / K_BOLTZMANN))) for kT in self.kTs]
 
-    def export_to_hdf5(self, path, mode='a'):
+    def export_to_hdf5(self, path, mode='a', libver='earliest'):
         """Export table to an HDF5 file.
 
         Parameters
@@ -255,10 +255,13 @@ class ThermalScattering(EqualityMixin):
         mode : {'r', r+', 'w', 'x', 'a'}
             Mode that is used to open the HDF5 file. This is the second argument
             to the :class:`h5py.File` constructor.
+        libver : {'earliest', 'latest'}
+            Compatibility mode for the HDF5 file. 'latest' will produce files
+            that are less backwards compatible but have performance benefits.
 
         """
         # Open file and write version
-        f = h5py.File(path, mode, libver='earliest')
+        f = h5py.File(path, mode, libver=libver)
         f.attrs['version'] = np.array(HDF5_VERSION)
 
         # Write basic data

--- a/openmc/data/thermal.py
+++ b/openmc/data/thermal.py
@@ -258,7 +258,7 @@ class ThermalScattering(EqualityMixin):
 
         """
         # Open file and write version
-        f = h5py.File(path, mode, libver='latest')
+        f = h5py.File(path, mode, libver='earliest')
         f.attrs['version'] = np.array(HDF5_VERSION)
 
         # Write basic data

--- a/openmc/mgxs/library.py
+++ b/openmc/mgxs/library.py
@@ -760,7 +760,7 @@ class Library(object):
 
     def build_hdf5_store(self, filename='mgxs.h5', directory='mgxs',
                          subdomains='all', nuclides='all', xs_type='macro',
-                         row_column='inout'):
+                         row_column='inout', libver='earliest'):
         """Export the multi-group cross section library to an HDF5 binary file.
 
         This method constructs an HDF5 file which stores the library's
@@ -794,6 +794,9 @@ class Library(object):
             Store scattering matrices indexed first by incoming group and
             second by outgoing group ('inout'), or vice versa ('outin').
             Defaults to 'inout'.
+        libver : {'earliest', 'latest'}
+            Compatibility mode for the HDF5 file. 'latest' will produce files
+            that are less backwards compatible but have performance benefits.
 
         Raises
         ------
@@ -823,7 +826,7 @@ class Library(object):
         # Add an attribute for the number of energy groups to the HDF5 file
         full_filename = os.path.join(directory, filename)
         full_filename = full_filename.replace(' ', '-')
-        f = h5py.File(full_filename, 'w', libver='earliest')
+        f = h5py.File(full_filename, 'w', libver=libver)
         f.attrs['# groups'] = self.num_groups
         f.close()
 

--- a/openmc/mgxs/library.py
+++ b/openmc/mgxs/library.py
@@ -823,7 +823,7 @@ class Library(object):
         # Add an attribute for the number of energy groups to the HDF5 file
         full_filename = os.path.join(directory, filename)
         full_filename = full_filename.replace(' ', '-')
-        f = h5py.File(full_filename, 'w')
+        f = h5py.File(full_filename, 'w', libver='earliest')
         f.attrs['# groups'] = self.num_groups
         f.close()
 

--- a/openmc/mgxs/mgxs.py
+++ b/openmc/mgxs/mgxs.py
@@ -1636,7 +1636,8 @@ class MGXS(object):
 
     def build_hdf5_store(self, filename='mgxs.h5', directory='mgxs',
                          subdomains='all', nuclides='all',
-                         xs_type='macro', row_column='inout', append=True):
+                         xs_type='macro', row_column='inout', append=True,
+                         libver='earliest'):
         """Export the multi-group cross section data to an HDF5 binary file.
 
         This method constructs an HDF5 file which stores the multi-group
@@ -1672,6 +1673,9 @@ class MGXS(object):
         append : bool
             If true, appends to an existing HDF5 file with the same filename
             directory (if one exists). Defaults to True.
+        libver : {'earliest', 'latest'}
+            Compatibility mode for the HDF5 file. 'latest' will produce files
+            that are less backwards compatible but have performance benefits.
 
         Raises
         ------
@@ -1693,9 +1697,9 @@ class MGXS(object):
         filename = filename.replace(' ', '-')
 
         if append and os.path.isfile(filename):
-            xs_results = h5py.File(filename, 'a', libver='earliest')
+            xs_results = h5py.File(filename, 'a')
         else:
-            xs_results = h5py.File(filename, 'w', libver='earliest')
+            xs_results = h5py.File(filename, 'w', libver=libver)
 
         # Construct a collection of the subdomains to report
         if not isinstance(subdomains, string_types):

--- a/openmc/mgxs/mgxs.py
+++ b/openmc/mgxs/mgxs.py
@@ -1693,9 +1693,9 @@ class MGXS(object):
         filename = filename.replace(' ', '-')
 
         if append and os.path.isfile(filename):
-            xs_results = h5py.File(filename, 'a')
+            xs_results = h5py.File(filename, 'a', libver='earliest')
         else:
-            xs_results = h5py.File(filename, 'w')
+            xs_results = h5py.File(filename, 'w', libver='earliest')
 
         # Construct a collection of the subdomains to report
         if not isinstance(subdomains, string_types):

--- a/openmc/mgxs_library.py
+++ b/openmc/mgxs_library.py
@@ -2504,20 +2504,23 @@ class MGXSLibrary(object):
 
         return library
 
-    def export_to_hdf5(self, filename='mgxs.h5'):
+    def export_to_hdf5(self, filename='mgxs.h5', libver='earliest'):
         """Create an hdf5 file that can be used for a simulation.
 
         Parameters
         ----------
         filename : str
             Filename of file, default is mgxs.h5.
+        libver : {'earliest', 'latest'}
+            Compatibility mode for the HDF5 file. 'latest' will produce files
+            that are less backwards compatible but have performance benefits.
 
         """
 
         check_type('filename', filename, string_types)
 
         # Create and write to the HDF5 file
-        file = h5py.File(filename, "w", libver='earliest')
+        file = h5py.File(filename, "w", libver=libver)
         file.attrs['filetype'] = np.string_(_FILETYPE_MGXS_LIBRARY)
         file.attrs['version'] = [_VERSION_MGXS_LIBRARY, 0]
         file.attrs['energy_groups'] = self.energy_groups.num_groups

--- a/openmc/mgxs_library.py
+++ b/openmc/mgxs_library.py
@@ -2517,7 +2517,7 @@ class MGXSLibrary(object):
         check_type('filename', filename, string_types)
 
         # Create and write to the HDF5 file
-        file = h5py.File(filename, "w")
+        file = h5py.File(filename, "w", libver='earliest')
         file.attrs['filetype'] = np.string_(_FILETYPE_MGXS_LIBRARY)
         file.attrs['version'] = [_VERSION_MGXS_LIBRARY, 0]
         file.attrs['energy_groups'] = self.energy_groups.num_groups

--- a/scripts/openmc-ace-to-hdf5
+++ b/scripts/openmc-ace-to-hdf5
@@ -46,7 +46,8 @@ parser.add_argument('libraries', nargs='*',
                     help='ACE libraries to convert to HDF5')
 parser.add_argument('-d', '--destination', default='.',
                     help='Directory to create new library in')
-parser.add_argument('-m', '--metastable', choices=['mcnp', 'nndc'], default='nndc',
+parser.add_argument('-m', '--metastable', choices=['mcnp', 'nndc'],
+                    default='nndc',
                     help='How to interpret ZAIDs for metastable nuclides')
 parser.add_argument('--xml', help='Old-style cross_sections.xml that '
                     'lists ACE libraries')
@@ -56,6 +57,9 @@ parser.add_argument('--xsdata', help='Serpent xsdata file that lists '
                     'ACE libraries')
 parser.add_argument('--fission_energy_release', help='HDF5 file containing '
                     'fission energy release data')
+parser.add_argument('--latest_hdf5', help='Use latest HDF5 format for '
+                    'performance over backwards compatibility',
+                    action='store_true')
 args = parser.parse_args()
 
 if not os.path.isdir(args.destination):
@@ -117,6 +121,10 @@ else:
 
 nuclides = {}
 library = openmc.data.DataLibrary()
+if args.latest_hdf5:
+    libver = 'latest'
+else:
+    libver = 'earliest'
 
 for filename in ace_libraries:
     # Check that ACE library exists
@@ -150,7 +158,7 @@ for filename in ace_libraries:
                 # Determine filename
                 outfile = os.path.join(args.destination,
                                        neutron.name.replace('.', '_') + '.h5')
-                neutron.export_to_hdf5(outfile, 'w')
+                neutron.export_to_hdf5(outfile, 'w', libver=libver)
 
                 # Register with library
                 library.register_file(outfile)
@@ -162,10 +170,11 @@ for filename in ace_libraries:
                 try:
                     neutron = \
                         openmc.data.IncidentNeutron.from_hdf5(nuclides[name])
-                    print('Converting {} (ACE) to {} (HDF5)'.format(table.name,
-                                                                    neutron.name))
+                    print('Converting {} (ACE) to {} (HDF5)'
+                          .format(table.name, neutron.name))
                     neutron.add_temperature_from_ace(table, args.metastable)
-                    neutron.export_to_hdf5(nuclides[name] + '_1', 'w')
+                    neutron.export_to_hdf5(nuclides[name] + '_1', 'w',
+                                           libver=libver)
                     os.rename(nuclides[name] + '_1', nuclides[name])
                 except Exception as e:
                     print('Failed to convert {}: {}'.format(table.name, e))
@@ -187,7 +196,7 @@ for filename in ace_libraries:
                 # Determine filename
                 outfile = os.path.join(args.destination,
                                        thermal.name.replace('.', '_') + '.h5')
-                thermal.export_to_hdf5(outfile, 'w')
+                thermal.export_to_hdf5(outfile, 'w', libver=libver)
 
                 # Register with library
                 library.register_file(outfile)
@@ -198,11 +207,13 @@ for filename in ace_libraries:
             else:
                 # Then we only need to append the data
                 try:
-                    thermal = openmc.data.ThermalScattering.from_hdf5(nuclides[name])
-                    print('Converting {} (ACE) to {} (HDF5)'.format(table.name,
-                                                                    thermal.name))
+                    thermal = openmc.data.ThermalScattering.from_hdf5(
+                                                                 nuclides[name])
+                    print('Converting {} (ACE) to {} (HDF5)'
+                          .format(table.name,thermal.name))
                     thermal.add_temperature_from_ace(table)
-                    thermal.export_to_hdf5(nuclides[name] + '_1', 'w')
+                    thermal.export_to_hdf5(nuclides[name] + '_1', 'w',
+                                           libver=libver)
                     os.rename(nuclides[name] + '_1', nuclides[name])
                 except Exception as e:
                     print('Failed to convert {}: {}'.format(table.name, e))

--- a/scripts/openmc-ace-to-hdf5
+++ b/scripts/openmc-ace-to-hdf5
@@ -57,9 +57,10 @@ parser.add_argument('--xsdata', help='Serpent xsdata file that lists '
                     'ACE libraries')
 parser.add_argument('--fission_energy_release', help='HDF5 file containing '
                     'fission energy release data')
-parser.add_argument('--latest_hdf5', help='Use latest HDF5 format for '
-                    'performance over backwards compatibility',
-                    action='store_true')
+parser.add_argument('--libver', choices=['earliest', 'latest'],
+                    default='earliest', help="Output HDF5 versioning. Use "
+                    "'earliest' for backwards compatibility or 'latest' for "
+                    "performance")
 args = parser.parse_args()
 
 if not os.path.isdir(args.destination):
@@ -121,10 +122,6 @@ else:
 
 nuclides = {}
 library = openmc.data.DataLibrary()
-if args.latest_hdf5:
-    libver = 'latest'
-else:
-    libver = 'earliest'
 
 for filename in ace_libraries:
     # Check that ACE library exists
@@ -158,7 +155,7 @@ for filename in ace_libraries:
                 # Determine filename
                 outfile = os.path.join(args.destination,
                                        neutron.name.replace('.', '_') + '.h5')
-                neutron.export_to_hdf5(outfile, 'w', libver=libver)
+                neutron.export_to_hdf5(outfile, 'w', libver=args.libver)
 
                 # Register with library
                 library.register_file(outfile)
@@ -174,7 +171,7 @@ for filename in ace_libraries:
                           .format(table.name, neutron.name))
                     neutron.add_temperature_from_ace(table, args.metastable)
                     neutron.export_to_hdf5(nuclides[name] + '_1', 'w',
-                                           libver=libver)
+                                           libver=args.libver)
                     os.rename(nuclides[name] + '_1', nuclides[name])
                 except Exception as e:
                     print('Failed to convert {}: {}'.format(table.name, e))
@@ -196,7 +193,7 @@ for filename in ace_libraries:
                 # Determine filename
                 outfile = os.path.join(args.destination,
                                        thermal.name.replace('.', '_') + '.h5')
-                thermal.export_to_hdf5(outfile, 'w', libver=libver)
+                thermal.export_to_hdf5(outfile, 'w', libver=args.libver)
 
                 # Register with library
                 library.register_file(outfile)
@@ -213,7 +210,7 @@ for filename in ace_libraries:
                           .format(table.name,thermal.name))
                     thermal.add_temperature_from_ace(table)
                     thermal.export_to_hdf5(nuclides[name] + '_1', 'w',
-                                           libver=libver)
+                                           libver=args.libver)
                     os.rename(nuclides[name] + '_1', nuclides[name])
                 except Exception as e:
                     print('Failed to convert {}: {}'.format(table.name, e))

--- a/scripts/openmc-convert-mcnp70-data
+++ b/scripts/openmc-convert-mcnp70-data
@@ -26,9 +26,10 @@ parser = argparse.ArgumentParser(
 )
 parser.add_argument('-d', '--destination', default='mcnp_endfb70',
                     help='Directory to create new library in')
-parser.add_argument('--latest_hdf5', help='Use latest HDF5 format for '
-                    'performance over backwards compatibility',
-                    action='store_true')
+parser.add_argument('--libver', choices=['earliest', 'latest'],
+                    default='earliest', help="Output HDF5 versioning. Use "
+                    "'earliest' for backwards compatibility or 'latest' for "
+                    "performance")
 parser.add_argument('mcnpdata', help='Directory containing endf70[a-k] and endf70sab')
 args = parser.parse_args()
 assert os.path.isdir(args.mcnpdata)
@@ -41,10 +42,6 @@ if not os.path.isdir(args.destination):
     os.mkdir(args.destination)
 
 library = openmc.data.DataLibrary()
-if args.latest_hdf5:
-    libver = 'latest'
-else:
-    libver = 'earliest'
 
 for path in sorted(endf70):
     print('Loading data from {}...'.format(path))
@@ -69,7 +66,7 @@ for path in sorted(endf70):
         # Export HDF5 file
         h5_file = os.path.join(args.destination, data.name + '.h5')
         print('Writing {}...'.format(h5_file))
-        data.export_to_hdf5(h5_file, 'w', libver=libver)
+        data.export_to_hdf5(h5_file, 'w', libver=args.libver)
 
         # Register with library
         library.register_file(h5_file)
@@ -98,7 +95,7 @@ if os.path.exists(endf70sab):
         # Export HDF5 file
         h5_file = os.path.join(args.destination, data.name + '.h5')
         print('Writing {}...'.format(h5_file))
-        data.export_to_hdf5(h5_file, 'w', libver=libver)
+        data.export_to_hdf5(h5_file, 'w', libver=args.libver)
 
         # Register with library
         library.register_file(h5_file)

--- a/scripts/openmc-convert-mcnp70-data
+++ b/scripts/openmc-convert-mcnp70-data
@@ -26,6 +26,9 @@ parser = argparse.ArgumentParser(
 )
 parser.add_argument('-d', '--destination', default='mcnp_endfb70',
                     help='Directory to create new library in')
+parser.add_argument('--latest_hdf5', help='Use latest HDF5 format for '
+                    'performance over backwards compatibility',
+                    action='store_true')
 parser.add_argument('mcnpdata', help='Directory containing endf70[a-k] and endf70sab')
 args = parser.parse_args()
 assert os.path.isdir(args.mcnpdata)
@@ -38,6 +41,10 @@ if not os.path.isdir(args.destination):
     os.mkdir(args.destination)
 
 library = openmc.data.DataLibrary()
+if args.latest_hdf5:
+    libver = 'latest'
+else:
+    libver = 'earliest'
 
 for path in sorted(endf70):
     print('Loading data from {}...'.format(path))
@@ -62,7 +69,7 @@ for path in sorted(endf70):
         # Export HDF5 file
         h5_file = os.path.join(args.destination, data.name + '.h5')
         print('Writing {}...'.format(h5_file))
-        data.export_to_hdf5(h5_file, 'w')
+        data.export_to_hdf5(h5_file, 'w', libver=libver)
 
         # Register with library
         library.register_file(h5_file)
@@ -91,7 +98,7 @@ if os.path.exists(endf70sab):
         # Export HDF5 file
         h5_file = os.path.join(args.destination, data.name + '.h5')
         print('Writing {}...'.format(h5_file))
-        data.export_to_hdf5(h5_file, 'w')
+        data.export_to_hdf5(h5_file, 'w', libver=libver)
 
         # Register with library
         library.register_file(h5_file)

--- a/scripts/openmc-convert-mcnp71-data
+++ b/scripts/openmc-convert-mcnp71-data
@@ -28,9 +28,10 @@ parser.add_argument('-d', '--destination', default='mcnp_endfb71',
                     help='Directory to create new library in')
 parser.add_argument('-f', '--fission_energy_release',
                     help='HDF5 file containing fission energy release data')
-parser.add_argument('--latest_hdf5', help='Use latest HDF5 format for '
-                    'performance over backwards compatibility',
-                    action='store_true')
+parser.add_argument('--libver', choices=['earliest', 'latest'],
+                    default='earliest', help="Output HDF5 versioning. Use "
+                    "'earliest' for backwards compatibility or 'latest' for "
+                    "performance")
 parser.add_argument('mcnpdata', help='Directory containing endf71x and ENDF71SaB')
 args = parser.parse_args()
 assert os.path.isdir(args.mcnpdata)
@@ -54,10 +55,6 @@ if not os.path.isdir(args.destination):
     os.mkdir(args.destination)
 
 library = openmc.data.DataLibrary()
-if args.latest_hdf5:
-    libver = 'latest'
-else:
-    libver = 'earliest'
 
 for basename, xs_list in sorted(suffixes.items()):
     # Convert first temperature for the table
@@ -87,7 +84,7 @@ for basename, xs_list in sorted(suffixes.items()):
     # Export HDF5 file
     h5_file = os.path.join(args.destination, data.name + '.h5')
     print('Writing {}...'.format(h5_file))
-    data.export_to_hdf5(h5_file, 'w', libver=libver)
+    data.export_to_hdf5(h5_file, 'w', libver=args.libver)
 
     # Register with library
     library.register_file(h5_file)

--- a/scripts/openmc-convert-mcnp71-data
+++ b/scripts/openmc-convert-mcnp71-data
@@ -28,6 +28,9 @@ parser.add_argument('-d', '--destination', default='mcnp_endfb71',
                     help='Directory to create new library in')
 parser.add_argument('-f', '--fission_energy_release',
                     help='HDF5 file containing fission energy release data')
+parser.add_argument('--latest_hdf5', help='Use latest HDF5 format for '
+                    'performance over backwards compatibility',
+                    action='store_true')
 parser.add_argument('mcnpdata', help='Directory containing endf71x and ENDF71SaB')
 args = parser.parse_args()
 assert os.path.isdir(args.mcnpdata)
@@ -51,6 +54,10 @@ if not os.path.isdir(args.destination):
     os.mkdir(args.destination)
 
 library = openmc.data.DataLibrary()
+if args.latest_hdf5:
+    libver = 'latest'
+else:
+    libver = 'earliest'
 
 for basename, xs_list in sorted(suffixes.items()):
     # Convert first temperature for the table
@@ -80,7 +87,7 @@ for basename, xs_list in sorted(suffixes.items()):
     # Export HDF5 file
     h5_file = os.path.join(args.destination, data.name + '.h5')
     print('Writing {}...'.format(h5_file))
-    data.export_to_hdf5(h5_file, 'w')
+    data.export_to_hdf5(h5_file, 'w', libver=libver)
 
     # Register with library
     library.register_file(h5_file)

--- a/scripts/openmc-get-jeff-data
+++ b/scripts/openmc-get-jeff-data
@@ -43,9 +43,10 @@ parser.add_argument('-b', '--batch', action='store_true',
                     help='supresses standard in')
 parser.add_argument('-d', '--destination', default='jeff-3.2-hdf5',
                     help='Directory to create new library in')
-parser.add_argument('--latest_hdf5', help='Use latest HDF5 format for '
-                    'performance over backwards compatibility',
-                    action='store_true')
+parser.add_argument('--libver', choices=['earliest', 'latest'],
+                    default='earliest', help="Output HDF5 versioning. Use "
+                    "'earliest' for backwards compatibility or 'latest' for "
+                    "performance")
 args = parser.parse_args()
 
 response = input(download_warning) if not args.batch else 'y'
@@ -168,10 +169,6 @@ if not os.path.isdir(args.destination):
     os.mkdir(args.destination)
 
 library = openmc.data.DataLibrary()
-if args.latest_hdf5:
-    libver = 'latest'
-else:
-    libver = 'earliest'
 
 for name, filenames in sorted(tables.items()):
     # Convert first temperature for the table
@@ -186,7 +183,7 @@ for name, filenames in sorted(tables.items()):
     # Export HDF5 file
     h5_file = os.path.join(args.destination, data.name + '.h5')
     print('Writing {}...'.format(h5_file))
-    data.export_to_hdf5(h5_file, 'w', libver=libver)
+    data.export_to_hdf5(h5_file, 'w', libver=args.libver)
 
     # Register with library
     library.register_file(h5_file)
@@ -229,7 +226,7 @@ for name, filenames in sorted(tables.items()):
     # Export HDF5 file
     h5_file = os.path.join(args.destination, data.name + '.h5')
     print('Writing {}...'.format(h5_file))
-    data.export_to_hdf5(h5_file, 'w', libver=libver)
+    data.export_to_hdf5(h5_file, 'w', libver=args.libver)
 
     # Register with library
     library.register_file(h5_file)

--- a/scripts/openmc-get-jeff-data
+++ b/scripts/openmc-get-jeff-data
@@ -43,6 +43,9 @@ parser.add_argument('-b', '--batch', action='store_true',
                     help='supresses standard in')
 parser.add_argument('-d', '--destination', default='jeff-3.2-hdf5',
                     help='Directory to create new library in')
+parser.add_argument('--latest_hdf5', help='Use latest HDF5 format for '
+                    'performance over backwards compatibility',
+                    action='store_true')
 args = parser.parse_args()
 
 response = input(download_warning) if not args.batch else 'y'
@@ -165,6 +168,10 @@ if not os.path.isdir(args.destination):
     os.mkdir(args.destination)
 
 library = openmc.data.DataLibrary()
+if args.latest_hdf5:
+    libver = 'latest'
+else:
+    libver = 'earliest'
 
 for name, filenames in sorted(tables.items()):
     # Convert first temperature for the table
@@ -179,7 +186,7 @@ for name, filenames in sorted(tables.items()):
     # Export HDF5 file
     h5_file = os.path.join(args.destination, data.name + '.h5')
     print('Writing {}...'.format(h5_file))
-    data.export_to_hdf5(h5_file, 'w')
+    data.export_to_hdf5(h5_file, 'w', libver=libver)
 
     # Register with library
     library.register_file(h5_file)
@@ -222,7 +229,7 @@ for name, filenames in sorted(tables.items()):
     # Export HDF5 file
     h5_file = os.path.join(args.destination, data.name + '.h5')
     print('Writing {}...'.format(h5_file))
-    data.export_to_hdf5(h5_file, 'w')
+    data.export_to_hdf5(h5_file, 'w', libver=libver)
 
     # Register with library
     library.register_file(h5_file)

--- a/scripts/openmc-get-nndc-data
+++ b/scripts/openmc-get-nndc-data
@@ -33,9 +33,10 @@ parser = argparse.ArgumentParser(
 )
 parser.add_argument('-b', '--batch', action='store_true',
                     help='supresses standard in')
-parser.add_argument('--latest_hdf5', help='Use latest HDF5 format for '
-                    'performance over backwards compatibility',
-                    action='store_true')
+parser.add_argument('--libver', choices=['earliest', 'latest'],
+                    default='earliest', help="Output HDF5 versioning. Use "
+                    "'earliest' for backwards compatibility or 'latest' for "
+                    "performance")
 args = parser.parse_args()
 
 
@@ -160,8 +161,7 @@ fer_file = os.path.join(data_dir, 'fission_Q_data_endfb71.h5')
 # Call the ace-to-hdf5 conversion script
 pwd = os.path.dirname(os.path.realpath(__file__))
 ace2hdf5 = os.path.join(pwd, 'openmc-ace-to-hdf5')
-args_out = [ace2hdf5, '-d', 'nndc_hdf5', '--fission_energy_release', fer_file]
-if args.latest_hdf5:
-    args_out += ['--latest_hdf5']
-args_out += ace_files
-subprocess.call(args_out)
+subprocess.call([ace2hdf5,
+                 '-d', 'nndc_hdf5',
+                 '--fission_energy_release', fer_file,
+                 '--libver', args.libver] + ace_files)

--- a/scripts/openmc-get-nndc-data
+++ b/scripts/openmc-get-nndc-data
@@ -33,6 +33,9 @@ parser = argparse.ArgumentParser(
 )
 parser.add_argument('-b', '--batch', action='store_true',
                     help='supresses standard in')
+parser.add_argument('--latest_hdf5', help='Use latest HDF5 format for '
+                    'performance over backwards compatibility',
+                    action='store_true')
 args = parser.parse_args()
 
 
@@ -154,7 +157,11 @@ ace_files = sorted(glob.glob(os.path.join('nndc', '**', '*.ace*')))
 data_dir = os.path.dirname(sys.modules['openmc.data'].__file__)
 fer_file = os.path.join(data_dir, 'fission_Q_data_endfb71.h5')
 
+# Call the ace-to-hdf5 conversion script
 pwd = os.path.dirname(os.path.realpath(__file__))
 ace2hdf5 = os.path.join(pwd, 'openmc-ace-to-hdf5')
-subprocess.call([ace2hdf5, '-d', 'nndc_hdf5', '--fission_energy_release',
-                 fer_file] + ace_files)
+args_out = [ace2hdf5, '-d', 'nndc_hdf5', '--fission_energy_release', fer_file]
+if args.latest_hdf5:
+    args_out += ['--latest_hdf5']
+args_out += ace_files
+subprocess.call(args_out)


### PR DESCRIPTION
Fixes #940.  This PR asks h5py to output HDF5 files in the most backwards-compatible format possible.  Twice we've had new users unable to get going from a fresh install of OpenMC because Anaconda3 uses a higher version for HDF5 than the Ubuntu defaults.  Plus, it's easy to get your HDF5 versions out-of-sync when you use many different machines.

I tested this on the NNDC U-235 data and it only increases file size from 4.3 MB to 4.7 MB---a price well worth paying in my opinion.