### PR TITLE
Cleanup naming and a divide-by-zero for multipole

### DIFF
--- a/openmc/data/multipole.py
+++ b/openmc/data/multipole.py
@@ -404,7 +404,7 @@ class WindowedMultipole(EqualityMixin):
             cv.check_type('curvefit', curvefit, np.ndarray)
             if len(curvefit.shape) != 3:
                 raise ValueError('Multipole curvefit arrays must be 3D')
-            if curvefit.shape[2] not in (2, 3):  # sigT, sigA (and maybe sigF)
+            if curvefit.shape[2] not in (2, 3):  # sig_t, sig_a (maybe sig_f)
                 raise ValueError('The third dimension of multipole curvefit'
                                  ' arrays must have a length of 2 or 3')
             if not np.issubdtype(curvefit.dtype, float):
@@ -531,8 +531,6 @@ class WindowedMultipole(EqualityMixin):
         sqrtkT = sqrt(K_BOLTZMANN * T)
         sqrtE = sqrt(E)
         invE = 1.0 / E
-        if sqrtkT > 0.0:
-            dopp = self.sqrtAWR / sqrtkT
 
         # Locate us.  The i_window calc omits a + 1 present in F90 because of
         # the 1-based vs. 0-based indexing.  Similarly startw needs to be
@@ -547,7 +545,7 @@ class WindowedMultipole(EqualityMixin):
         # not appear in the absorption and fission equations.
         if startw <= endw:
             twophi = np.zeros(self.num_l, dtype=np.float)
-            sigT_factor = np.zeros(self.num_l, dtype=np.cfloat)
+            sig_t_factor = np.zeros(self.num_l, dtype=np.cfloat)
 
             for iL in range(self.num_l):
                 twophi[iL] = self.pseudo_k0RS[iL] * sqrtE
@@ -562,35 +560,36 @@ class WindowedMultipole(EqualityMixin):
                     twophi[iL] = twophi[iL] - np.arctan(arg)
 
             twophi = 2.0 * twophi
-            sigT_factor = np.cos(twophi) - 1j*np.sin(twophi)
+            sig_t_factor = np.cos(twophi) - 1j*np.sin(twophi)
 
         # Initialize the ouptut cross sections.
-        sigT = 0.0
-        sigA = 0.0
-        sigF = 0.0
+        sig_t = 0.0
+        sig_a = 0.0
+        sig_f = 0.0
 
         # ======================================================================
         # Add the contribution from the curvefit polynomial.
 
         if sqrtkT != 0 and self.broaden_poly[i_window]:
             # Broaden the curvefit.
+            dopp = self.sqrtAWR / sqrtkT
             broadened_polynomials = _broaden_wmp_polynomials(E, dopp,
                                                              self.fit_order + 1)
             for i_poly in range(self.fit_order+1):
-                sigT += (self.curvefit[i_window, i_poly, _FIT_T]
-                         * broadened_polynomials[i_poly])
-                sigA += (self.curvefit[i_window, i_poly, _FIT_A]
-                         * broadened_polynomials[i_poly])
+                sig_t += (self.curvefit[i_window, i_poly, _FIT_T]
+                          * broadened_polynomials[i_poly])
+                sig_a += (self.curvefit[i_window, i_poly, _FIT_A]
+                          * broadened_polynomials[i_poly])
                 if self.fissionable:
-                    sigF += (self.curvefit[i_window, i_poly, _FIT_F]
-                             * broadened_polynomials[i_poly])
+                    sig_f += (self.curvefit[i_window, i_poly, _FIT_F]
+                              * broadened_polynomials[i_poly])
         else:
             temp = invE
             for i_poly in range(self.fit_order+1):
-                sigT += self.curvefit[i_window, i_poly, _FIT_T] * temp
-                sigA += self.curvefit[i_window, i_poly, _FIT_A] * temp
+                sig_t += self.curvefit[i_window, i_poly, _FIT_T] * temp
+                sig_a += self.curvefit[i_window, i_poly, _FIT_A] * temp
                 if self.fissionable:
-                    sigF += self.curvefit[i_window, i_poly, _FIT_F] * temp
+                    sig_f += self.curvefit[i_window, i_poly, _FIT_F] * temp
                 temp *= sqrtE
 
         # ======================================================================
@@ -602,45 +601,46 @@ class WindowedMultipole(EqualityMixin):
                 psi_chi = -1j / (self.data[i_pole, _MP_EA] - sqrtE)
                 c_temp = psi_chi / E
                 if self.formalism == 'MLBW':
-                    sigT += ((self.data[i_pole, _MLBW_RT] * c_temp *
-                              sigT_factor[self.l_value[i_pole]-1]).real
-                             + (self.data[i_pole, _MLBW_RX] * c_temp).real)
-                    sigA += (self.data[i_pole, _MLBW_RA] * c_temp).real
+                    sig_t += ((self.data[i_pole, _MLBW_RT] * c_temp *
+                               sig_t_factor[self.l_value[i_pole]-1]).real
+                              + (self.data[i_pole, _MLBW_RX] * c_temp).real)
+                    sig_a += (self.data[i_pole, _MLBW_RA] * c_temp).real
                     if self.fissionable:
-                        sigF += (self.data[i_pole, _MLBW_RF] * c_temp).real
+                        sig_f += (self.data[i_pole, _MLBW_RF] * c_temp).real
                 elif self.formalism == 'RM':
-                    sigT += (self.data[i_pole, _RM_RT] * c_temp *
-                             sigT_factor[self.l_value[i_pole]-1]).real
-                    sigA += (self.data[i_pole, _RM_RA] * c_temp).real
+                    sig_t += (self.data[i_pole, _RM_RT] * c_temp *
+                              sig_t_factor[self.l_value[i_pole]-1]).real
+                    sig_a += (self.data[i_pole, _RM_RA] * c_temp).real
                     if self.fissionable:
-                        sigF += (self.data[i_pole, _RM_RF] * c_temp).real
+                        sig_f += (self.data[i_pole, _RM_RF] * c_temp).real
                 else:
                     raise ValueError('Unrecognized/Unsupported R-matrix'
                                      ' formalism')
 
         else:
             # At temperature, use Faddeeva function-based form.
+            dopp = self.sqrtAWR / sqrtkT
             for i_pole in range(startw, endw):
                 Z = (sqrtE - self.data[i_pole, _MP_EA]) * dopp
                 w_val = _faddeeva(Z) * dopp * invE * sqrt(pi)
                 if self.formalism == 'MLBW':
-                    sigT += ((self.data[i_pole, _MLBW_RT] *
-                              sigT_factor[self.l_value[i_pole]-1] +
-                              self.data[i_pole, _MLBW_RX]) * w_val).real
-                    sigA += (self.data[i_pole, _MLBW_RA] * w_val).real
+                    sig_t += ((self.data[i_pole, _MLBW_RT] *
+                               sig_t_factor[self.l_value[i_pole]-1] +
+                               self.data[i_pole, _MLBW_RX]) * w_val).real
+                    sig_a += (self.data[i_pole, _MLBW_RA] * w_val).real
                     if self.fissionable:
-                        sigF += (self.data[i_pole, _MLBW_RF] * w_val).real
+                        sig_f += (self.data[i_pole, _MLBW_RF] * w_val).real
                 elif self.formalism == 'RM':
-                    sigT += (self.data[i_pole, _RM_RT] * w_val *
-                             sigT_factor[self.l_value[i_pole]-1]).real
-                    sigA += (self.data[i_pole, _RM_RA] * w_val).real
+                    sig_t += (self.data[i_pole, _RM_RT] * w_val *
+                              sig_t_factor[self.l_value[i_pole]-1]).real
+                    sig_a += (self.data[i_pole, _RM_RA] * w_val).real
                     if self.fissionable:
-                        sigF += (self.data[i_pole, _RM_RF] * w_val).real
+                        sig_f += (self.data[i_pole, _RM_RF] * w_val).real
                 else:
                     raise ValueError('Unrecognized/Unsupported R-matrix'
                                      ' formalism')
 
-        return sigT, sigA, sigF
+        return sig_t, sig_a, sig_f
 
     def __call__(self, E, T):
         """Compute total, absorption, and fission cross sections.

--- a/src/tallies/tally.F90
+++ b/src/tallies/tally.F90
@@ -2382,7 +2382,7 @@ contains
 
     type(Particle), intent(in) :: p
 
-    integer :: i, j, m
+    integer :: i, j
     integer :: i_tally
     integer :: i_filt
     integer :: i_bin
@@ -3472,7 +3472,7 @@ contains
     integer :: l
     logical :: scoring_diff_nuclide
     real(8) :: flux_deriv
-    real(8) :: dsigT, dsigA, dsigF, cum_dsig
+    real(8) :: dsig_t, dsig_a, dsig_f, cum_dsig
 
     if (score == ZERO) return
 
@@ -3713,17 +3713,17 @@ contains
                   if (mat % nuclide(l) == p % event_nuclide) exit
                 end do
 
-                dsigT = ZERO
+                dsig_t = ZERO
                 associate (nuc => nuclides(p % event_nuclide))
                   if (nuc % mp_present .and. &
                        p % last_E >= nuc % multipole % start_E .and. &
                        p % last_E <= nuc % multipole % end_E) then
                     call multipole_deriv_eval(nuc % multipole, p % last_E, &
-                         p % sqrtkT, dsigT, dsigA, dsigF)
+                         p % sqrtkT, dsig_t, dsig_a, dsig_f)
                   end if
                 end associate
                 score = score * (flux_deriv &
-                     + dsigT * mat % atom_density(l) / material_xs % total)
+                     + dsig_t * mat % atom_density(l) / material_xs % total)
               end associate
             else
               score = score * flux_deriv
@@ -3739,17 +3739,17 @@ contains
                   if (mat % nuclide(l) == p % event_nuclide) exit
                 end do
 
-                dsigT = ZERO
-                dsigA = ZERO
+                dsig_t = ZERO
+                dsig_a = ZERO
                 associate (nuc => nuclides(p % event_nuclide))
                   if (nuc % mp_present .and. &
                        p % last_E >= nuc % multipole % start_E .and. &
                        p % last_E <= nuc % multipole % end_E) then
                     call multipole_deriv_eval(nuc % multipole, p % last_E, &
-                         p % sqrtkT, dsigT, dsigA, dsigF)
+                         p % sqrtkT, dsig_t, dsig_a, dsig_f)
                   end if
                 end associate
-                score = score * (flux_deriv + (dsigT - dsigA) &
+                score = score * (flux_deriv + (dsig_t - dsig_a) &
                      * mat % atom_density(l) / &
                      (material_xs % total - material_xs % absorption))
               end associate
@@ -3766,17 +3766,17 @@ contains
                   if (mat % nuclide(l) == p % event_nuclide) exit
                 end do
 
-                dsigA = ZERO
+                dsig_a = ZERO
                 associate (nuc => nuclides(p % event_nuclide))
                   if (nuc % mp_present .and. &
                        p % last_E >= nuc % multipole % start_E .and. &
                        p % last_E <= nuc % multipole % end_E) then
                     call multipole_deriv_eval(nuc % multipole, p % last_E, &
-                         p % sqrtkT, dsigT, dsigA, dsigF)
+                         p % sqrtkT, dsig_t, dsig_a, dsig_f)
                   end if
                 end associate
-                score = score * (flux_deriv &
-                     + dsigA * mat % atom_density(l) / material_xs % absorption)
+                score = score * (flux_deriv + dsig_a * mat % atom_density(l) &
+                                              / material_xs % absorption)
               end associate
             else
               score = score * flux_deriv
@@ -3791,17 +3791,17 @@ contains
                   if (mat % nuclide(l) == p % event_nuclide) exit
                 end do
 
-                dsigF = ZERO
+                dsig_f = ZERO
                 associate (nuc => nuclides(p % event_nuclide))
                   if (nuc % mp_present .and. &
                        p % last_E >= nuc % multipole % start_E .and. &
                        p % last_E <= nuc % multipole % end_E) then
                     call multipole_deriv_eval(nuc % multipole, p % last_E, &
-                         p % sqrtkT, dsigT, dsigA, dsigF)
+                         p % sqrtkT, dsig_t, dsig_a, dsig_f)
                   end if
                 end associate
                 score = score * (flux_deriv &
-                     + dsigF * mat % atom_density(l) / material_xs % fission)
+                     + dsig_f * mat % atom_density(l) / material_xs % fission)
               end associate
             else
               score = score * flux_deriv
@@ -3816,17 +3816,17 @@ contains
                   if (mat % nuclide(l) == p % event_nuclide) exit
                 end do
 
-                dsigF = ZERO
+                dsig_f = ZERO
                 associate (nuc => nuclides(p % event_nuclide))
                   if (nuc % mp_present .and. &
                        p % last_E >= nuc % multipole % start_E .and. &
                        p % last_E <= nuc % multipole % end_E) then
                     call multipole_deriv_eval(nuc % multipole, p % last_E, &
-                         p % sqrtkT, dsigT, dsigA, dsigF)
+                         p % sqrtkT, dsig_t, dsig_a, dsig_f)
                   end if
                 end associate
                 score = score * (flux_deriv &
-                     + dsigF * mat % atom_density(l) / material_xs % nu_fission&
+                     + dsig_f * mat % atom_density(l) / material_xs % nu_fission&
                      * micro_xs(p % event_nuclide) % nu_fission &
                      / micro_xs(p % event_nuclide) % fission)
               end associate
@@ -3859,8 +3859,8 @@ contains
                          p % last_E <= nuc % multipole % end_E .and. &
                          micro_xs(mat % nuclide(l)) % total > ZERO) then
                       call multipole_deriv_eval(nuc % multipole, p % last_E, &
-                           p % sqrtkT, dsigT, dsigA, dsigF)
-                      cum_dsig = cum_dsig + dsigT * mat % atom_density(l)
+                           p % sqrtkT, dsig_t, dsig_a, dsig_f)
+                      cum_dsig = cum_dsig + dsig_t * mat % atom_density(l)
                     end if
                   end associate
                 end do
@@ -3869,17 +3869,17 @@ contains
                    + cum_dsig / material_xs % total)
             else if (materials(p % material) % id == deriv % diff_material &
                  .and. material_xs % total > ZERO) then
-              dsigT = ZERO
+              dsig_t = ZERO
               associate (nuc => nuclides(i_nuclide))
                 if (nuc % mp_present .and. &
                      p % last_E >= nuc % multipole % start_E .and. &
                      p % last_E <= nuc % multipole % end_E) then
                   call multipole_deriv_eval(nuc % multipole, p % last_E, &
-                       p % sqrtkT, dsigT, dsigA, dsigF)
+                       p % sqrtkT, dsig_t, dsig_a, dsig_f)
                 end if
               end associate
               score = score * (flux_deriv &
-                   + dsigT / micro_xs(i_nuclide) % total)
+                   + dsig_t / micro_xs(i_nuclide) % total)
             else
               score = score * flux_deriv
             end if
@@ -3898,9 +3898,9 @@ contains
                          (micro_xs(mat % nuclide(l)) % total &
                          - micro_xs(mat % nuclide(l)) % absorption) > ZERO) then
                       call multipole_deriv_eval(nuc % multipole, p % last_E, &
-                           p % sqrtkT, dsigT, dsigA, dsigF)
+                           p % sqrtkT, dsig_t, dsig_a, dsig_f)
                       cum_dsig = cum_dsig &
-                           + (dsigT - dsigA) * mat % atom_density(l)
+                           + (dsig_t - dsig_a) * mat % atom_density(l)
                     end if
                   end associate
                 end do
@@ -3910,17 +3910,17 @@ contains
             else if ( materials(p % material) % id == deriv % diff_material &
                  .and. (material_xs % total - material_xs % absorption) > ZERO)&
                  then
-              dsigT = ZERO
-              dsigA = ZERO
+              dsig_t = ZERO
+              dsig_a = ZERO
               associate (nuc => nuclides(i_nuclide))
                 if (nuc % mp_present .and. &
                      p % last_E >= nuc % multipole % start_E .and. &
                      p % last_E <= nuc % multipole % end_E) then
                   call multipole_deriv_eval(nuc % multipole, p % last_E, &
-                       p % sqrtkT, dsigT, dsigA, dsigF)
+                       p % sqrtkT, dsig_t, dsig_a, dsig_f)
                 end if
               end associate
-              score = score * (flux_deriv + (dsigT - dsigA) &
+              score = score * (flux_deriv + (dsig_t - dsig_a) &
                    / (micro_xs(i_nuclide) % total &
                    - micro_xs(i_nuclide) % absorption))
             else
@@ -3940,8 +3940,8 @@ contains
                          p % last_E <= nuc % multipole % end_E .and. &
                          micro_xs(mat % nuclide(l)) % absorption > ZERO) then
                       call multipole_deriv_eval(nuc % multipole, p % last_E, &
-                           p % sqrtkT, dsigT, dsigA, dsigF)
-                      cum_dsig = cum_dsig + dsigA * mat % atom_density(l)
+                           p % sqrtkT, dsig_t, dsig_a, dsig_f)
+                      cum_dsig = cum_dsig + dsig_a * mat % atom_density(l)
                     end if
                   end associate
                 end do
@@ -3950,17 +3950,17 @@ contains
                    + cum_dsig / material_xs % absorption)
             else if (materials(p % material) % id == deriv % diff_material &
                  .and. material_xs % absorption > ZERO) then
-              dsigA = ZERO
+              dsig_a = ZERO
               associate (nuc => nuclides(i_nuclide))
                 if (nuc % mp_present .and. &
                      p % last_E >= nuc % multipole % start_E .and. &
                      p % last_E <= nuc % multipole % end_E) then
                   call multipole_deriv_eval(nuc % multipole, p % last_E, &
-                       p % sqrtkT, dsigT, dsigA, dsigF)
+                       p % sqrtkT, dsig_t, dsig_a, dsig_f)
                 end if
               end associate
               score = score * (flux_deriv &
-                   + dsigA / micro_xs(i_nuclide) % absorption)
+                   + dsig_a / micro_xs(i_nuclide) % absorption)
             else
               score = score * flux_deriv
             end if
@@ -3978,8 +3978,8 @@ contains
                          p % last_E <= nuc % multipole % end_E .and. &
                          micro_xs(mat % nuclide(l)) % fission > ZERO) then
                       call multipole_deriv_eval(nuc % multipole, p % last_E, &
-                           p % sqrtkT, dsigT, dsigA, dsigF)
-                      cum_dsig = cum_dsig + dsigF * mat % atom_density(l)
+                           p % sqrtkT, dsig_t, dsig_a, dsig_f)
+                      cum_dsig = cum_dsig + dsig_f * mat % atom_density(l)
                     end if
                   end associate
                 end do
@@ -3988,17 +3988,17 @@ contains
                    + cum_dsig / material_xs % fission)
             else if (materials(p % material) % id == deriv % diff_material &
                  .and. material_xs % fission > ZERO) then
-              dsigF = ZERO
+              dsig_f = ZERO
               associate (nuc => nuclides(i_nuclide))
                 if (nuc % mp_present .and. &
                      p % last_E >= nuc % multipole % start_E .and. &
                      p % last_E <= nuc % multipole % end_E) then
                   call multipole_deriv_eval(nuc % multipole, p % last_E, &
-                       p % sqrtkT, dsigT, dsigA, dsigF)
+                       p % sqrtkT, dsig_t, dsig_a, dsig_f)
                 end if
               end associate
               score = score * (flux_deriv &
-                   + dsigF / micro_xs(i_nuclide) % fission)
+                   + dsig_f / micro_xs(i_nuclide) % fission)
             else
               score = score * flux_deriv
             end if
@@ -4016,8 +4016,8 @@ contains
                          p % last_E <= nuc % multipole % end_E .and. &
                          micro_xs(mat % nuclide(l)) % nu_fission > ZERO) then
                       call multipole_deriv_eval(nuc % multipole, p % last_E, &
-                           p % sqrtkT, dsigT, dsigA, dsigF)
-                      cum_dsig = cum_dsig + dsigF * mat % atom_density(l) &
+                           p % sqrtkT, dsig_t, dsig_a, dsig_f)
+                      cum_dsig = cum_dsig + dsig_f * mat % atom_density(l) &
                            * micro_xs(mat % nuclide(l)) % nu_fission &
                            / micro_xs(mat % nuclide(l)) % fission
                     end if
@@ -4028,17 +4028,17 @@ contains
                    + cum_dsig / material_xs % nu_fission)
             else if (materials(p % material) % id == deriv % diff_material &
                  .and. material_xs % nu_fission > ZERO) then
-              dsigF = ZERO
+              dsig_f = ZERO
               associate (nuc => nuclides(i_nuclide))
                 if (nuc % mp_present .and. &
                      p % last_E >= nuc % multipole % start_E .and. &
                      p % last_E <= nuc % multipole % end_E) then
                   call multipole_deriv_eval(nuc % multipole, p % last_E, &
-                       p % sqrtkT, dsigT, dsigA, dsigF)
+                       p % sqrtkT, dsig_t, dsig_a, dsig_f)
                 end if
               end associate
               score = score * (flux_deriv &
-                   + dsigF / micro_xs(i_nuclide) % fission)
+                   + dsig_f / micro_xs(i_nuclide) % fission)
             else
               score = score * flux_deriv
             end if
@@ -4066,7 +4066,7 @@ contains
     real(8),        intent(in) :: distance ! Neutron flight distance
 
     integer :: i, l
-    real(8) :: dsigT, dsigA, dsigF
+    real(8) :: dsig_t, dsig_a, dsig_f
 
     ! A void material cannot be perturbed so it will not affect flux derivatives
     if (p % material == MATERIAL_VOID) return
@@ -4109,9 +4109,9 @@ contains
                     ! (1 / phi) * (d_phi / d_T) = - (d_Sigma_tot / d_T) * dist
                     ! (1 / phi) * (d_phi / d_T) = - N (d_sigma_tot / d_T) * dist
                     call multipole_deriv_eval(nuc % multipole, p % E, &
-                         p % sqrtkT, dsigT, dsigA, dsigF)
+                         p % sqrtkT, dsig_t, dsig_a, dsig_f)
                     deriv % flux_deriv = deriv % flux_deriv &
-                         - distance * dsigT * mat % atom_density(l)
+                         - distance * dsig_t * mat % atom_density(l)
                   end if
                 end associate
               end do
@@ -4142,7 +4142,7 @@ contains
     type(Particle), intent(in) :: p
 
     integer :: i, j, l
-    real(8) :: dsigT, dsigA, dsigF
+    real(8) :: dsig_t, dsig_a, dsig_f
 
     ! A void material cannot be perturbed so it will not affect flux derivatives
     if (p % material == MATERIAL_VOID) return
@@ -4196,8 +4196,8 @@ contains
                     ! (1 / phi) * (d_phi / d_T) = (d_Sigma_s / d_T) / Sigma_s
                     ! (1 / phi) * (d_phi / d_T) = (d_sigma_s / d_T) / sigma_s
                     call multipole_deriv_eval(nuc % multipole, p % last_E, &
-                         p % sqrtkT, dsigT, dsigA, dsigF)
-                    deriv % flux_deriv = deriv % flux_deriv + (dsigT - dsigA)&
+                         p % sqrtkT, dsig_t, dsig_a, dsig_f)
+                    deriv % flux_deriv = deriv % flux_deriv + (dsig_t - dsig_a)&
                          / (micro_xs(mat % nuclide(l)) % total &
                          - micro_xs(mat % nuclide(l)) % absorption)
                     ! Note that this is an approximation!  The real scattering


### PR DESCRIPTION
After discussing divide-by-zero exceptions with @paulromano on #953, I was curious to see if our test suite passes with `-ffpe-trap=zero`.  It does, except for the one spot in the multipole calculations that we were discussing.  Having spent so much time with multipole, I feel a smidgen guilty for it being the _only_ source of divide-by-zeros in our test suite so this PR fixes that (benign) divide-by-zero.  Note that there is a non-benign divide-by-zero for `multipole_deriv_eval` at 0K, but fixing that requires development time that I can't justify at the moment :(

While I was at it, I also decided to change the variables like `sigT` to `sig_t` to match our styleguide.

On a side note, @paulromano, my opinion of Python's ZeroDivisionError is softened a bit after seeing that the whole OpenMC test suite can be run without encountering divide-by-zero on the Fortran side (good job!).  I still don't think it's worth breaking from the IEEE standard behavior that's adopted by most other languages, but I can understand why they did so.  Out of curiosity I tried Julia, R, and JavaScript which all give quietly return infs.  Mathematica in quintessential Mathematica-style gives ComplexInfinity which I assume is the most correct but least useful result.  I haven't yet found a language that shares Python's behavior.  From the existence of the [fpectl module](https://docs.python.org/3/library/fpectl.html), I think even Python used to behave differently (note that the examples for that module don't work anymore).