### PR TITLE
Small optimizations for cross section lookups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,9 +116,9 @@ if(CMAKE_Fortran_COMPILER_ID STREQUAL GNU)
   endif()
 
   # GCC compiler options
-  list(APPEND f90flags -cpp -std=f2008ts -fbacktrace -O2)
+  list(APPEND f90flags -cpp -std=f2008ts -fbacktrace -O2 -fstack-arrays)
   if(debug)
-    list(REMOVE_ITEM f90flags -O2)
+    list(REMOVE_ITEM f90flags -O2 -fstack-arrays)
     list(APPEND f90flags -g -Wall -Wno-unused-dummy-argument -pedantic
       -fbounds-check -ffpe-trap=invalid,overflow,underflow)
     list(APPEND ldflags -g)

--- a/src/cross_section.F90
+++ b/src/cross_section.F90
@@ -157,7 +157,7 @@ contains
     real(8) :: sig_t, sig_a, sig_f ! Intermediate multipole variables
 
     ! Initialize cached cross sections to zero
-    micro_xs(i_nuclide) % elastic         = -ONE
+    micro_xs(i_nuclide) % elastic         = CACHE_INVALID
     micro_xs(i_nuclide) % thermal         = ZERO
     micro_xs(i_nuclide) % thermal_elastic = ZERO
 

--- a/src/cross_section.F90
+++ b/src/cross_section.F90
@@ -266,29 +266,29 @@ contains
           micro_xs(i_nuclide) % interp_factor = f
 
           ! Calculate microscopic nuclide total cross section
-          micro_xs(i_nuclide) % total = (ONE - f) * xs % total(i_grid) &
-               + f * xs % total(i_grid + 1)
+          micro_xs(i_nuclide) % total = (ONE - f) * xs % value(SUM_XS_TOTAL,i_grid) &
+               + f * xs % value(SUM_XS_TOTAL,i_grid + 1)
 
           ! Calculate microscopic nuclide elastic cross section
-          micro_xs(i_nuclide) % elastic = (ONE - f) * xs % elastic(i_grid) &
-               + f * xs % elastic(i_grid + 1)
-
-          ! Calculate microscopic nuclide absorption cross section
-          micro_xs(i_nuclide) % absorption = (ONE - f) * xs % absorption( &
-               i_grid) + f * xs % absorption(i_grid + 1)
+          micro_xs(i_nuclide) % elastic = (ONE - f) * xs % value(SUM_XS_ELASTIC,i_grid) &
+               + f * xs % value(SUM_XS_ELASTIC,i_grid + 1)
 
           if (nuc % fissionable) then
             ! Calculate microscopic nuclide total cross section
-            micro_xs(i_nuclide) % fission = (ONE - f) * xs % fission(i_grid) &
-                 + f * xs % fission(i_grid + 1)
+            micro_xs(i_nuclide) % fission = (ONE - f) * xs % value(SUM_XS_FISSION,i_grid) &
+                 + f * xs % value(SUM_XS_FISSION,i_grid + 1)
 
             ! Calculate microscopic nuclide nu-fission cross section
-            micro_xs(i_nuclide) % nu_fission = (ONE - f) * xs % nu_fission( &
-                 i_grid) + f * xs % nu_fission(i_grid + 1)
+            micro_xs(i_nuclide) % nu_fission = (ONE - f) * xs % value(SUM_XS_NU_FISSION, &
+                 i_grid) + f * xs % value(SUM_XS_NU_FISSION,i_grid + 1)
           else
             micro_xs(i_nuclide) % fission         = ZERO
             micro_xs(i_nuclide) % nu_fission      = ZERO
           end if
+
+          ! Calculate microscopic nuclide absorption cross section
+          micro_xs(i_nuclide) % absorption = (ONE - f) * xs % value(SUM_XS_ABSORPTION, &
+               i_grid) + f * xs % value(SUM_XS_ABSORPTION,i_grid + 1)
         end associate
 
         ! Depletion-related reactions

--- a/src/cross_section.F90
+++ b/src/cross_section.F90
@@ -181,14 +181,13 @@ contains
         call multipole_eval(nuc % multipole, E, sqrtkT, sig_t, sig_a, sig_f)
 
         micro_xs(i_nuclide) % total = sig_t
-        micro_xs(i_nuclide) % absorption = sig_a
         micro_xs(i_nuclide) % elastic = sig_t - sig_a
+        micro_xs(i_nuclide) % absorption = sig_a
+        micro_xs(i_nuclide) % fission = sig_f
 
         if (nuc % fissionable) then
-          micro_xs(i_nuclide) % fission = sig_f
           micro_xs(i_nuclide) % nu_fission = sig_f * nuc % nu(E, EMISSION_TOTAL)
         else
-          micro_xs(i_nuclide) % fission    = ZERO
           micro_xs(i_nuclide) % nu_fission = ZERO
         end if
 

--- a/src/cross_section.F90
+++ b/src/cross_section.F90
@@ -233,7 +233,7 @@ contains
           if (f > prn()) i_temp = i_temp + 1
         end select
 
-        associate (grid => nuc % grid(i_temp), xs => nuc % sum_xs(i_temp))
+        associate (grid => nuc % grid(i_temp), xs => nuc % xs(i_temp))
           ! Determine the energy grid index using a logarithmic mapping to
           ! reduce the energy range over which a binary search needs to be
           ! performed
@@ -266,29 +266,29 @@ contains
           micro_xs(i_nuclide) % interp_factor = f
 
           ! Calculate microscopic nuclide total cross section
-          micro_xs(i_nuclide) % total = (ONE - f) * xs % value(SUM_XS_TOTAL,i_grid) &
-               + f * xs % value(SUM_XS_TOTAL,i_grid + 1)
+          micro_xs(i_nuclide) % total = (ONE - f) * xs % value(XS_TOTAL,i_grid) &
+               + f * xs % value(XS_TOTAL,i_grid + 1)
 
           ! Calculate microscopic nuclide elastic cross section
-          micro_xs(i_nuclide) % elastic = (ONE - f) * xs % value(SUM_XS_ELASTIC,i_grid) &
-               + f * xs % value(SUM_XS_ELASTIC,i_grid + 1)
+          micro_xs(i_nuclide) % elastic = (ONE - f) * xs % value(XS_ELASTIC,i_grid) &
+               + f * xs % value(XS_ELASTIC,i_grid + 1)
 
           if (nuc % fissionable) then
             ! Calculate microscopic nuclide total cross section
-            micro_xs(i_nuclide) % fission = (ONE - f) * xs % value(SUM_XS_FISSION,i_grid) &
-                 + f * xs % value(SUM_XS_FISSION,i_grid + 1)
+            micro_xs(i_nuclide) % fission = (ONE - f) * xs % value(XS_FISSION,i_grid) &
+                 + f * xs % value(XS_FISSION,i_grid + 1)
 
             ! Calculate microscopic nuclide nu-fission cross section
-            micro_xs(i_nuclide) % nu_fission = (ONE - f) * xs % value(SUM_XS_NU_FISSION, &
-                 i_grid) + f * xs % value(SUM_XS_NU_FISSION,i_grid + 1)
+            micro_xs(i_nuclide) % nu_fission = (ONE - f) * xs % value(XS_NU_FISSION, &
+                 i_grid) + f * xs % value(XS_NU_FISSION,i_grid + 1)
           else
             micro_xs(i_nuclide) % fission         = ZERO
             micro_xs(i_nuclide) % nu_fission      = ZERO
           end if
 
           ! Calculate microscopic nuclide absorption cross section
-          micro_xs(i_nuclide) % absorption = (ONE - f) * xs % value(SUM_XS_ABSORPTION, &
-               i_grid) + f * xs % value(SUM_XS_ABSORPTION,i_grid + 1)
+          micro_xs(i_nuclide) % absorption = (ONE - f) * xs % value(XS_ABSORPTION, &
+               i_grid) + f * xs % value(XS_ABSORPTION,i_grid + 1)
         end associate
 
         ! Depletion-related reactions

--- a/src/nuclide_header.F90
+++ b/src/nuclide_header.F90
@@ -115,6 +115,10 @@ module nuclide_header
 ! nuclide at the current energy
 !===============================================================================
 
+  ! Arbitrary value to indicate invalid cache state for elastic scattering
+  ! (NuclideMicroXS % elastic)
+  real(8), parameter :: CACHE_INVALID = dble(Z"FFE0000000000000")
+
   type NuclideMicroXS
     ! Microscopic cross sections in barns
     real(8) :: total

--- a/src/nuclide_header.F90
+++ b/src/nuclide_header.F90
@@ -39,11 +39,9 @@ module nuclide_header
   ! Positions for first dimension of Nuclide % xs
   integer, parameter :: &
        XS_TOTAL      = 1, &
-       XS_ELASTIC    = 2, &
+       XS_ABSORPTION = 2, &
        XS_FISSION    = 3, &
-       XS_NU_FISSION = 4, &
-       XS_ABSORPTION = 5, &
-       XS_HEATING    = 6
+       XS_NU_FISSION = 4
 
   ! The array within SumXS is of shape (6, n_energy) where the first dimension
   ! corresponds to the following values: 1) total, 2) elastic scattering, 3)
@@ -120,11 +118,12 @@ module nuclide_header
   type NuclideMicroXS
     ! Microscopic cross sections in barns
     real(8) :: total
-    real(8) :: elastic          ! If sab_frac is not 1 or 0, then this value is
-                                !   averaged over bound and non-bound nuclei
     real(8) :: absorption       ! absorption (disappearance)
     real(8) :: fission          ! fission
     real(8) :: nu_fission       ! neutron production from fission
+
+    real(8) :: elastic          ! If sab_frac is not 1 or 0, then this value is
+                                !   averaged over bound and non-bound nuclei
     real(8) :: thermal          ! Bound thermal elastic & inelastic scattering
     real(8) :: thermal_elastic  ! Bound thermal elastic scattering
 
@@ -155,7 +154,6 @@ module nuclide_header
 
   type MaterialMacroXS
     real(8) :: total         ! macroscopic total xs
-    real(8) :: elastic       ! macroscopic elastic scattering xs
     real(8) :: absorption    ! macroscopic absorption xs
     real(8) :: fission       ! macroscopic fission xs
     real(8) :: nu_fission    ! macroscopic production xs
@@ -605,10 +603,6 @@ contains
         do t = 1, n_temperature
           j = rx % xs(t) % threshold
           n = size(rx % xs(t) % value)
-
-          ! Copy elastic
-          if (rx % MT == ELASTIC) this % xs(t) % value(XS_ELASTIC,:) = &
-               rx % xs(t) % value
 
           ! Add contribution to total cross section
           this % xs(t) % value(XS_TOTAL,j:j+n-1) = this % xs(t) % &

--- a/src/nuclide_header.F90
+++ b/src/nuclide_header.F90
@@ -43,9 +43,9 @@ module nuclide_header
        XS_FISSION    = 3, &
        XS_NU_FISSION = 4
 
-  ! The array within SumXS is of shape (6, n_energy) where the first dimension
-  ! corresponds to the following values: 1) total, 2) elastic scattering, 3)
-  ! fission, 4) neutron production, 5) absorption (MT > 100), 6) heating
+  ! The array within SumXS is of shape (4, n_energy) where the first dimension
+  ! corresponds to the following values: 1) total, 2) absorption (MT > 100), 3)
+  ! fission, 4) neutron production
   type SumXS
     real(8), allocatable :: value(:,:)
   end type SumXS
@@ -576,7 +576,7 @@ contains
     do i = 1, n_temperature
       ! Allocate and initialize derived cross sections
       n_grid = size(this % grid(i) % energy)
-      allocate(this % xs(i) % value(6,n_grid))
+      allocate(this % xs(i) % value(4,n_grid))
       this % xs(i) % value(:,:) = ZERO
     end do
 

--- a/src/physics.F90
+++ b/src/physics.F90
@@ -338,6 +338,18 @@ contains
          micro_xs(i_nuclide) % absorption)
     sampled = .false.
 
+    ! Calculate elastic cross section if need be
+    if (micro_xs(i_nuclide) % elastic == ZERO) then
+      if (i_temp > 0) then
+        associate (xs => nuc % reactions(1) % xs(i_temp) % value)
+          micro_xs(i_nuclide) % elastic = (ONE - f)*xs(i_grid) + f*xs(i_grid + 1)
+        end associate
+      else
+        micro_xs(i_nuclide) % elastic = micro_xs(i_nuclide) % total - &
+             micro_xs(i_nuclide) % absorption
+      end if
+    end if
+
     prob = micro_xs(i_nuclide) % elastic - micro_xs(i_nuclide) % thermal
     if (prob > cutoff) then
       ! =======================================================================

--- a/src/physics.F90
+++ b/src/physics.F90
@@ -339,7 +339,7 @@ contains
     sampled = .false.
 
     ! Calculate elastic cross section if it wasn't precalculated
-    if (micro_xs(i_nuclide) % elastic < ZERO) then
+    if (micro_xs(i_nuclide) % elastic == CACHE_INVALID) then
       call calculate_elastic_xs(i_nuclide)
     end if
 

--- a/src/tallies/tally.F90
+++ b/src/tallies/tally.F90
@@ -1009,20 +1009,6 @@ contains
         ! Simply count number of scoring events
         score = ONE
 
-      case (ELASTIC)
-        if (t % estimator == ESTIMATOR_ANALOG) then
-          ! Check if event MT matches
-          if (p % event_MT /= ELASTIC) cycle SCORE_LOOP
-          score = p % last_wgt * flux
-
-        else
-          if (i_nuclide > 0) then
-            score = micro_xs(i_nuclide) % elastic * atom_density * flux
-          else
-            score = material_xs % elastic * flux
-          end if
-        end if
-
       case (SCORE_FISS_Q_PROMPT)
         score = ZERO
 

--- a/src/tallies/tally.F90
+++ b/src/tallies/tally.F90
@@ -1017,7 +1017,7 @@ contains
 
         else
           if (i_nuclide > 0) then
-            if (micro_xs(i_nuclide) % elastic < ZERO) then
+            if (micro_xs(i_nuclide) % elastic == CACHE_INVALID) then
               call calculate_elastic_xs(i_nuclide)
             end if
             score = micro_xs(i_nuclide) % elastic * atom_density * flux
@@ -1030,7 +1030,7 @@ contains
 
                 ! Get index in nuclides array
                 i_nuc = materials(p % material) % nuclide(l)
-                if (micro_xs(i_nuc) % elastic < ZERO) then
+                if (micro_xs(i_nuc) % elastic == CACHE_INVALID) then
                   call calculate_elastic_xs(i_nuc)
                 end if
 


### PR DESCRIPTION
This pull request makes a few optimizations to the calculation of cross sections that should result in a modest improvement in performance for problems with large nuclide inventories. The optimizations are as follows:

1. The "summed cross sections" that are stored as part of `Nuclide % sum_xs` in (which is of type `SumXS`) are stored such that the cross sections for a given energy grid point are not contiguous. In this PR, they've been collapsed into a 2D array and all cross sections for a grid point are contiguous. Thus, all summed cross sections for a single grid point should appear on the same cache line.
2. In the cross section calculation routines, a number of reaction cross sections are "cached" so that they can be easily accessed during the remainder of the transport algorithm. For example, the total cross section is obviously needed in order to calculate a distance-to-collision, the fission cross section is needed to calculate k-effective estimators, and absorption is needed for implicit capture. Elastic is also "cached", but the reality is that we don't really need to know elastic unless a collision actually happens. This PR changes our cross section routines to not calculate elastic unless they have to. If a neutron is in the thermal or unresolved energy ranges, it can become necessary to calculate the elastic cross section in order to, for example, adjust the total cross section to account for an S(a,b) table.
3. By default, gfortran allocates automatic arrays on the heap. We found that this causes a pretty severe impact on performance for multipole runs (the `multipole_eval` subroutine in particular). I've added the `-fstack-arrays` argument when compiling with gfortran to avoid this.

All of these optimizations were suggested by @liangjg, so he really deserves credit.

I did some performance measurements of our SMR model to see what the impact would be. We have a version of this benchmark with both fresh fuel and depleted fuel. In both cases, depletion tallies are present (7 reaction rates in every fuel material). I ran these cases on a node with two Intel Xeon Platinum 8176 CPUs, each which has 28 cores (and 2 hyperthreads per core). The results are as follows (inactive/active rates shown are kiloneutrons/sec):

Branch  | Fuel | Inactive | Active
------- | ---- | -------: | -----:
develop         | fresh | 253.1 | 142.2
xs-improvements | fresh | 255.8 | 143.8
develop         | depleted | 66.2 | 26.6
xs-improvements | depleted | 70.1 | 27.7

On the fresh fuel case (which only has five nuclides in fuel), the performance is virtually the same. On the depleted case though, these optimizations lead to a 6% improvement in inactive batch performance and a 4% improvement in active batch performance.
