### PR TITLE
Allow OMP_SCHEDULE to control schedule of main parallel do loop

### DIFF
--- a/src/initialize.F90
+++ b/src/initialize.F90
@@ -45,6 +45,9 @@ contains
     integer, intent(in), optional :: intracomm  ! MPI intracommunicator
 
     integer :: err
+#ifdef _OPENMP
+    character(MAX_WORD_LEN) :: envvar
+#endif
 
     ! Copy the communicator to a new variable. This is done to avoid changing
     ! the signature of this subroutine. If MPI is being used but no communicator
@@ -74,6 +77,14 @@ contains
 #ifdef MPI
     ! Setup MPI
     call initialize_mpi(comm)
+#endif
+
+#ifdef _OPENMP
+    ! Change schedule of main parallel-do loop if OMP_SCHEDULE is set
+    call get_environment_variable("OMP_SCHEDULE", envvar)
+    if (len_trim(envvar) == 0) then
+      call omp_set_schedule(omp_sched_static, 0)
+    end if
 #endif
 
     ! Initialize HDF5 interface

--- a/src/simulation.F90
+++ b/src/simulation.F90
@@ -100,7 +100,7 @@ contains
 
       ! ====================================================================
       ! LOOP OVER PARTICLES
-!$omp parallel do schedule(static) firstprivate(p) copyin(tally_derivs)
+!$omp parallel do schedule(runtime) firstprivate(p) copyin(tally_derivs)
       PARTICLE_LOOP: do i_work = 1, work
         current_work = i_work
 


### PR DESCRIPTION
Currently, our main loop over particles uses a static schedule, i.e., if you are simulating 1000 particles on 4 threads, each thread will simulate a block of 250 particles. When you're running on a system with 4 or 8 threads, that's fine. However, on a system with, say, 100s of hardware threads on a single node, static scheduling can lead to pretty bad load imbalances if there aren't enough particles per generation, i.e., if the loop isn't big enough. The simple solution to this is to not use a static schedule -- OpenMP also allows dynamic and guided schedules which provide automatic load balancing. However, we don't use those schedules for the sake of reproducibility, which makes testing much easier.

For the best performance, you'd really want to use a dynamic schedule. This pull request allows a non-static schedule to be set using the OMP_SCHEDULE environment variable thereby at least giving the user an option to maximize performance if they don't care about reproducibility.

@salcedop Since this issue is closest to your heart, would you like to review this pull request?