### PR TITLE
Raise CalledProcessError if openmc.run fails

### DIFF
--- a/openmc/executor.py
+++ b/openmc/executor.py
@@ -15,18 +15,22 @@ def _run(args, output, cwd):
                          stderr=subprocess.STDOUT, universal_newlines=True)
 
     # Capture and re-print OpenMC output in real-time
+    lines = []
     while True:
         # If OpenMC is finished, break loop
         line = p.stdout.readline()
         if not line and p.poll() is not None:
             break
 
+        lines.append(line)
         if output:
             # If user requested output, print to screen
             print(line, end='')
 
-    # Return the returncode (integer, zero if no problems encountered)
-    return p.returncode
+    # Raise an exception if return status is non-zero
+    if p.returncode != 0:
+        raise subprocess.CalledProcessError(p.returncode, ' '.join(args),
+                                            ''.join(lines))
 
 
 def plot_geometry(output=True, openmc_exec='openmc', cwd='.'):
@@ -42,7 +46,7 @@ def plot_geometry(output=True, openmc_exec='openmc', cwd='.'):
         Path to working directory to run in
 
     """
-    return _run([openmc_exec, '-p'], output, cwd)
+    _run([openmc_exec, '-p'], output, cwd)
 
 
 def plot_inline(plots, openmc_exec='openmc', cwd='.', convert_exec='convert'):
@@ -133,7 +137,7 @@ def calculate_volumes(threads=None, output=True, cwd='.',
     if mpi_args is not None:
         args = mpi_args + args
 
-    return _run(args, output, cwd)
+    _run(args, output, cwd)
 
 
 def run(particles=None, threads=None, geometry_debug=False,
@@ -189,4 +193,4 @@ def run(particles=None, threads=None, geometry_debug=False,
     if mpi_args is not None:
         args = mpi_args + args
 
-    return _run(args, output, cwd)
+    _run(args, output, cwd)

--- a/openmc/executor.py
+++ b/openmc/executor.py
@@ -45,6 +45,11 @@ def plot_geometry(output=True, openmc_exec='openmc', cwd='.'):
     cwd : str, optional
         Path to working directory to run in
 
+    Raises
+    ------
+    subprocess.CalledProcessError
+        If the `openmc` executable returns a non-zero status
+
     """
     _run([openmc_exec, '-p'], output, cwd)
 
@@ -66,6 +71,11 @@ def plot_inline(plots, openmc_exec='openmc', cwd='.', convert_exec='convert'):
         Path to working directory to run in
     convert_exec : str, optional
         Command that can convert PPM files into PNG files
+
+    Raises
+    ------
+    subprocess.CalledProcessError
+        If the `openmc` executable returns a non-zero status
 
     """
     from IPython.display import Image, display
@@ -125,6 +135,11 @@ def calculate_volumes(threads=None, output=True, cwd='.',
         Path to working directory to run in. Defaults to the current working
         directory.
 
+    Raises
+    ------
+    subprocess.CalledProcessError
+        If the `openmc` executable returns a non-zero status
+
     See Also
     --------
     openmc.VolumeCalculation
@@ -171,8 +186,12 @@ def run(particles=None, threads=None, geometry_debug=False,
         MPI execute command and any additional MPI arguments to pass,
         e.g. ['mpiexec', '-n', '8'].
 
-    """
+    Raises
+    ------
+    subprocess.CalledProcessError
+        If the `openmc` executable returns a non-zero status
 
+    """
     args = [openmc_exec]
 
     if isinstance(particles, Integral) and particles > 0:

--- a/tests/test_mg_convert/test_mg_convert.py
+++ b/tests/test_mg_convert/test_mg_convert.py
@@ -139,13 +139,10 @@ class MGXSTestHarness(PyAPITestHarness):
 
             if self._opts.mpi_exec is not None:
                 mpi_args = [self._opts.mpi_exec, '-n', self._opts.mpi_np]
-                returncode = openmc.run(openmc_exec=self._opts.exe,
-                                        mpi_args=mpi_args)
+                openmc.run(openmc_exec=self._opts.exe, mpi_args=mpi_args)
 
             else:
-                returncode = openmc.run(openmc_exec=self._opts.exe)
-
-            assert returncode == 0, 'OpenMC did not exit successfully.'
+                openmc.run(openmc_exec=self._opts.exe)
 
             sp = openmc.StatePoint('statepoint.' + str(batches) + '.h5')
 

--- a/tests/test_mgxs_library_ce_to_mg/test_mgxs_library_ce_to_mg.py
+++ b/tests/test_mgxs_library_ce_to_mg/test_mgxs_library_ce_to_mg.py
@@ -36,13 +36,9 @@ class MGXSTestHarness(PyAPITestHarness):
         # Initial run
         if self._opts.mpi_exec is not None:
             mpi_args = [self._opts.mpi_exec, '-n', self._opts.mpi_np]
-            returncode = openmc.run(openmc_exec=self._opts.exe,
-                                    mpi_args=mpi_args)
+            openmc.run(openmc_exec=self._opts.exe, mpi_args=mpi_args)
         else:
-            returncode = openmc.run(openmc_exec=self._opts.exe)
-
-        assert returncode == 0, 'CE OpenMC calculation did not exit' \
-                                'successfully.'
+            openmc.run(openmc_exec=self._opts.exe)
 
         # Build MG Inputs
         # Get data needed to execute Library calculations.
@@ -73,10 +69,9 @@ class MGXSTestHarness(PyAPITestHarness):
         # Re-run MG mode.
         if self._opts.mpi_exec is not None:
             mpi_args = [self._opts.mpi_exec, '-n', self._opts.mpi_np]
-            returncode = openmc.run(openmc_exec=self._opts.exe,
-                                    mpi_args=mpi_args)
+            openmc.run(openmc_exec=self._opts.exe, mpi_args=mpi_args)
         else:
-            returncode = openmc.run(openmc_exec=self._opts.exe)
+            openmc.run(openmc_exec=self._opts.exe)
 
     def _cleanup(self):
         super(MGXSTestHarness, self)._cleanup()

--- a/tests/test_plot/test_plot.py
+++ b/tests/test_plot/test_plot.py
@@ -19,8 +19,7 @@ class PlotTestHarness(TestHarness):
         self._plot_names = plot_names
 
     def _run_openmc(self):
-        returncode = openmc.plot_geometry(openmc_exec=self._opts.exe)
-        assert returncode == 0, 'OpenMC did not exit successfully.'
+        openmc.plot_geometry(openmc_exec=self._opts.exe)
 
     def _test_output_created(self):
         """Make sure *.ppm has been created."""

--- a/tests/test_statepoint_restart/test_statepoint_restart.py
+++ b/tests/test_statepoint_restart/test_statepoint_restart.py
@@ -50,14 +50,10 @@ class StatepointRestartTestHarness(TestHarness):
         # Run OpenMC
         if self._opts.mpi_exec is not None:
             mpi_args = [self._opts.mpi_exec, '-n', self._opts.mpi_np]
-            returncode = openmc.run(restart_file=statepoint,
-                                    openmc_exec=self._opts.exe,
-                                    mpi_args=mpi_args)
+            openmc.run(restart_file=statepoint, openmc_exec=self._opts.exe,
+                       mpi_args=mpi_args)
         else:
-            returncode = openmc.run(openmc_exec=self._opts.exe,
-                                    restart_file=statepoint)
-
-        assert returncode == 0, 'OpenMC did not exit successfully.'
+            openmc.run(openmc_exec=self._opts.exe, restart_file=statepoint)
 
 
 if __name__ == '__main__':

--- a/tests/testing_harness.py
+++ b/tests/testing_harness.py
@@ -62,14 +62,10 @@ class TestHarness(object):
 
     def _run_openmc(self):
         if self._opts.mpi_exec is not None:
-            returncode = openmc.run(
-                openmc_exec=self._opts.exe,
-                mpi_args=[self._opts.mpi_exec, '-n', self._opts.mpi_np])
-
+            openmc.run(openmc_exec=self._opts.exe,
+                       mpi_args=[self._opts.mpi_exec, '-n', self._opts.mpi_np])
         else:
-            returncode = openmc.run(openmc_exec=self._opts.exe)
-
-        assert returncode == 0, 'OpenMC did not exit successfully.'
+            openmc.run(openmc_exec=self._opts.exe)
 
     def _test_output_created(self):
         """Make sure statepoint.* and tallies.out have been created."""
@@ -189,13 +185,11 @@ class ParticleRestartTestHarness(TestHarness):
             args['mpi_args'] = [self._opts.mpi_exec, '-n', self._opts.mpi_np]
 
         # Initial run
-        returncode = openmc.run(**args)
-        assert returncode == 0, 'OpenMC did not exit successfully.'
+        openmc.run(**args)
 
         # Run particle restart
         args.update({'restart_file': self._sp_name})
-        returncode = openmc.run(**args)
-        assert returncode == 0, 'OpenMC did not exit successfully.'
+        openmc.run(**args)
 
     def _test_output_created(self):
         """Make sure the restart file has been created."""


### PR DESCRIPTION
Right now, when `openmc.run()` is called from Python, the return status of the openmc executable is returned. Because a user is unlikely to check the return status, this can result in a script where `openmc.run()` fails but the script continues. A better solution is to have `openmc.run()` raise an exception if the underlying openmc executable fails; that's what this PR does. Other functions that call the openmc executable (like `openmc.plot_geometry()`) also raise an exception now too.