### PR TITLE
Add <create_fission_neutrons> to rng and rnc

### DIFF
--- a/src/relaxng/settings.rnc
+++ b/src/relaxng/settings.rnc
@@ -3,6 +3,8 @@ element settings {
 
   element confidence_intervals { xsd:boolean }? &
 
+  element create_fission_neutrons { xsd:boolean }? &
+
   element cutoff {
     (element weight { xsd:double } | attribute weight { xsd:double })? &
     (element weight_avg { xsd:double } | attribute weight_avg { xsd:double })?

--- a/src/relaxng/settings.rng
+++ b/src/relaxng/settings.rng
@@ -12,6 +12,11 @@
       </element>
     </optional>
     <optional>
+      <element name="create_fission_neutrons">
+        <data type="boolean"/>
+      </element>
+    </optional>
+    <optional>
       <element name="cutoff">
         <interleave>
           <optional>


### PR DESCRIPTION
Was using this feature from #736 and modifying the XMLs directly like a Neanderthal when I discovered that we hadn't added it to the .rng and .rng files.