### PR TITLE
Made not finding the particle's cell while tracking a non-fatal error

### DIFF
--- a/src/tracking.F90
+++ b/src/tracking.F90
@@ -2,7 +2,7 @@ module tracking
 
   use constants
   use cross_section,      only: calculate_xs
-  use error,              only: fatal_error, warning, write_message
+  use error,              only: warning, write_message
   use geometry_header,    only: cells
   use geometry,           only: find_cell, distance_to_boundary, cross_lattice, &
                                 check_cell_overlap
@@ -85,7 +85,9 @@ contains
       if (p % coord(p % n_coord) % cell == NONE) then
         call find_cell(p, found_cell)
         if (.not. found_cell) then
-          call fatal_error("Could not locate particle " // trim(to_str(p % id)))
+          call p % mark_as_lost("Could not find the cell containing" &
+                     // " particle " // trim(to_str(p %id)))
+          return
         end if
 
         ! set birth cell attribute


### PR DESCRIPTION
In the tracking file, at the beginning of the event loop, there is a search for the cell that contains the particle. If it fails to find a cell, currently this leads to calling a fatal error.  
To my knowledge, this makes it impossible to continue the simulation. 

With mark_as_lost, introduced in PR #948 as a replacement for handle_lost_particle, a particle file is created instead, for debugging purposes, and the simulation can go on. 