### PR TITLE
Transition surface implementation to C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,14 +48,14 @@ add_definitions(-DMAX_COORD=${maxcoord})
 set(MPI_ENABLED FALSE)
 if($ENV{FC} MATCHES "(mpi[^/]*|ftn)$")
   message("-- Detected MPI wrapper: $ENV{FC}")
-  add_definitions(-DMPI)
+  add_definitions(-DOPENMC_MPI)
   set(MPI_ENABLED TRUE)
 endif()
 
 # Check for Fortran 2008 MPI interface
 if(MPI_ENABLED AND mpif08)
   message("-- Using Fortran 2008 MPI bindings")
-  add_definitions(-DMPIF08)
+  add_definitions(-DOPENMC_MPIF08)
 endif()
 
 #===============================================================================
@@ -435,6 +435,7 @@ set(LIBOPENMC_FORTRAN_SRC
   src/tallies/trigger_header.F90
 )
 set(LIBOPENMC_CXX_SRC
+  src/hdf5_interface.h
   src/random_lcg.h
   src/random_lcg.cpp
   src/surface_header.C

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -435,6 +435,7 @@ set(LIBOPENMC_FORTRAN_SRC
   src/tallies/trigger_header.F90
 )
 set(LIBOPENMC_CXX_SRC
+  src/error.h
   src/hdf5_interface.h
   src/random_lcg.h
   src/random_lcg.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -437,11 +437,13 @@ set(LIBOPENMC_FORTRAN_SRC
 set(LIBOPENMC_CXX_SRC
   src/error.h
   src/hdf5_interface.h
-  src/random_lcg.h
   src/random_lcg.cpp
-  src/surface_header.C
-  src/pugixml/pugixml.hpp
-  src/pugixml/pugixml.cpp)
+  src/random_lcg.h
+  src/surface.cpp
+  src/surface.h
+  src/xml_interface.h
+  src/pugixml/pugixml.cpp
+  src/pugixml/pugixml.hpp)
 add_library(libopenmc SHARED ${LIBOPENMC_FORTRAN_SRC} ${LIBOPENMC_CXX_SRC})
 set_target_properties(libopenmc PROPERTIES OUTPUT_NAME openmc)
 add_executable(${program} src/main.F90)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -436,7 +436,10 @@ set(LIBOPENMC_FORTRAN_SRC
 )
 set(LIBOPENMC_CXX_SRC
   src/random_lcg.h
-  src/random_lcg.cpp)
+  src/random_lcg.cpp
+  src/surface_header.C
+  src/pugixml/pugixml.hpp
+  src/pugixml/pugixml.cpp)
 add_library(libopenmc SHARED ${LIBOPENMC_FORTRAN_SRC} ${LIBOPENMC_CXX_SRC})
 set_target_properties(libopenmc PROPERTIES OUTPUT_NAME openmc)
 add_executable(${program} src/main.F90)

--- a/openmc/capi/settings.py
+++ b/openmc/capi/settings.py
@@ -11,8 +11,7 @@ _RUN_MODES = {1: 'fixed source',
               5: 'volume'}
 
 _dll.openmc_set_seed.argtypes = [c_int64]
-_dll.openmc_set_seed.restype = c_int
-_dll.openmc_set_seed.errcheck = _error_handler
+_dll.openmc_get_seed.restype = c_int64
 
 
 class _Settings(object):
@@ -43,7 +42,7 @@ class _Settings(object):
 
     @property
     def seed(self):
-        return c_int64.in_dll(_dll, 'seed').value
+        return _dll.openmc_get_seed()
 
     @seed.setter
     def seed(self, seed):

--- a/src/api.F90
+++ b/src/api.F90
@@ -171,7 +171,7 @@ contains
     ! Close FORTRAN interface.
     call h5close_f(err)
 
-#ifdef MPI
+#ifdef OPENMC_MPI
     ! Free all MPI types
     call MPI_TYPE_FREE(MPI_BANK, err)
 #endif

--- a/src/api.F90
+++ b/src/api.F90
@@ -18,7 +18,7 @@ module openmc_api
   use initialize,      only: openmc_init
   use particle_header, only: Particle
   use plot,            only: openmc_plot_geometry
-  use random_lcg,      only: seed, openmc_set_seed
+  use random_lcg,      only: openmc_get_seed, openmc_set_seed
   use settings
   use simulation_header
   use source_header,   only: openmc_extend_sources, openmc_source_set_strength
@@ -60,6 +60,7 @@ module openmc_api
   public :: openmc_get_filter_next_id
   public :: openmc_get_material_index
   public :: openmc_get_nuclide_index
+  public :: openmc_get_seed
   public :: openmc_get_tally_index
   public :: openmc_global_tallies
   public :: openmc_hard_reset
@@ -79,6 +80,7 @@ module openmc_api
   public :: openmc_plot_geometry
   public :: openmc_reset
   public :: openmc_run
+  public :: openmc_set_seed
   public :: openmc_simulation_finalize
   public :: openmc_simulation_init
   public :: openmc_source_bank
@@ -142,7 +144,7 @@ contains
     run_CE = .true.
     run_mode = NONE
     satisfy_triggers = .false.
-    seed = 1_8
+    call openmc_set_seed(DEFAULT_SEED)
     source_latest = .false.
     source_separate = .false.
     source_write = .true.
@@ -228,8 +230,6 @@ contains
 !===============================================================================
 
   subroutine openmc_hard_reset() bind(C)
-    integer :: err
-
     ! Reset all tallies and timers
     call openmc_reset()
 
@@ -238,7 +238,7 @@ contains
     total_gen = 0
 
     ! Reset the random number generator state
-    err = openmc_set_seed(1_8)
+    call openmc_set_seed(DEFAULT_SEED)
   end subroutine openmc_hard_reset
 
 !===============================================================================

--- a/src/cmfd_execute.F90
+++ b/src/cmfd_execute.F90
@@ -105,7 +105,7 @@ contains
     real(8) :: hxyz(3) ! cell dimensions of current ijk cell
     real(8) :: vol     ! volume of cell
     real(8),allocatable :: source(:,:,:,:)  ! tmp source array for entropy
-#ifdef MPI
+#ifdef OPENMC_MPI
     integer :: mpi_err ! MPI error code
 #endif
 
@@ -197,7 +197,7 @@ contains
 
     end if
 
-#ifdef MPI
+#ifdef OPENMC_MPI
     ! Broadcast full source to all procs
     call MPI_BCAST(cmfd % cmfd_src, n, MPI_REAL8, 0, mpi_intracomm, mpi_err)
 #endif
@@ -234,7 +234,7 @@ contains
     real(8) :: norm     ! normalization factor
     logical :: outside  ! any source sites outside mesh
     logical :: in_mesh  ! source site is inside mesh
-#ifdef MPI
+#ifdef OPENMC_MPI
     integer :: mpi_err
 #endif
 
@@ -291,7 +291,7 @@ contains
       if (.not. cmfd_feedback) return
 
       ! Broadcast weight factors to all procs
-#ifdef MPI
+#ifdef OPENMC_MPI
       call MPI_BCAST(cmfd % weightfactors, ng*nx*ny*nz, MPI_REAL8, 0, &
            mpi_intracomm, mpi_err)
 #endif

--- a/src/constants.F90
+++ b/src/constants.F90
@@ -43,9 +43,9 @@ module constants
   real(8), parameter :: TINY_BIT = 1e-8_8
 
   ! User for precision in geometry
-  real(8), parameter :: FP_PRECISION = 1e-14_8
-  real(8), parameter :: FP_REL_PRECISION = 1e-5_8
-  real(8), parameter :: FP_COINCIDENT = 1e-12_8
+  real(C_DOUBLE), bind(C, name='FP_PRECISION') :: FP_PRECISION = 1e-14_8
+  real(C_DOUBLE), bind(C, name='FP_REL_PRECISION') :: FP_REL_PRECISION = 1e-5_8
+  real(C_DOUBLE), bind(C, name='FP_COINCIDENT') :: FP_COINCIDENT = 1e-12_8
 
   ! Maximum number of collisions/crossings
   integer, parameter :: MAX_EVENTS = 1000000
@@ -95,11 +95,10 @@ module constants
   ! GEOMETRY-RELATED CONSTANTS
 
   ! Boundary conditions
-  integer, parameter ::  &
-       BC_TRANSMIT = 0,  & ! Transmission boundary condition (default)
-       BC_VACUUM   = 1,  & ! Vacuum boundary condition
-       BC_REFLECT  = 2,  & ! Reflecting boundary condition
-       BC_PERIODIC = 3     ! Periodic boundary condition
+  integer(C_INT), bind(C, name="BC_TRANSMIT") :: BC_TRANSMIT
+  integer(C_INT), bind(C, name="BC_VACUUM") :: BC_VACUUM
+  integer(C_INT), bind(C, name="BC_REFLECT") :: BC_REFLECT
+  integer(C_INT), bind(C, name="BC_PERIODIC") :: BC_PERIODIC
 
   ! Logical operators for cell definitions
   integer, parameter ::              &

--- a/src/eigenvalue.F90
+++ b/src/eigenvalue.F90
@@ -42,11 +42,11 @@ contains
     type(Bank), save, allocatable :: &
          & temp_sites(:)       ! local array of extra sites on each node
 
-#ifdef MPI
+#ifdef OPENMC_MPI
     integer    :: mpi_err      ! MPI error code
     integer(8) :: n            ! number of sites to send/recv
     integer    :: neighbor     ! processor to send/recv data from
-#ifdef MPIF08
+#ifdef OPENMC_MPIF08
     type(MPI_Request) :: request(20)
 #else
     integer    :: request(20)  ! communication request for send/recving sites
@@ -66,7 +66,7 @@ contains
     ! fission bank its own sites starts in order to ensure reproducibility by
     ! skipping ahead to the proper seed.
 
-#ifdef MPI
+#ifdef OPENMC_MPI
     start = 0_8
     call MPI_EXSCAN(n_bank, start, 1, MPI_INTEGER8, MPI_SUM, &
          mpi_intracomm, mpi_err)
@@ -148,7 +148,7 @@ contains
     ! neighboring processors, we have to perform an ALLGATHER to determine the
     ! indices for all processors
 
-#ifdef MPI
+#ifdef OPENMC_MPI
     ! First do an exclusive scan to get the starting indices for
     start = 0_8
     call MPI_EXSCAN(index_temp, start, 1, MPI_INTEGER8, MPI_SUM, &
@@ -191,7 +191,7 @@ contains
     call time_bank_sample % stop()
     call time_bank_sendrecv % start()
 
-#ifdef MPI
+#ifdef OPENMC_MPI
     ! ==========================================================================
     ! SEND BANK SITES TO NEIGHBORS
 
@@ -343,14 +343,14 @@ contains
   subroutine calculate_generation_keff()
 
     real(8) :: keff_reduced
-#ifdef MPI
+#ifdef OPENMC_MPI
     integer :: mpi_err ! MPI error code
 #endif
 
     ! Get keff for this generation by subtracting off the starting value
     keff_generation = global_tallies(RESULT_VALUE, K_TRACKLENGTH) - keff_generation
 
-#ifdef MPI
+#ifdef OPENMC_MPI
     ! Combine values across all processors
     call MPI_ALLREDUCE(keff_generation, keff_reduced, 1, MPI_REAL8, &
          MPI_SUM, mpi_intracomm, mpi_err)
@@ -584,7 +584,7 @@ contains
 
     real(8) :: total         ! total weight in source bank
     logical :: sites_outside ! were there sites outside the ufs mesh?
-#ifdef MPI
+#ifdef OPENMC_MPI
     integer :: n             ! total number of ufs mesh cells
     integer :: mpi_err       ! MPI error code
 #endif
@@ -608,7 +608,7 @@ contains
         call fatal_error("Source sites outside of the UFS mesh!")
       end if
 
-#ifdef MPI
+#ifdef OPENMC_MPI
       ! Send source fraction to all processors
       n = product(m % dimension)
       call MPI_BCAST(source_frac, n, MPI_REAL8, 0, mpi_intracomm, mpi_err)

--- a/src/error.F90
+++ b/src/error.F90
@@ -194,6 +194,14 @@ contains
 
   end subroutine fatal_error
 
+  subroutine fatal_error_from_c(message, message_len) bind(C)
+    integer(C_INT),    intent(in), value :: message_len
+    character(C_CHAR), intent(in)        :: message(message_len)
+    character(message_len+1) :: message_out
+    write(message_out, *) message
+    call fatal_error(message_out)
+  end subroutine
+
 !===============================================================================
 ! WRITE_MESSAGE displays an informational message to the log file and the
 ! standard output stream.

--- a/src/error.F90
+++ b/src/error.F90
@@ -195,9 +195,9 @@ contains
   end subroutine fatal_error
 
   subroutine fatal_error_from_c(message, message_len) bind(C)
-    integer(C_INT),    intent(in), value :: message_len
-    character(C_CHAR), intent(in)        :: message(message_len)
-    character(message_len+1) :: message_out
+    integer(C_INT),         intent(in), value :: message_len
+    character(kind=C_CHAR), intent(in)        :: message(message_len)
+    character(message_len+1)                  :: message_out
     write(message_out, *) message
     call fatal_error(message_out)
   end subroutine

--- a/src/error.F90
+++ b/src/error.F90
@@ -128,7 +128,7 @@ contains
     integer :: line_wrap ! length of line
     integer :: length    ! length of message
     integer :: indent    ! length of indentation
-#ifdef MPI
+#ifdef OPENMC_MPI
     integer :: mpi_err
 #endif
 
@@ -180,7 +180,7 @@ contains
       end if
     end do
 
-#ifdef MPI
+#ifdef OPENMC_MPI
     ! Abort MPI
     call MPI_ABORT(mpi_intracomm, code, mpi_err)
 #endif

--- a/src/error.h
+++ b/src/error.h
@@ -3,6 +3,10 @@
 
 #include <cstring>
 #include <string>
+#include <sstream>
+
+
+namespace openmc {
 
 
 extern "C" void fatal_error_from_c(const char *message, int message_len);
@@ -19,4 +23,12 @@ void fatal_error(const std::string &message)
   fatal_error_from_c(message.c_str(), message.length());
 }
 
+
+void fatal_error(const std::stringstream &message)
+{
+  std::string out {message.str()};
+  fatal_error_from_c(out.c_str(), out.length());
+}
+
+} // namespace openmc
 #endif // ERROR_H

--- a/src/error.h
+++ b/src/error.h
@@ -1,0 +1,21 @@
+#ifndef ERROR_H
+#define ERROR_H
+
+#include <string>
+
+
+extern "C" void fatal_error_from_c(const char *message, int message_len);
+
+
+void fatal_error(const char *message)
+{
+  fatal_error_from_c(message, strlen(message));
+}
+
+
+void fatal_error(const std::string &message)
+{
+  fatal_error_from_c(message.c_str(), message.length());
+}
+
+#endif // ERROR_H

--- a/src/error.h
+++ b/src/error.h
@@ -1,6 +1,7 @@
 #ifndef ERROR_H
 #define ERROR_H
 
+#include <cstring>
 #include <string>
 
 

--- a/src/geometry.F90
+++ b/src/geometry.F90
@@ -44,6 +44,17 @@ module geometry
       real(C_DOUBLE), intent(in)        :: xyz(3);
       real(C_DOUBLE), intent(out)       :: uvw(3);
     end subroutine surface_normal_c
+
+    function surface_periodic_c(surf_ind1, surf_ind2, xyz, uvw) &
+         bind(C, name="surface_periodic") result(rotational)
+      use ISO_C_BINDING
+      implicit none
+      integer(C_INT), intent(in), value :: surf_ind1;
+      integer(C_INT), intent(in), value :: surf_ind2;
+      real(C_DOUBLE), intent(inout)     :: xyz(3);
+      real(C_DOUBLE), intent(inout)     :: uvw(3);
+      logical(C_BOOL)                   :: rotational
+    end function surface_periodic_c
   end interface
 
 contains

--- a/src/geometry.F90
+++ b/src/geometry.F90
@@ -35,6 +35,15 @@ module geometry
       logical(C_BOOL), value :: coincident;
       real(C_DOUBLE) :: d;
     end function surface_distance_c
+
+    subroutine surface_normal_c(surf_ind, xyz, uvw) &
+         bind(C, name='surface_normal')
+      use ISO_C_BINDING
+      implicit none
+      integer(C_INT), value :: surf_ind;
+      real(C_DOUBLE) :: xyz(3);
+      real(C_DOUBLE) :: uvw(3);
+    end subroutine surface_normal_c
   end interface
 
 contains
@@ -76,6 +85,7 @@ contains
     integer :: token
     logical :: actual_sense    ! sense of particle wrt surface
     logical :: alt_sense
+    real(8) :: uvw1(3), uvw2(3)
 
     in_cell = .true.
     do i = 1, size(c%rpn)
@@ -100,6 +110,14 @@ contains
             write(*, *) p % coord (p % n_coord) % xyz
             write(*, *) p % coord (p % n_coord) % uvw
             write(*, *) actual_sense, alt_sense
+            call fatal_error("")
+          end if
+          uvw1 = surfaces(abs(token))%obj%normal(p%coord(p%n_coord)%xyz)
+          call surface_normal_c(abs(token)-1, p%coord(p%n_coord)%xyz, uvw2)
+          if (.not. all(uvw1 - uvw2 == ZERO)) then
+            write(*, *) "Surface normals don't match"
+            write(*, *) uvw1
+            write(*, *) uvw2
             call fatal_error("")
           end if
           if (actual_sense .neqv. (token > 0)) then

--- a/src/geometry.F90
+++ b/src/geometry.F90
@@ -537,7 +537,6 @@ contains
     real(8) :: surf_uvw(3)        ! surface normal direction
     logical :: coincident         ! is particle on surface?
     type(Cell),       pointer :: c
-    class(Surface),   pointer :: surf
     class(Lattice),   pointer :: lat
 
     ! inialize distance to infinity (huge)

--- a/src/geometry.F90
+++ b/src/geometry.F90
@@ -54,16 +54,24 @@ module geometry
       real(C_DOUBLE), intent(out)       :: uvw(3);
     end subroutine surface_normal_c
 
-    function surface_periodic_c(surf_ind1, surf_ind2, xyz, uvw) &
+    function surface_periodic_c(surf_ind1, xyz, uvw) &
          bind(C, name="surface_periodic") result(rotational)
       use ISO_C_BINDING
       implicit none
       integer(C_INT), intent(in), value :: surf_ind1;
-      integer(C_INT), intent(in), value :: surf_ind2;
       real(C_DOUBLE), intent(inout)     :: xyz(3);
       real(C_DOUBLE), intent(inout)     :: uvw(3);
       logical(C_BOOL)                   :: rotational
     end function surface_periodic_c
+
+    function surface_i_periodic_c(surf_ind) bind(C, name="surface_i_periodic") &
+         result(i_periodic)
+      use ISO_C_BINDING
+      implicit none
+      integer(C_INT), intent(in), value :: surf_ind
+      integer(C_INT)                    :: i_periodic
+    end function
+
   end interface
 
 contains
@@ -857,15 +865,15 @@ contains
       ! Copy positive neighbors to Surface instance
       n = neighbor_pos(i)%size()
       if (n > 0) then
-        allocate(surfaces(i)%obj%neighbor_pos(n))
-        surfaces(i)%obj%neighbor_pos(:) = neighbor_pos(i)%data(1:n)
+        allocate(surfaces(i)%neighbor_pos(n))
+        surfaces(i)%neighbor_pos(:) = neighbor_pos(i)%data(1:n)
       end if
 
       ! Copy negative neighbors to Surface instance
       n = neighbor_neg(i)%size()
       if (n > 0) then
-        allocate(surfaces(i)%obj%neighbor_neg(n))
-        surfaces(i)%obj%neighbor_neg(:) = neighbor_neg(i)%data(1:n)
+        allocate(surfaces(i)%neighbor_neg(n))
+        surfaces(i)%neighbor_neg(:) = neighbor_neg(i)%data(1:n)
       end if
     end do
 

--- a/src/hdf5_interface.F90
+++ b/src/hdf5_interface.F90
@@ -124,7 +124,7 @@ contains
       ! Setup file access property list with parallel I/O access
       call h5pcreate_f(H5P_FILE_ACCESS_F, plist, hdf5_err)
 #ifdef PHDF5
-#ifdef MPIF08
+#ifdef OPENMC_MPIF08
       call h5pset_fapl_mpio_f(plist, mpi_intracomm%MPI_VAL, &
            MPI_INFO_NULL%MPI_VAL, hdf5_err)
 #else
@@ -174,7 +174,7 @@ contains
       ! Setup file access property list with parallel I/O access
       call h5pcreate_f(H5P_FILE_ACCESS_F, plist, hdf5_err)
 #ifdef PHDF5
-#ifdef MPIF08
+#ifdef OPENMC_MPIF08
       call h5pset_fapl_mpio_f(plist, mpi_intracomm%MPI_VAL, &
            MPI_INFO_NULL%MPI_VAL, hdf5_err)
 #else

--- a/src/hdf5_interface.h
+++ b/src/hdf5_interface.h
@@ -9,6 +9,9 @@
 #include "error.h"
 
 
+namespace openmc {
+
+
 hid_t
 create_group(hid_t parent_id, char const *name)
 {
@@ -84,4 +87,5 @@ write_string(hid_t group_id, char const *name, const std::string &buffer)
   write_string(group_id, name, buffer.c_str());
 }
 
+} // namespace openmc
 #endif //HDF5_INTERFACE_H

--- a/src/hdf5_interface.h
+++ b/src/hdf5_interface.h
@@ -1,10 +1,43 @@
 #ifndef HDF5_INTERFACE_H
 #define HDF5_INTERFACE_H
 
-#include <array>  // For std::array
-#include <string.h>  // For strlen
+#include <array>
+#include <string.h>
 
 #include "hdf5.h"
+
+#include "error.h"
+
+
+hid_t
+create_group(hid_t parent_id, char const *name)
+{
+  hid_t out = H5Gcreate(parent_id, name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  if (out < 0) {
+    std::string err_msg{"Failed to create HDF5 group \""};
+    err_msg += name;
+    err_msg += "\"";
+    fatal_error(err_msg);
+  }
+  return out;
+}
+
+
+hid_t
+create_group(hid_t parent_id, const std::string &name)
+{
+  return create_group(parent_id, name.c_str());
+}
+
+
+void
+close_group(hid_t group_id)
+{
+  herr_t err = H5Gclose(group_id);
+  if (err < 0) {
+    fatal_error("Failed to close HDF5 group");
+  }
+}
 
 
 template<std::size_t array_len> void
@@ -42,6 +75,13 @@ write_string(hid_t group_id, char const *name, char const *buffer)
   H5Tclose(datatype);
   H5Sclose(dataspace);
   H5Dclose(dataset);
+}
+
+
+void
+write_string(hid_t group_id, char const *name, const std::string &buffer)
+{
+  write_string(group_id, name, buffer.c_str());
 }
 
 #endif //HDF5_INTERFACE_H

--- a/src/hdf5_interface.h
+++ b/src/hdf5_interface.h
@@ -1,0 +1,47 @@
+#ifndef HDF5_INTERFACE_H
+#define HDF5_INTERFACE_H
+
+#include <array>  // For std::array
+#include <string.h>  // For strlen
+
+#include "hdf5.h"
+
+
+template<std::size_t array_len> void
+write_double_1D(hid_t group_id, char const *name,
+                std::array<double, array_len> &buffer)
+{
+  hsize_t dims[1]{array_len};
+  hid_t dataspace = H5Screate_simple(1, dims, NULL);
+
+  hid_t dataset = H5Dcreate(group_id, name, H5T_NATIVE_DOUBLE, dataspace,
+                            H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+
+  H5Dwrite(dataset, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT,
+           &buffer[0]);
+
+  H5Sclose(dataspace);
+  H5Dclose(dataset);
+}
+
+
+void
+write_string(hid_t group_id, char const *name, char const *buffer)
+{
+  size_t buffer_len = strlen(buffer);
+  hid_t datatype = H5Tcopy(H5T_C_S1);
+  H5Tset_size(datatype, buffer_len);
+
+  hid_t dataspace = H5Screate(H5S_SCALAR);
+
+  hid_t dataset = H5Dcreate(group_id, name, datatype, dataspace,
+                            H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+
+  H5Dwrite(dataset, datatype, H5S_ALL, H5S_ALL, H5P_DEFAULT, buffer);
+
+  H5Tclose(datatype);
+  H5Sclose(dataspace);
+  H5Dclose(dataset);
+}
+
+#endif //HDF5_INTERFACE_H

--- a/src/initialize.F90
+++ b/src/initialize.F90
@@ -44,7 +44,6 @@ contains
   subroutine openmc_init(intracomm) bind(C)
     integer, intent(in), optional :: intracomm  ! MPI intracommunicator
 
-    integer :: err
 #ifdef _OPENMP
     character(MAX_WORD_LEN) :: envvar
 #endif
@@ -95,7 +94,7 @@ contains
 
     ! Initialize random number generator -- if the user specifies a seed, it
     ! will be re-initialized later
-    err = openmc_set_seed(DEFAULT_SEED)
+    call openmc_set_seed(DEFAULT_SEED)
 
     ! Read XML input files
     call read_input_xml()

--- a/src/initialize.F90
+++ b/src/initialize.F90
@@ -52,8 +52,8 @@ contains
     ! Copy the communicator to a new variable. This is done to avoid changing
     ! the signature of this subroutine. If MPI is being used but no communicator
     ! was passed, assume MPI_COMM_WORLD.
-#ifdef MPI
-#ifdef MPIF08
+#ifdef OPENMC_MPI
+#ifdef OPENMC_MPIF08
     type(MPI_Comm), intent(in) :: comm     ! MPI intracommunicator
     if (present(intracomm)) then
       comm % MPI_VAL = intracomm
@@ -74,7 +74,7 @@ contains
     call time_total%start()
     call time_initialize%start()
 
-#ifdef MPI
+#ifdef OPENMC_MPI
     ! Setup MPI
     call initialize_mpi(comm)
 #endif
@@ -108,7 +108,7 @@ contains
 
   end subroutine openmc_init
 
-#ifdef MPI
+#ifdef OPENMC_MPI
 !===============================================================================
 ! INITIALIZE_MPI starts up the Message Passing Interface (MPI) and determines
 ! the number of processors the problem is being run with as well as the rank of
@@ -116,7 +116,7 @@ contains
 !===============================================================================
 
   subroutine initialize_mpi(intracomm)
-#ifdef MPIF08
+#ifdef OPENMC_MPIF08
     type(MPI_Comm), intent(in) :: intracomm  ! MPI intracommunicator
 #else
     integer, intent(in) :: intracomm         ! MPI intracommunicator
@@ -124,7 +124,7 @@ contains
 
     integer                   :: mpi_err          ! MPI error code
     integer                   :: bank_blocks(5)   ! Count for each datatype
-#ifdef MPIF08
+#ifdef OPENMC_MPIF08
     type(MPI_Datatype)        :: bank_types(5)
 #else
     integer                   :: bank_types(5)    ! Datatypes

--- a/src/input_xml.F90
+++ b/src/input_xml.F90
@@ -54,7 +54,7 @@ module input_xml
       implicit none
       type(C_PTR) :: node_ptr
     end subroutine read_surfaces
-  end interface 
+  end interface
 
 contains
 
@@ -1081,77 +1081,23 @@ contains
 
       select type(s)
       type is (SurfaceXPlane)
-        s%x0 = coeffs(1)
-
         ! Determine outer surfaces
-        xmin = min(xmin, s % x0)
-        xmax = max(xmax, s % x0)
-        if (xmin == s % x0) i_xmin = i
-        if (xmax == s % x0) i_xmax = i
+        xmin = min(xmin, coeffs(1))
+        xmax = max(xmax, coeffs(1))
+        if (xmin == coeffs(1)) i_xmin = i
+        if (xmax == coeffs(1)) i_xmax = i
       type is (SurfaceYPlane)
-        s%y0 = coeffs(1)
-
         ! Determine outer surfaces
-        ymin = min(ymin, s % y0)
-        ymax = max(ymax, s % y0)
-        if (ymin == s % y0) i_ymin = i
-        if (ymax == s % y0) i_ymax = i
+        ymin = min(ymin, coeffs(1))
+        ymax = max(ymax, coeffs(1))
+        if (ymin == coeffs(1)) i_ymin = i
+        if (ymax == coeffs(1)) i_ymax = i
       type is (SurfaceZPlane)
-        s%z0 = coeffs(1)
-
         ! Determine outer surfaces
-        zmin = min(zmin, s % z0)
-        zmax = max(zmax, s % z0)
-        if (zmin == s % z0) i_zmin = i
-        if (zmax == s % z0) i_zmax = i
-      type is (SurfacePlane)
-        s%A = coeffs(1)
-        s%B = coeffs(2)
-        s%C = coeffs(3)
-        s%D = coeffs(4)
-      type is (SurfaceXCylinder)
-        s%y0 = coeffs(1)
-        s%z0 = coeffs(2)
-        s%r = coeffs(3)
-      type is (SurfaceYCylinder)
-        s%x0 = coeffs(1)
-        s%z0 = coeffs(2)
-        s%r = coeffs(3)
-      type is (SurfaceZCylinder)
-        s%x0 = coeffs(1)
-        s%y0 = coeffs(2)
-        s%r = coeffs(3)
-      type is (SurfaceSphere)
-        s%x0 = coeffs(1)
-        s%y0 = coeffs(2)
-        s%z0 = coeffs(3)
-        s%r = coeffs(4)
-      type is (SurfaceXCone)
-        s%x0 = coeffs(1)
-        s%y0 = coeffs(2)
-        s%z0 = coeffs(3)
-        s%r2 = coeffs(4)
-      type is (SurfaceYCone)
-        s%x0 = coeffs(1)
-        s%y0 = coeffs(2)
-        s%z0 = coeffs(3)
-        s%r2 = coeffs(4)
-      type is (SurfaceZCone)
-        s%x0 = coeffs(1)
-        s%y0 = coeffs(2)
-        s%z0 = coeffs(3)
-        s%r2 = coeffs(4)
-      type is (SurfaceQuadric)
-        s%A = coeffs(1)
-        s%B = coeffs(2)
-        s%C = coeffs(3)
-        s%D = coeffs(4)
-        s%E = coeffs(5)
-        s%F = coeffs(6)
-        s%G = coeffs(7)
-        s%H = coeffs(8)
-        s%J = coeffs(9)
-        s%K = coeffs(10)
+        zmin = min(zmin, coeffs(1))
+        zmax = max(zmax, coeffs(1))
+        if (zmin == coeffs(1)) i_zmin = i
+        if (zmax == coeffs(1)) i_zmax = i
       end select
 
       ! No longer need coefficients

--- a/src/input_xml.F90
+++ b/src/input_xml.F90
@@ -349,7 +349,7 @@ contains
     ! Copy random number seed if specified
     if (check_for_node(root, "seed")) then
       call get_node_value(root, "seed", seed)
-      err = openmc_set_seed(seed)
+      call openmc_set_seed(seed)
     end if
 
     ! Number of bins for logarithmic grid

--- a/src/input_xml.F90
+++ b/src/input_xml.F90
@@ -48,6 +48,14 @@ module input_xml
   implicit none
   save
 
+  interface
+    subroutine read_surfaces(node_ptr) bind(C, name='read_surfaces')
+      use ISO_C_BINDING
+      implicit none
+      type(C_PTR) :: node_ptr
+    end subroutine read_surfaces
+  end interface 
+
 contains
 
 !===============================================================================
@@ -966,6 +974,7 @@ contains
 
     ! get pointer to list of xml <surface>
     call get_node_list(root, "surface", node_surf_list)
+    call read_surfaces(root % ptr)
 
     ! Get number of <surface> tags
     n_surfaces = size(node_surf_list)

--- a/src/input_xml.F90
+++ b/src/input_xml.F90
@@ -1068,13 +1068,6 @@ contains
       ! surface coordinates.
 
       n = node_word_count(node_surf, "coeffs")
-      if (n < coeffs_reqd) then
-        call fatal_error("Not enough coefficients specified for surface: " &
-             // trim(to_str(s%id)))
-      elseif (n > coeffs_reqd) then
-        call fatal_error("Too many coefficients specified for surface: " &
-             // trim(to_str(s%id)))
-      end if
 
       allocate(coeffs(n))
       call get_node_array(node_surf, "coeffs", coeffs)

--- a/src/main.F90
+++ b/src/main.F90
@@ -9,13 +9,13 @@ program main
 
   implicit none
 
-#ifdef MPI
+#ifdef OPENMC_MPI
   integer :: mpi_err ! MPI error code
 #endif
 
   ! Initialize run -- when run with MPI, pass communicator
-#ifdef MPI
-#ifdef MPIF08
+#ifdef OPENMC_MPI
+#ifdef OPENMC_MPIF08
   call openmc_init(MPI_COMM_WORLD % MPI_VAL)
 #else
   call openmc_init(MPI_COMM_WORLD)
@@ -39,7 +39,7 @@ program main
   ! finalize run
   call openmc_finalize()
 
-#ifdef MPI
+#ifdef OPENMC_MPI
   ! If MPI is in use and enabled, terminate it
   call MPI_FINALIZE(mpi_err)
 #endif

--- a/src/mesh.F90
+++ b/src/mesh.F90
@@ -34,7 +34,7 @@ contains
     integer :: n        ! number of energy groups / size
     integer :: mesh_bin ! mesh bin
     integer :: e_bin    ! energy bin
-#ifdef MPI
+#ifdef OPENMC_MPI
     integer :: mpi_err  ! MPI error code
 #endif
     logical :: outside  ! was any site outside mesh?
@@ -86,7 +86,7 @@ contains
       cnt_(e_bin, mesh_bin) = cnt_(e_bin, mesh_bin) + bank_array(i) % wgt
     end do FISSION_SITES
 
-#ifdef MPI
+#ifdef OPENMC_MPI
     ! collect values from all processors
     n = size(cnt_)
     call MPI_REDUCE(cnt_, cnt, n, MPI_REAL8, MPI_SUM, 0, mpi_intracomm, mpi_err)

--- a/src/message_passing.F90
+++ b/src/message_passing.F90
@@ -1,7 +1,7 @@
 module message_passing
 
-#ifdef MPI
-#ifdef MPIF08
+#ifdef OPENMC_MPI
+#ifdef OPENMC_MPIF08
   use mpi_f08
 #else
   use mpi
@@ -16,7 +16,7 @@ module message_passing
   integer :: rank        = 0       ! rank of process
   logical :: master      = .true.  ! master process?
   logical :: mpi_enabled = .false. ! is MPI in use and initialized?
-#ifdef MPIF08
+#ifdef OPENMC_MPIF08
   type(MPI_Datatype) :: MPI_BANK   ! MPI datatype for fission bank
   type(MPI_Comm) :: mpi_intracomm  ! MPI intra-communicator
 #else

--- a/src/output.F90
+++ b/src/output.F90
@@ -259,7 +259,7 @@ contains
 
     ! Print surface
     if (p % surface /= NONE) then
-      write(ou,*) '  Surface = ' // to_str(sign(surfaces(i)%id, p % surface))
+      write(ou,*) '  Surface = ' // to_str(sign(surfaces(i)%id(), p % surface))
     end if
 
     ! Display weight, energy, grid index, and interpolation factor

--- a/src/output.F90
+++ b/src/output.F90
@@ -88,7 +88,7 @@ contains
     ! Write the date and time
     write(UNIT=OUTPUT_UNIT, FMT='(9X,"Date/Time | ",A)') time_stamp()
 
-#ifdef MPI
+#ifdef OPENMC_MPI
     ! Write number of processors
     write(UNIT=OUTPUT_UNIT, FMT='(5X,"MPI Processes | ",A)') &
          trim(to_str(n_procs))

--- a/src/output.F90
+++ b/src/output.F90
@@ -259,7 +259,7 @@ contains
 
     ! Print surface
     if (p % surface /= NONE) then
-      write(ou,*) '  Surface = ' // to_str(sign(surfaces(i)%obj%id, p % surface))
+      write(ou,*) '  Surface = ' // to_str(sign(surfaces(i)%id, p % surface))
     end if
 
     ! Display weight, energy, grid index, and interpolation factor

--- a/src/random_lcg.F90
+++ b/src/random_lcg.F90
@@ -4,8 +4,6 @@ module random_lcg
 
   implicit none
 
-  integer(C_INT64_T), bind(C) :: seed
-
   interface
     function prn() result(pseudo_rn) bind(C)
       use ISO_C_BINDING
@@ -38,11 +36,16 @@ module random_lcg
       integer(C_INT), value :: n
     end subroutine prn_set_stream
 
-    function openmc_set_seed(new_seed) result(err) bind(C)
+    function openmc_get_seed() result(seed) bind(C)
+      use ISO_C_BINDING
+      implicit none
+      integer(C_INT64_T) :: seed
+    end function openmc_get_seed
+
+    subroutine openmc_set_seed(new_seed) bind(C)
       use ISO_C_BINDING
       implicit none
       integer(C_INT64_T), value :: new_seed
-      integer(C_INT)            :: err
-    end function openmc_set_seed
+    end subroutine openmc_set_seed
   end interface
 end module random_lcg

--- a/src/random_lcg.cpp
+++ b/src/random_lcg.cpp
@@ -133,7 +133,9 @@ prn_set_stream(int i)
 //                               API FUNCTIONS
 //==============================================================================
 
-extern "C" int
+extern "C" int64_t openmc_get_seed() {return seed;}
+
+extern "C" void
 openmc_set_seed(int64_t new_seed)
 {
   seed = new_seed;
@@ -144,7 +146,6 @@ openmc_set_seed(int64_t new_seed)
     }
     prn_set_stream(STREAM_TRACKING);
   }
-  return 0;
 }
 
 } // namespace openmc

--- a/src/random_lcg.cpp
+++ b/src/random_lcg.cpp
@@ -2,6 +2,9 @@
 #include <cmath>
 
 
+namespace openmc {
+
+
 // Constants
 extern "C" const int N_STREAMS         {5};
 extern "C" const int STREAM_TRACKING   {0};
@@ -143,3 +146,5 @@ openmc_set_seed(int64_t new_seed)
   }
   return 0;
 }
+
+} // namespace openmc

--- a/src/random_lcg.h
+++ b/src/random_lcg.h
@@ -78,12 +78,18 @@ extern "C" void prn_set_stream(int n);
 //==============================================================================
 
 //==============================================================================
+//! Get OpenMC's master seed.
+//==============================================================================
+
+extern "C" int64_t openmc_get_seed();
+
+//==============================================================================
 //! Set OpenMC's master seed.
 //! @param new_seed The master seed. All other seeds will be derived from this
 //! one.
 //==============================================================================
 
-extern "C" int openmc_set_seed(int64_t new_seed);
+extern "C" void openmc_set_seed(int64_t new_seed);
 
 } // namespace openmc
 #endif // RANDOM_LCG_H

--- a/src/random_lcg.h
+++ b/src/random_lcg.h
@@ -3,6 +3,9 @@
 
 #include <cstdint>
 
+
+namespace openmc {
+
 //==============================================================================
 // Module constants.
 //==============================================================================
@@ -82,4 +85,5 @@ extern "C" void prn_set_stream(int n);
 
 extern "C" int openmc_set_seed(int64_t new_seed);
 
+} // namespace openmc
 #endif // RANDOM_LCG_H

--- a/src/simulation.F90
+++ b/src/simulation.F90
@@ -320,7 +320,7 @@ contains
 
   subroutine finalize_batch()
 
-#ifdef MPI
+#ifdef OPENMC_MPI
     integer :: mpi_err ! MPI error code
 #endif
 
@@ -342,7 +342,7 @@ contains
 
     ! Check_triggers
     if (master) call check_triggers()
-#ifdef MPI
+#ifdef OPENMC_MPI
     call MPI_BCAST(satisfy_triggers, 1, MPI_LOGICAL, 0, &
          mpi_intracomm, mpi_err)
 #endif
@@ -469,7 +469,7 @@ contains
   subroutine openmc_simulation_finalize() bind(C)
 
     integer    :: i       ! loop index
-#ifdef MPI
+#ifdef OPENMC_MPI
     integer    :: n       ! size of arrays
     integer    :: mpi_err  ! MPI error code
     integer(8) :: temp
@@ -494,7 +494,7 @@ contains
     ! Increment total number of generations
     total_gen = total_gen + current_batch*gen_per_batch
 
-#ifdef MPI
+#ifdef OPENMC_MPI
     ! Broadcast tally results so that each process has access to results
     if (allocated(tallies)) then
       do i = 1, size(tallies)

--- a/src/source.F90
+++ b/src/source.F90
@@ -1,7 +1,7 @@
 module source
 
   use hdf5, only: HID_T
-#ifdef MPI
+#ifdef OPENMC_MPI
   use message_passing
 #endif
 

--- a/src/state_point.F90
+++ b/src/state_point.F90
@@ -26,7 +26,7 @@ module state_point
   use mgxs_header,        only: nuclides_MG
   use nuclide_header,     only: nuclides
   use output,             only: time_stamp
-  use random_lcg,         only: seed
+  use random_lcg,         only: openmc_get_seed, openmc_set_seed
   use settings
   use simulation_header
   use string,             only: to_str, count_digits, zero_padded, to_f_string
@@ -97,7 +97,7 @@ contains
       call write_attribute(file_id, "path", path_input)
 
       ! Write out random number seed
-      call write_dataset(file_id, "seed", seed)
+      call write_dataset(file_id, "seed", openmc_get_seed())
 
       ! Write run information
       if (run_CE) then
@@ -642,6 +642,7 @@ contains
     integer :: n
     integer :: int_array(3)
     integer, allocatable :: array(:)
+    integer(C_INT64_T) :: seed
     integer(HID_T) :: file_id
     integer(HID_T) :: cmfd_group
     integer(HID_T) :: tallies_group
@@ -672,6 +673,7 @@ contains
 
     ! Read and overwrite random number seed
     call read_dataset(seed, file_id, "seed")
+    call openmc_set_seed(seed)
 
     ! It is not impossible for a state point to be generated from a CE run but
     ! to be loaded in to an MG run (or vice versa), check to prevent that.

--- a/src/state_point.F90
+++ b/src/state_point.F90
@@ -523,7 +523,7 @@ contains
     integer(HID_T) :: tallies_group, tally_group
     real(8), allocatable :: tally_temp(:,:,:) ! contiguous array of results
     real(8), target :: global_temp(3,N_GLOBAL_TALLIES)
-#ifdef MPI
+#ifdef OPENMC_MPI
     integer :: mpi_err ! MPI error code
     real(8) :: dummy   ! temporary receive buffer for non-root reduces
 #endif
@@ -543,7 +543,7 @@ contains
     end if
 
 
-#ifdef MPI
+#ifdef OPENMC_MPI
     ! Reduce global tallies
     n_bins = size(global_tallies)
     call MPI_REDUCE(global_tallies, global_temp, n_bins, MPI_REAL8, MPI_SUM, &
@@ -586,7 +586,7 @@ contains
 
             ! The MPI_IN_PLACE specifier allows the master to copy values into
             ! a receive buffer without having a temporary variable
-#ifdef MPI
+#ifdef OPENMC_MPI
             call MPI_REDUCE(MPI_IN_PLACE, tally_temp, n_bins, MPI_REAL8, &
                  MPI_SUM, 0, mpi_intracomm, mpi_err)
 #endif
@@ -610,7 +610,7 @@ contains
             deallocate(dummy_tally % results)
           else
             ! Receive buffer not significant at other processors
-#ifdef MPI
+#ifdef OPENMC_MPI
             call MPI_REDUCE(tally_temp, dummy, n_bins, MPI_REAL8, MPI_SUM, &
                  0, mpi_intracomm, mpi_err)
 #endif
@@ -849,7 +849,7 @@ contains
     integer(HID_T) :: plist    ! property list
 #else
     integer :: i
-#ifdef MPI
+#ifdef OPENMC_MPI
     integer :: mpi_err ! MPI error code
     type(Bank), allocatable, target :: temp_source(:)
 #endif
@@ -897,7 +897,7 @@ contains
            dspace, dset, hdf5_err)
 
       ! Save source bank sites since the souce_bank array is overwritten below
-#ifdef MPI
+#ifdef OPENMC_MPI
       allocate(temp_source(work))
       temp_source(:) = source_bank(:)
 #endif
@@ -907,7 +907,7 @@ contains
         dims(1) = work_index(i+1) - work_index(i)
         call h5screate_simple_f(1, dims, memspace, hdf5_err)
 
-#ifdef MPI
+#ifdef OPENMC_MPI
         ! Receive source sites from other processes
         if (i > 0) then
           call MPI_RECV(source_bank, int(dims(1)), MPI_BANK, i, i, &
@@ -933,12 +933,12 @@ contains
       call h5dclose_f(dset, hdf5_err)
 
       ! Restore state of source bank
-#ifdef MPI
+#ifdef OPENMC_MPI
       source_bank(:) = temp_source(:)
       deallocate(temp_source)
 #endif
     else
-#ifdef MPI
+#ifdef OPENMC_MPI
       call MPI_SEND(source_bank, int(work), MPI_BANK, 0, rank, &
            mpi_intracomm, mpi_err)
 #endif

--- a/src/summary.F90
+++ b/src/summary.F90
@@ -251,16 +251,7 @@ contains
 
     ! Write information on each surface
     SURFACE_LOOP: do i = 1, n_surfaces
-      s => surfaces(i)%obj
-      surface_group = create_group(surfaces_group, "surface " // &
-           trim(to_str(s%id)))
-
-      call surface_to_hdf5_c(i-1, surface_group)
-
-      ! Write name for this surface
-      call write_dataset(surface_group, "name", s%name)
-
-      call close_group(surface_group)
+      call surface_to_hdf5_c(i-1, surfaces_group)
     end do SURFACE_LOOP
 
     call close_group(surfaces_group)

--- a/src/summary.F90
+++ b/src/summary.F90
@@ -133,12 +133,11 @@ contains
     real(8), allocatable :: cell_temperatures(:)
     integer(HID_T) :: geom_group
     integer(HID_T) :: cells_group, cell_group
-    integer(HID_T) :: surfaces_group, surface_group
+    integer(HID_T) :: surfaces_group
     integer(HID_T) :: universes_group, univ_group
     integer(HID_T) :: lattices_group, lattice_group
     character(:), allocatable :: region_spec
     type(Cell),     pointer :: c
-    class(Surface), pointer :: s
     class(Lattice), pointer :: lat
 
     ! Use H5LT interface to write number of geometry objects
@@ -233,7 +232,7 @@ contains
           region_spec = trim(region_spec) // " |"
         case default
           region_spec = trim(region_spec) // " " // to_str(&
-               sign(surfaces(abs(k))%obj%id, k))
+               sign(surfaces(abs(k))%id, k))
         end select
       end do
       call write_dataset(cell_group, "region", adjustl(region_spec))

--- a/src/summary.F90
+++ b/src/summary.F90
@@ -24,17 +24,6 @@ module summary
 
   public :: write_summary
 
-  interface
-    subroutine surface_to_hdf5_c(surf_ind, group) &
-         bind(C, name='surface_to_hdf5')
-      use ISO_C_BINDING
-      use hdf5
-      implicit none
-      integer(C_INT), intent(in), value :: surf_ind
-      integer(HID_T), intent(in), value :: group
-    end subroutine surface_to_hdf5_c
-  end interface
-
 contains
 
 !===============================================================================
@@ -232,7 +221,7 @@ contains
           region_spec = trim(region_spec) // " |"
         case default
           region_spec = trim(region_spec) // " " // to_str(&
-               sign(surfaces(abs(k))%id, k))
+               sign(surfaces(abs(k))%id(), k))
         end select
       end do
       call write_dataset(cell_group, "region", adjustl(region_spec))
@@ -250,7 +239,7 @@ contains
 
     ! Write information on each surface
     SURFACE_LOOP: do i = 1, n_surfaces
-      call surface_to_hdf5_c(i-1, surfaces_group)
+      call surfaces(i) % to_hdf5(surfaces_group)
     end do SURFACE_LOOP
 
     call close_group(surfaces_group)

--- a/src/surface.cpp
+++ b/src/surface.cpp
@@ -1053,10 +1053,12 @@ extern "C" void
 read_surfaces(pugi::xml_node *node)
 {
   // Count the number of surfaces.
-  int n_surfaces{0};
   for (pugi::xml_node surf_node = node->child("surface"); surf_node;
        surf_node = surf_node.next_sibling("surface")) {
     n_surfaces++;
+  }
+  if (n_surfaces == 0) {
+    fatal_error("No surfaces found in geometry.xml!");
   }
 
   // Allocate the array of Surface pointers.
@@ -1137,7 +1139,14 @@ read_surfaces(pugi::xml_node *node)
       // Downcast to the PeriodicSurface type.
       Surface *surf_base = surfaces_c[i_surf];
       PeriodicSurface *surf = dynamic_cast<PeriodicSurface *>(surf_base);
-      //TODO: check for null pointer
+
+      // Make sure this surface inherits from PeriodicSurface.
+      if (surf == NULL) {
+        std::string err_msg{"Periodic boundary condition not supported for "
+                            "surface "};
+        err_msg += std::to_string(surf_base->id);
+        err_msg += ". Periodic BCs are only supported for planar surfaces.";
+      }
 
       // See if this surface makes part of the global bounding box.
       struct BoundingBox bb = surf->bounding_box();

--- a/src/surface.cpp
+++ b/src/surface.cpp
@@ -1,12 +1,12 @@
 #include "surface.h"
 
 #include <array>
+#include <cmath>
 #include <sstream>
 
 #include "error.h"
 #include "hdf5_interface.h"
 #include "xml_interface.h"
-#include <iostream>
 
 
 namespace openmc {

--- a/src/surface.cpp
+++ b/src/surface.cpp
@@ -1,79 +1,11 @@
-#include <algorithm>  // for std::transform
 #include <array>
-#include <cstring>  // For strcmp
-#include <limits>  // For numeric_limits
-#include <map>
 #include <math.h>  // For fabs
-
-#include "pugixml/pugixml.hpp"
-#include "hdf5.h"
 
 #include "error.h"
 #include "hdf5_interface.h"
+#include "xml_interface.h"
 
-// DEBUGGING
-#include <typeinfo>
-#include <iostream>
-
-bool
-check_for_node(const pugi::xml_node &node, const char *name)
-{
-  if (node.attribute(name)) {
-    return true;
-  } else if (node.child(name)) {
-    return true;
-  } else {
-    return false;
-  }
-}
-
-std::string
-get_node_value(const pugi::xml_node &node, const char *name)
-{
-  const pugi::char_t *value_char;
-  if (node.attribute(name)) {
-    value_char = node.attribute(name).value();
-  } else if (node.child(name)) {
-    value_char = node.child_value(name);
-  } else {
-    std::string err_msg("Node \"");
-    err_msg += name;
-    err_msg += "\" is not a memeber of the \"";
-    err_msg += node.name();
-    err_msg += "\" XML node";
-    fatal_error(err_msg);
-  }
-
-  std::string value(value_char);
-  std::transform(value.begin(), value.end(), value.begin(), ::tolower);
-  //TODO: trim whitespace
-  return value;
-}
-
-//==============================================================================
-// Constants
-//==============================================================================
-
-//extern "C" const double FP_COINCIDENT{1e-12};
-//extern "C" const double INFTY{std::numeric_limits<double>::max()};
-extern "C" double FP_COINCIDENT;
-//extern "C" double INFTY;
-const double INFTY{std::numeric_limits<double>::max()};
-const int C_NONE{-1};
-
-extern "C" const int BC_TRANSMIT{0};
-extern "C" const int BC_VACUUM{1};
-extern "C" const int BC_REFLECT{2};
-extern "C" const int BC_PERIODIC{3};
-
-//==============================================================================
-// Global array of surfaces
-//==============================================================================
-
-class Surface;
-Surface **surfaces_c;
-
-std::map<int, int> surface_dict;
+#include "surface.h"
 
 //==============================================================================
 // Helper functions for reading the "coeffs" node of an XML surface element
@@ -84,18 +16,13 @@ int word_count(const std::string &text)
   bool in_word = false;
   int count{0};
   for (auto c = text.begin(); c != text.end(); c++) {
-    switch(*c) {
-      case ' ' :
-      case '\t' :
-      case '\r' :
-      case '\n' :
-        if (in_word) {
-          in_word = false;
-          count++;
-        }
-        break;
-      default :
-        in_word = true;
+    if (std::isspace(*c)) {
+      if (in_word) {
+        in_word = false;
+        count++;
+      }
+    } else {
+      in_word = true;
     }
   }
   if (in_word) count++;
@@ -188,75 +115,8 @@ void read_coeffs(pugi::xml_node surf_node, int surf_id, double &c1, double &c2,
 }
 
 //==============================================================================
+// Surface implementation
 //==============================================================================
-
-struct BoundingBox
-{
-  double xmin;
-  double xmax;
-  double ymin;
-  double ymax;
-  double zmin;
-  double zmax;
-};
-
-//==============================================================================
-//! A geometry primitive used to define regions of 3D space.
-//==============================================================================
-
-class Surface
-{
-public:
-  int id;                    //!< Unique ID
-  //int neighbor_pos[],        //!< List of cells on positive side
-  //    neighbor_neg[];        //!< List of cells on negative side
-  int bc;                    //!< Boundary condition
-  std::string name{""};      //!< User-defined name
-
-  Surface(pugi::xml_node surf_node);
-
-  //! Determine which side of a surface a point lies on.
-  //! @param xyz[3] The 3D Cartesian coordinate of a point.
-  //! @param uvw[3] A direction used to "break ties" and pick a sense when the
-  //!   point is very close to the surface.
-  //! @return true if the point is on the "positive" side of the surface and
-  //!   false otherwise.
-  bool sense(const double xyz[3], const double uvw[3]) const;
-
-  //! Determine the direction of a ray reflected from the surface.
-  //! @param xyz[3] The point at which the ray is incident.
-  //! @param uvw[3] A direction.  This is both an input and an output parameter.
-  //!   It specifies the icident direction on input and the reflected direction
-  //!   on output.
-  void reflect(const double xyz[3], double uvw[3]) const;
-
-  //! Evaluate the equation describing the surface.
-  //!
-  //! Surfaces can be described by some function f(x, y, z) = 0.  This member
-  //! function evaluates that mathematical function.
-  //! @param xyz[3] A 3D Cartesian coordinate.
-  virtual double evaluate(const double xyz[3]) const = 0;
-
-  //! Compute the distance between a point and the surface along a ray.
-  //! @param xyz[3] A 3D Cartesian coordinate.
-  //! @param uvw[3] The direction of the ray.
-  //! @param coincident A hint to the code that the given point should lie
-  //!   exactly on the surface.
-  virtual double distance(const double xyz[3], const double uvw[3],
-                          bool coincident) const = 0;
-
-  //! Compute the local outward normal direction of the surface.
-  //! @param xyz[3] A 3D Cartesian coordinate.
-  //! @param uvw[3] This output argument provides the normal.
-  virtual void normal(const double xyz[3], double uvw[3]) const = 0;
-
-  //! Write all information needed to reconstruct the surface to an HDF5 group.
-  //! @param group_id An HDF5 group id.
-  void to_hdf5(hid_t group_id) const;
-
-protected:
-  virtual void to_hdf5_inner(hid_t group_id) const = 0;
-};
 
 Surface::Surface(pugi::xml_node surf_node)
 {
@@ -367,33 +227,8 @@ Surface::to_hdf5(hid_t group_id) const
 }
 
 //==============================================================================
-//! A `Surface` that supports periodic boundary conditions.
-//!
-//! Translational periodicity is supported for the `XPlane`, `YPlane`, `ZPlane`,
-//! and `Plane` types.  Rotational periodicity is supported for
-//! `XPlane`-`YPlane` pairs.
+// PeriodicSurface implementation
 //==============================================================================
-
-class PeriodicSurface : public Surface
-{
-public:
-  int i_periodic{C_NONE};    //!< Index of corresponding periodic surface
-
-  PeriodicSurface(pugi::xml_node surf_node);
-
-  //! Translate a particle onto this surface from a periodic partner surface.
-  //! @param other A pointer to the partner surface in this periodic BC.
-  //! @param xyz[3] A point on the partner surface that will be translated onto
-  //!   this surface.
-  //! @param uvw[3] A direction that will be rotated for systems with rotational
-  //!   periodicity.
-  //! @return true if this surface and its partner make a rotationally-periodic
-  //!   boundary condition.
-  virtual bool periodic_translate(PeriodicSurface *other, double xyz[3],
-                                  double uvw[3]) const = 0;
-
-  virtual struct BoundingBox bounding_box() const = 0;
-};
 
 PeriodicSurface::PeriodicSurface(pugi::xml_node surf_node)
   : Surface(surf_node)
@@ -437,26 +272,8 @@ axis_aligned_plane_normal(const double xyz[3], double uvw[3])
 }
 
 //==============================================================================
-// SurfaceXPlane
-//! A plane perpendicular to the x-axis.
-//
-//! The plane is described by the equation \f$x - x_0 = 0\f$
+// SurfaceXPlane implementation
 //==============================================================================
-
-class SurfaceXPlane : public PeriodicSurface
-{
-  double x0;
-public:
-  SurfaceXPlane(pugi::xml_node surf_node);
-  double evaluate(const double xyz[3]) const;
-  double distance(const double xyz[3], const double uvw[3], bool coincident)
-         const;
-  void normal(const double xyz[3], double uvw[3]) const;
-  void to_hdf5_inner(hid_t group_id) const;
-  bool periodic_translate(PeriodicSurface *other, double xyz[3], double uvw[3])
-       const;
-  struct BoundingBox bounding_box() const;
-};
 
 SurfaceXPlane::SurfaceXPlane(pugi::xml_node surf_node)
   : PeriodicSurface(surf_node)
@@ -521,26 +338,8 @@ SurfaceXPlane::bounding_box() const
 }
 
 //==============================================================================
-// SurfaceYPlane
-//! A plane perpendicular to the y-axis.
-//
-//! The plane is described by the equation \f$y - y_0 = 0\f$
+// SurfaceYPlane implementation
 //==============================================================================
-
-class SurfaceYPlane : public PeriodicSurface
-{
-  double y0;
-public:
-  SurfaceYPlane(pugi::xml_node surf_node);
-  double evaluate(const double xyz[3]) const;
-  double distance(const double xyz[3], const double uvw[3],
-                  bool coincident) const;
-  void normal(const double xyz[3], double uvw[3]) const;
-  void to_hdf5_inner(hid_t group_id) const;
-  bool periodic_translate(PeriodicSurface *other, double xyz[3], double uvw[3])
-       const;
-  struct BoundingBox bounding_box() const;
-};
 
 SurfaceYPlane::SurfaceYPlane(pugi::xml_node surf_node)
   : PeriodicSurface(surf_node)
@@ -605,26 +404,8 @@ SurfaceYPlane::bounding_box() const
 }
 
 //==============================================================================
-// SurfaceZPlane
-//! A plane perpendicular to the z-axis.
-//
-//! The plane is described by the equation \f$z - z_0 = 0\f$
+// SurfaceZPlane implementation
 //==============================================================================
-
-class SurfaceZPlane : public PeriodicSurface
-{
-  double z0;
-public:
-  SurfaceZPlane(pugi::xml_node surf_node);
-  double evaluate(const double xyz[3]) const;
-  double distance(const double xyz[3], const double uvw[3],
-                  bool coincident) const;
-  void normal(const double xyz[3], double uvw[3]) const;
-  void to_hdf5_inner(hid_t group_id) const;
-  bool periodic_translate(PeriodicSurface *other, double xyz[3], double uvw[3])
-       const;
-  struct BoundingBox bounding_box() const;
-};
 
 SurfaceZPlane::SurfaceZPlane(pugi::xml_node surf_node)
   : PeriodicSurface(surf_node)
@@ -671,26 +452,8 @@ SurfaceZPlane::bounding_box() const
 }
 
 //==============================================================================
-// SurfacePlane
-//! A general plane.
-//
-//! The plane is described by the equation \f$A x + B y + C z - D = 0\f$
+// SurfacePlane implementation
 //==============================================================================
-
-class SurfacePlane : public PeriodicSurface
-{
-  double A, B, C, D;
-public:
-  SurfacePlane(pugi::xml_node surf_node);
-  double evaluate(const double xyz[3]) const;
-  double distance(const double xyz[3], const double uvw[3], bool coincident)
-         const;
-  void normal(const double xyz[3], double uvw[3]) const;
-  void to_hdf5_inner(hid_t group_id) const;
-  bool periodic_translate(PeriodicSurface *other, double xyz[3], double uvw[3])
-       const;
-  struct BoundingBox bounding_box() const;
-};
 
 SurfacePlane::SurfacePlane(pugi::xml_node surf_node)
   : PeriodicSurface(surf_node)
@@ -832,24 +595,8 @@ axis_aligned_cylinder_normal(const double xyz[3], double uvw[3], double offset1,
 }
 
 //==============================================================================
-// SurfaceXCylinder
-//! A cylinder aligned along the x-axis.
-//
-//! The cylinder is described by the equation
-//! \f$(y - y_0)^2 + (z - z_0)^2 - R^2 = 0\f$
+// SurfaceXCylinder implementation
 //==============================================================================
-
-class SurfaceXCylinder : public Surface
-{
-  double y0, z0, r;
-public:
-  SurfaceXCylinder(pugi::xml_node surf_node);
-  double evaluate(const double xyz[3]) const;
-  double distance(const double xyz[3], const double uvw[3],
-                  bool coincident) const;
-  void normal(const double xyz[3], double uvw[3]) const;
-  void to_hdf5_inner(hid_t group_id) const;
-};
 
 SurfaceXCylinder::SurfaceXCylinder(pugi::xml_node surf_node)
   : Surface(surf_node)
@@ -883,24 +630,8 @@ void SurfaceXCylinder::to_hdf5_inner(hid_t group_id) const
 }
 
 //==============================================================================
-// SurfaceYCylinder
-//! A cylinder aligned along the y-axis.
-//
-//! The cylinder is described by the equation
-//! \f$(x - x_0)^2 + (z - z_0)^2 - R^2 = 0\f$
+// SurfaceYCylinder implementation
 //==============================================================================
-
-class SurfaceYCylinder : public Surface
-{
-  double x0, z0, r;
-public:
-  SurfaceYCylinder(pugi::xml_node surf_node);
-  double evaluate(const double xyz[3]) const;
-  double distance(const double xyz[3], const double uvw[3],
-                  bool coincident) const;
-  void normal(const double xyz[3], double uvw[3]) const;
-  void to_hdf5_inner(hid_t group_id) const;
-};
 
 SurfaceYCylinder::SurfaceYCylinder(pugi::xml_node surf_node)
   : Surface(surf_node)
@@ -933,24 +664,8 @@ void SurfaceYCylinder::to_hdf5_inner(hid_t group_id) const
 }
 
 //==============================================================================
-// SurfaceZCylinder
-//! A cylinder aligned along the z-axis.
-//
-//! The cylinder is described by the equation
-//! \f$(x - x_0)^2 + (y - y_0)^2 - R^2 = 0\f$
+// SurfaceZCylinder implementation
 //==============================================================================
-
-class SurfaceZCylinder : public Surface
-{
-  double x0, y0, r;
-public:
-  SurfaceZCylinder(pugi::xml_node surf_node);
-  double evaluate(const double xyz[3]) const;
-  double distance(const double xyz[3], const double uvw[3],
-                  bool coincident) const;
-  void normal(const double xyz[3], double uvw[3]) const;
-  void to_hdf5_inner(hid_t group_id) const;
-};
 
 SurfaceZCylinder::SurfaceZCylinder(pugi::xml_node surf_node)
   : Surface(surf_node)
@@ -983,24 +698,8 @@ void SurfaceZCylinder::to_hdf5_inner(hid_t group_id) const
 }
 
 //==============================================================================
-// SurfaceSphere
-//! A sphere.
-//
-//! The cylinder is described by the equation
-//! \f$(x - x_0)^2 + (y - y_0)^2 + (z - z_0)^2 - R^2 = 0\f$
+// SurfaceSphere implementation
 //==============================================================================
-
-class SurfaceSphere : public Surface
-{
-  double x0, y0, z0, r;
-public:
-  SurfaceSphere(pugi::xml_node surf_node);
-  double evaluate(const double xyz[3]) const;
-  double distance(const double xyz[3], const double uvw[3],
-                  bool coincident) const;
-  void normal(const double xyz[3], double uvw[3]) const;
-  void to_hdf5_inner(hid_t group_id) const;
-};
 
 SurfaceSphere::SurfaceSphere(pugi::xml_node surf_node)
   : Surface(surf_node)
@@ -1153,24 +852,8 @@ axis_aligned_cone_normal(const double xyz[3], double uvw[3], double offset1,
 }
 
 //==============================================================================
-// SurfaceXCone
-//! A cone aligned along the x-axis.
-//
-//! The cylinder is described by the equation
-//! \f$(y - y_0)^2 + (z - z_0)^2 - R^2 (x - x_0)^2 = 0\f$
+// SurfaceXCone implementation
 //==============================================================================
-
-class SurfaceXCone : public Surface
-{
-  double x0, y0, z0, r_sq;
-public:
-  SurfaceXCone(pugi::xml_node surf_node);
-  double evaluate(const double xyz[3]) const;
-  double distance(const double xyz[3], const double uvw[3],
-                  bool coincident) const;
-  void normal(const double xyz[3], double uvw[3]) const;
-  void to_hdf5_inner(hid_t group_id) const;
-};
 
 SurfaceXCone::SurfaceXCone(pugi::xml_node surf_node)
   : Surface(surf_node)
@@ -1203,24 +886,8 @@ void SurfaceXCone::to_hdf5_inner(hid_t group_id) const
 }
 
 //==============================================================================
-// SurfaceYCone
-//! A cone aligned along the y-axis.
-//
-//! The cylinder is described by the equation
-//! \f$(x - x_0)^2 + (z - z_0)^2 - R^2 (y - y_0)^2 = 0\f$
+// SurfaceYCone implementation
 //==============================================================================
-
-class SurfaceYCone : public Surface
-{
-  double x0, y0, z0, r_sq;
-public:
-  SurfaceYCone(pugi::xml_node surf_node);
-  double evaluate(const double xyz[3]) const;
-  double distance(const double xyz[3], const double uvw[3],
-                  bool coincident) const;
-  void normal(const double xyz[3], double uvw[3]) const;
-  void to_hdf5_inner(hid_t group_id) const;
-};
 
 SurfaceYCone::SurfaceYCone(pugi::xml_node surf_node)
   : Surface(surf_node)
@@ -1253,24 +920,8 @@ void SurfaceYCone::to_hdf5_inner(hid_t group_id) const
 }
 
 //==============================================================================
-// SurfaceZCone
-//! A cone aligned along the z-axis.
-//
-//! The cylinder is described by the equation
-//! \f$(x - x_0)^2 + (y - y_0)^2 - R^2 (z - z_0)^2 = 0\f$
+// SurfaceZCone implementation
 //==============================================================================
-
-class SurfaceZCone : public Surface
-{
-  double x0, y0, z0, r_sq;
-public:
-  SurfaceZCone(pugi::xml_node surf_node);
-  double evaluate(const double xyz[3]) const;
-  double distance(const double xyz[3], const double uvw[3],
-                  bool coincident) const;
-  void normal(const double xyz[3], double uvw[3]) const;
-  void to_hdf5_inner(hid_t group_id) const;
-};
 
 SurfaceZCone::SurfaceZCone(pugi::xml_node surf_node)
   : Surface(surf_node)
@@ -1303,24 +954,8 @@ void SurfaceZCone::to_hdf5_inner(hid_t group_id) const
 }
 
 //==============================================================================
-// SurfaceQuadric
-//! A general surface described by a quadratic equation.
-//
-//! \f$A x^2 + B y^2 + C z^2 + D x y + E y z + F x z + G x + H y + J z + K = 0\f$
+// SurfaceQuadric implementation
 //==============================================================================
-
-class SurfaceQuadric : public Surface
-{
-  // Ax^2 + By^2 + Cz^2 + Dxy + Eyz + Fxz + Gx + Hy + Jz + K = 0
-  double A, B, C, D, E, F, G, H, J, K;
-public:
-  SurfaceQuadric(pugi::xml_node surf_node);
-  double evaluate(const double xyz[3]) const;
-  double distance(const double xyz[3], const double uvw[3],
-                  bool coincident) const;
-  void normal(const double xyz[3], double uvw[3]) const;
-  void to_hdf5_inner(hid_t group_id) const;
-};
 
 SurfaceQuadric::SurfaceQuadric(pugi::xml_node surf_node)
   : Surface(surf_node)
@@ -1472,9 +1107,10 @@ read_surfaces(pugi::xml_node *node)
         surfaces_c[i_surf] = new SurfaceQuadric(surf_node);
 
       } else {
-        std::cout << "Call error here!" << std::endl;
-        std::cout << surf_type << std::endl;
-        //TODO: call fatal_error
+        std::string err_msg{"Invalid surface type, \""};
+        err_msg += surf_type;
+        err_msg += "\"";
+        fatal_error(err_msg);
       }
     }
   }
@@ -1591,59 +1227,4 @@ read_surfaces(pugi::xml_node *node)
       }
     }
   }
-}
-
-//==============================================================================
-
-extern "C" bool
-surface_sense(int surf_ind, double xyz[3], double uvw[3])
-{
-  return surfaces_c[surf_ind]->sense(xyz, uvw);
-}
-
-extern "C" void
-surface_reflect(int surf_ind, double xyz[3], double uvw[3])
-{
-  surfaces_c[surf_ind]->reflect(xyz, uvw);
-}
-
-extern "C" double
-surface_distance(int surf_ind, double xyz[3], double uvw[3], bool coincident)
-{
-  return surfaces_c[surf_ind]->distance(xyz, uvw, coincident);
-}
-
-extern "C" void
-surface_normal(int surf_ind, double xyz[3], double uvw[3])
-{
-  return surfaces_c[surf_ind]->normal(xyz, uvw);
-}
-
-extern "C" void
-surface_to_hdf5(int surf_ind, hid_t group)
-{
-  surfaces_c[surf_ind]->to_hdf5(group);
-}
-
-extern "C" bool
-surface_periodic(int surf_ind1, double xyz[3], double uvw[3])
-{
-  // Hopefully this function has only been called for a pair of surfaces that
-  // support periodic BCs (checking should have been done when reading the
-  // geometry XML).  Downcast the surfaces to the PeriodicSurface type so we
-  // can call the periodic_translate method.
-  Surface *surf1_gen = surfaces_c[surf_ind1];
-  PeriodicSurface *surf1 = dynamic_cast<PeriodicSurface *>(surf1_gen);
-  Surface *surf2_gen = surfaces_c[surf1->i_periodic];
-  PeriodicSurface *surf2 = dynamic_cast<PeriodicSurface *>(surf2_gen);
-
-  // Call the type-bound methods.
-  return surf2->periodic_translate(surf1, xyz, uvw);
-}
-
-extern "C" int
-surface_i_periodic(int surf_ind)
-{
-  PeriodicSurface *surf = dynamic_cast<PeriodicSurface *>(surfaces_c[surf_ind]);
-  return surf->i_periodic;
 }

--- a/src/surface.h
+++ b/src/surface.h
@@ -1,0 +1,431 @@
+#ifndef SURFACE_H
+#define SURFACE_H
+
+#include <map>
+#include <limits>  // For numeric_limits
+
+#include "hdf5.h"
+#include "pugixml/pugixml.hpp"
+
+//==============================================================================
+// Module constants
+//==============================================================================
+
+extern "C" const int BC_TRANSMIT{0};
+extern "C" const int BC_VACUUM{1};
+extern "C" const int BC_REFLECT{2};
+extern "C" const int BC_PERIODIC{3};
+
+//==============================================================================
+// Constants that should eventually be moved out of this file
+//==============================================================================
+
+extern "C" double FP_COINCIDENT;
+const double INFTY{std::numeric_limits<double>::max()};
+const int C_NONE{-1};
+
+//==============================================================================
+// Global variables
+//==============================================================================
+
+class Surface;
+Surface **surfaces_c;
+
+std::map<int, int> surface_dict;
+
+//==============================================================================
+//! Coordinates for an axis-aligned cube that bounds a geometric object.
+//==============================================================================
+
+struct BoundingBox
+{
+  double xmin;
+  double xmax;
+  double ymin;
+  double ymax;
+  double zmin;
+  double zmax;
+};
+
+//==============================================================================
+//! A geometry primitive used to define regions of 3D space.
+//==============================================================================
+
+class Surface
+{
+public:
+  int id;                    //!< Unique ID
+  //int neighbor_pos[],        //!< List of cells on positive side
+  //    neighbor_neg[];        //!< List of cells on negative side
+  int bc;                    //!< Boundary condition
+  std::string name{""};      //!< User-defined name
+
+  Surface(pugi::xml_node surf_node);
+
+  //! Determine which side of a surface a point lies on.
+  //! @param xyz[3] The 3D Cartesian coordinate of a point.
+  //! @param uvw[3] A direction used to "break ties" and pick a sense when the
+  //!   point is very close to the surface.
+  //! @return true if the point is on the "positive" side of the surface and
+  //!   false otherwise.
+  bool sense(const double xyz[3], const double uvw[3]) const;
+
+  //! Determine the direction of a ray reflected from the surface.
+  //! @param xyz[3] The point at which the ray is incident.
+  //! @param uvw[3] A direction.  This is both an input and an output parameter.
+  //!   It specifies the icident direction on input and the reflected direction
+  //!   on output.
+  void reflect(const double xyz[3], double uvw[3]) const;
+
+  //! Evaluate the equation describing the surface.
+  //!
+  //! Surfaces can be described by some function f(x, y, z) = 0.  This member
+  //! function evaluates that mathematical function.
+  //! @param xyz[3] A 3D Cartesian coordinate.
+  virtual double evaluate(const double xyz[3]) const = 0;
+
+  //! Compute the distance between a point and the surface along a ray.
+  //! @param xyz[3] A 3D Cartesian coordinate.
+  //! @param uvw[3] The direction of the ray.
+  //! @param coincident A hint to the code that the given point should lie
+  //!   exactly on the surface.
+  virtual double distance(const double xyz[3], const double uvw[3],
+                          bool coincident) const = 0;
+
+  //! Compute the local outward normal direction of the surface.
+  //! @param xyz[3] A 3D Cartesian coordinate.
+  //! @param uvw[3] This output argument provides the normal.
+  virtual void normal(const double xyz[3], double uvw[3]) const = 0;
+
+  //! Write all information needed to reconstruct the surface to an HDF5 group.
+  //! @param group_id An HDF5 group id.
+  void to_hdf5(hid_t group_id) const;
+
+protected:
+  virtual void to_hdf5_inner(hid_t group_id) const = 0;
+};
+
+//==============================================================================
+//! A `Surface` that supports periodic boundary conditions.
+//!
+//! Translational periodicity is supported for the `XPlane`, `YPlane`, `ZPlane`,
+//! and `Plane` types.  Rotational periodicity is supported for
+//! `XPlane`-`YPlane` pairs.
+//==============================================================================
+
+class PeriodicSurface : public Surface
+{
+public:
+  int i_periodic{C_NONE};    //!< Index of corresponding periodic surface
+
+  PeriodicSurface(pugi::xml_node surf_node);
+
+  //! Translate a particle onto this surface from a periodic partner surface.
+  //! @param other A pointer to the partner surface in this periodic BC.
+  //! @param xyz[3] A point on the partner surface that will be translated onto
+  //!   this surface.
+  //! @param uvw[3] A direction that will be rotated for systems with rotational
+  //!   periodicity.
+  //! @return true if this surface and its partner make a rotationally-periodic
+  //!   boundary condition.
+  virtual bool periodic_translate(PeriodicSurface *other, double xyz[3],
+                                  double uvw[3]) const = 0;
+
+  //! Get the bounding box for this surface.
+  virtual struct BoundingBox bounding_box() const = 0;
+};
+
+//==============================================================================
+//! A plane perpendicular to the x-axis.
+//
+//! The plane is described by the equation \f$x - x_0 = 0\f$
+//==============================================================================
+
+class SurfaceXPlane : public PeriodicSurface
+{
+  double x0;
+public:
+  SurfaceXPlane(pugi::xml_node surf_node);
+  double evaluate(const double xyz[3]) const;
+  double distance(const double xyz[3], const double uvw[3], bool coincident)
+         const;
+  void normal(const double xyz[3], double uvw[3]) const;
+  void to_hdf5_inner(hid_t group_id) const;
+  bool periodic_translate(PeriodicSurface *other, double xyz[3], double uvw[3])
+       const;
+  struct BoundingBox bounding_box() const;
+};
+
+//==============================================================================
+//! A plane perpendicular to the y-axis.
+//
+//! The plane is described by the equation \f$y - y_0 = 0\f$
+//==============================================================================
+
+class SurfaceYPlane : public PeriodicSurface
+{
+  double y0;
+public:
+  SurfaceYPlane(pugi::xml_node surf_node);
+  double evaluate(const double xyz[3]) const;
+  double distance(const double xyz[3], const double uvw[3],
+                  bool coincident) const;
+  void normal(const double xyz[3], double uvw[3]) const;
+  void to_hdf5_inner(hid_t group_id) const;
+  bool periodic_translate(PeriodicSurface *other, double xyz[3], double uvw[3])
+       const;
+  struct BoundingBox bounding_box() const;
+};
+
+//==============================================================================
+//! A plane perpendicular to the z-axis.
+//
+//! The plane is described by the equation \f$z - z_0 = 0\f$
+//==============================================================================
+
+class SurfaceZPlane : public PeriodicSurface
+{
+  double z0;
+public:
+  SurfaceZPlane(pugi::xml_node surf_node);
+  double evaluate(const double xyz[3]) const;
+  double distance(const double xyz[3], const double uvw[3],
+                  bool coincident) const;
+  void normal(const double xyz[3], double uvw[3]) const;
+  void to_hdf5_inner(hid_t group_id) const;
+  bool periodic_translate(PeriodicSurface *other, double xyz[3], double uvw[3])
+       const;
+  struct BoundingBox bounding_box() const;
+};
+
+//==============================================================================
+//! A general plane.
+//
+//! The plane is described by the equation \f$A x + B y + C z - D = 0\f$
+//==============================================================================
+
+class SurfacePlane : public PeriodicSurface
+{
+  double A, B, C, D;
+public:
+  SurfacePlane(pugi::xml_node surf_node);
+  double evaluate(const double xyz[3]) const;
+  double distance(const double xyz[3], const double uvw[3], bool coincident)
+         const;
+  void normal(const double xyz[3], double uvw[3]) const;
+  void to_hdf5_inner(hid_t group_id) const;
+  bool periodic_translate(PeriodicSurface *other, double xyz[3], double uvw[3])
+       const;
+  struct BoundingBox bounding_box() const;
+};
+
+//==============================================================================
+//! A cylinder aligned along the x-axis.
+//
+//! The cylinder is described by the equation
+//! \f$(y - y_0)^2 + (z - z_0)^2 - R^2 = 0\f$
+//==============================================================================
+
+class SurfaceXCylinder : public Surface
+{
+  double y0, z0, r;
+public:
+  SurfaceXCylinder(pugi::xml_node surf_node);
+  double evaluate(const double xyz[3]) const;
+  double distance(const double xyz[3], const double uvw[3],
+                  bool coincident) const;
+  void normal(const double xyz[3], double uvw[3]) const;
+  void to_hdf5_inner(hid_t group_id) const;
+};
+
+//==============================================================================
+//! A cylinder aligned along the y-axis.
+//
+//! The cylinder is described by the equation
+//! \f$(x - x_0)^2 + (z - z_0)^2 - R^2 = 0\f$
+//==============================================================================
+
+class SurfaceYCylinder : public Surface
+{
+  double x0, z0, r;
+public:
+  SurfaceYCylinder(pugi::xml_node surf_node);
+  double evaluate(const double xyz[3]) const;
+  double distance(const double xyz[3], const double uvw[3],
+                  bool coincident) const;
+  void normal(const double xyz[3], double uvw[3]) const;
+  void to_hdf5_inner(hid_t group_id) const;
+};
+
+//==============================================================================
+//! A cylinder aligned along the z-axis.
+//
+//! The cylinder is described by the equation
+//! \f$(x - x_0)^2 + (y - y_0)^2 - R^2 = 0\f$
+//==============================================================================
+
+class SurfaceZCylinder : public Surface
+{
+  double x0, y0, r;
+public:
+  SurfaceZCylinder(pugi::xml_node surf_node);
+  double evaluate(const double xyz[3]) const;
+  double distance(const double xyz[3], const double uvw[3],
+                  bool coincident) const;
+  void normal(const double xyz[3], double uvw[3]) const;
+  void to_hdf5_inner(hid_t group_id) const;
+};
+
+//==============================================================================
+//! A sphere.
+//
+//! The cylinder is described by the equation
+//! \f$(x - x_0)^2 + (y - y_0)^2 + (z - z_0)^2 - R^2 = 0\f$
+//==============================================================================
+
+class SurfaceSphere : public Surface
+{
+  double x0, y0, z0, r;
+public:
+  SurfaceSphere(pugi::xml_node surf_node);
+  double evaluate(const double xyz[3]) const;
+  double distance(const double xyz[3], const double uvw[3],
+                  bool coincident) const;
+  void normal(const double xyz[3], double uvw[3]) const;
+  void to_hdf5_inner(hid_t group_id) const;
+};
+
+//==============================================================================
+//! A cone aligned along the x-axis.
+//
+//! The cylinder is described by the equation
+//! \f$(y - y_0)^2 + (z - z_0)^2 - R^2 (x - x_0)^2 = 0\f$
+//==============================================================================
+
+class SurfaceXCone : public Surface
+{
+  double x0, y0, z0, r_sq;
+public:
+  SurfaceXCone(pugi::xml_node surf_node);
+  double evaluate(const double xyz[3]) const;
+  double distance(const double xyz[3], const double uvw[3],
+                  bool coincident) const;
+  void normal(const double xyz[3], double uvw[3]) const;
+  void to_hdf5_inner(hid_t group_id) const;
+};
+
+//==============================================================================
+//! A cone aligned along the y-axis.
+//
+//! The cylinder is described by the equation
+//! \f$(x - x_0)^2 + (z - z_0)^2 - R^2 (y - y_0)^2 = 0\f$
+//==============================================================================
+
+class SurfaceYCone : public Surface
+{
+  double x0, y0, z0, r_sq;
+public:
+  SurfaceYCone(pugi::xml_node surf_node);
+  double evaluate(const double xyz[3]) const;
+  double distance(const double xyz[3], const double uvw[3],
+                  bool coincident) const;
+  void normal(const double xyz[3], double uvw[3]) const;
+  void to_hdf5_inner(hid_t group_id) const;
+};
+
+//==============================================================================
+//! A cone aligned along the z-axis.
+//
+//! The cylinder is described by the equation
+//! \f$(x - x_0)^2 + (y - y_0)^2 - R^2 (z - z_0)^2 = 0\f$
+//==============================================================================
+
+class SurfaceZCone : public Surface
+{
+  double x0, y0, z0, r_sq;
+public:
+  SurfaceZCone(pugi::xml_node surf_node);
+  double evaluate(const double xyz[3]) const;
+  double distance(const double xyz[3], const double uvw[3],
+                  bool coincident) const;
+  void normal(const double xyz[3], double uvw[3]) const;
+  void to_hdf5_inner(hid_t group_id) const;
+};
+
+//==============================================================================
+//! A general surface described by a quadratic equation.
+//
+//! \f$A x^2 + B y^2 + C z^2 + D x y + E y z + F x z + G x + H y + J z + K = 0\f$
+//==============================================================================
+
+class SurfaceQuadric : public Surface
+{
+  // Ax^2 + By^2 + Cz^2 + Dxy + Eyz + Fxz + Gx + Hy + Jz + K = 0
+  double A, B, C, D, E, F, G, H, J, K;
+public:
+  SurfaceQuadric(pugi::xml_node surf_node);
+  double evaluate(const double xyz[3]) const;
+  double distance(const double xyz[3], const double uvw[3],
+                  bool coincident) const;
+  void normal(const double xyz[3], double uvw[3]) const;
+  void to_hdf5_inner(hid_t group_id) const;
+};
+
+//==============================================================================
+// Fortran compatibility functions
+//==============================================================================
+
+extern "C" bool
+surface_sense(int surf_ind, double xyz[3], double uvw[3])
+{
+  return surfaces_c[surf_ind]->sense(xyz, uvw);
+}
+
+extern "C" void
+surface_reflect(int surf_ind, double xyz[3], double uvw[3])
+{
+  surfaces_c[surf_ind]->reflect(xyz, uvw);
+}
+
+extern "C" double
+surface_distance(int surf_ind, double xyz[3], double uvw[3], bool coincident)
+{
+  return surfaces_c[surf_ind]->distance(xyz, uvw, coincident);
+}
+
+extern "C" void
+surface_normal(int surf_ind, double xyz[3], double uvw[3])
+{
+  return surfaces_c[surf_ind]->normal(xyz, uvw);
+}
+
+extern "C" void
+surface_to_hdf5(int surf_ind, hid_t group)
+{
+  surfaces_c[surf_ind]->to_hdf5(group);
+}
+
+extern "C" bool
+surface_periodic(int surf_ind1, double xyz[3], double uvw[3])
+{
+  // Hopefully this function has only been called for a pair of surfaces that
+  // support periodic BCs (checking should have been done when reading the
+  // geometry XML).  Downcast the surfaces to the PeriodicSurface type so we
+  // can call the periodic_translate method.
+  Surface *surf1_gen = surfaces_c[surf_ind1];
+  PeriodicSurface *surf1 = dynamic_cast<PeriodicSurface *>(surf1_gen);
+  Surface *surf2_gen = surfaces_c[surf1->i_periodic];
+  PeriodicSurface *surf2 = dynamic_cast<PeriodicSurface *>(surf2_gen);
+
+  // Call the type-bound methods.
+  return surf2->periodic_translate(surf1, xyz, uvw);
+}
+
+extern "C" int
+surface_i_periodic(int surf_ind)
+{
+  PeriodicSurface *surf = dynamic_cast<PeriodicSurface *>(surfaces_c[surf_ind]);
+  return surf->i_periodic;
+}
+
+#endif // SURFACE_H

--- a/src/surface.h
+++ b/src/surface.h
@@ -67,7 +67,7 @@ public:
   int bc;                    //!< Boundary condition
   std::string name{""};      //!< User-defined name
 
-  Surface(pugi::xml_node surf_node);
+  explicit Surface(pugi::xml_node surf_node);
 
   virtual ~Surface() {}
 
@@ -127,7 +127,7 @@ class PeriodicSurface : public Surface
 public:
   int i_periodic{C_NONE};    //!< Index of corresponding periodic surface
 
-  PeriodicSurface(pugi::xml_node surf_node);
+  explicit PeriodicSurface(pugi::xml_node surf_node);
 
   //! Translate a particle onto this surface from a periodic partner surface.
   //! @param other A pointer to the partner surface in this periodic BC.
@@ -141,7 +141,7 @@ public:
                                   double uvw[3]) const = 0;
 
   //! Get the bounding box for this surface.
-  virtual struct BoundingBox bounding_box() const = 0;
+  virtual BoundingBox bounding_box() const = 0;
 };
 
 //==============================================================================
@@ -154,7 +154,7 @@ class SurfaceXPlane : public PeriodicSurface
 {
   double x0;
 public:
-  SurfaceXPlane(pugi::xml_node surf_node);
+  explicit SurfaceXPlane(pugi::xml_node surf_node);
   double evaluate(const double xyz[3]) const;
   double distance(const double xyz[3], const double uvw[3], bool coincident)
          const;
@@ -162,7 +162,7 @@ public:
   void to_hdf5_inner(hid_t group_id) const;
   bool periodic_translate(PeriodicSurface *other, double xyz[3], double uvw[3])
        const;
-  struct BoundingBox bounding_box() const;
+  BoundingBox bounding_box() const;
 };
 
 //==============================================================================
@@ -175,7 +175,7 @@ class SurfaceYPlane : public PeriodicSurface
 {
   double y0;
 public:
-  SurfaceYPlane(pugi::xml_node surf_node);
+  explicit SurfaceYPlane(pugi::xml_node surf_node);
   double evaluate(const double xyz[3]) const;
   double distance(const double xyz[3], const double uvw[3],
                   bool coincident) const;
@@ -183,7 +183,7 @@ public:
   void to_hdf5_inner(hid_t group_id) const;
   bool periodic_translate(PeriodicSurface *other, double xyz[3], double uvw[3])
        const;
-  struct BoundingBox bounding_box() const;
+  BoundingBox bounding_box() const;
 };
 
 //==============================================================================
@@ -196,7 +196,7 @@ class SurfaceZPlane : public PeriodicSurface
 {
   double z0;
 public:
-  SurfaceZPlane(pugi::xml_node surf_node);
+  explicit SurfaceZPlane(pugi::xml_node surf_node);
   double evaluate(const double xyz[3]) const;
   double distance(const double xyz[3], const double uvw[3],
                   bool coincident) const;
@@ -204,7 +204,7 @@ public:
   void to_hdf5_inner(hid_t group_id) const;
   bool periodic_translate(PeriodicSurface *other, double xyz[3], double uvw[3])
        const;
-  struct BoundingBox bounding_box() const;
+  BoundingBox bounding_box() const;
 };
 
 //==============================================================================
@@ -217,7 +217,7 @@ class SurfacePlane : public PeriodicSurface
 {
   double A, B, C, D;
 public:
-  SurfacePlane(pugi::xml_node surf_node);
+  explicit SurfacePlane(pugi::xml_node surf_node);
   double evaluate(const double xyz[3]) const;
   double distance(const double xyz[3], const double uvw[3], bool coincident)
          const;
@@ -225,7 +225,7 @@ public:
   void to_hdf5_inner(hid_t group_id) const;
   bool periodic_translate(PeriodicSurface *other, double xyz[3], double uvw[3])
        const;
-  struct BoundingBox bounding_box() const;
+  BoundingBox bounding_box() const;
 };
 
 //==============================================================================
@@ -239,7 +239,7 @@ class SurfaceXCylinder : public Surface
 {
   double y0, z0, r;
 public:
-  SurfaceXCylinder(pugi::xml_node surf_node);
+  explicit SurfaceXCylinder(pugi::xml_node surf_node);
   double evaluate(const double xyz[3]) const;
   double distance(const double xyz[3], const double uvw[3],
                   bool coincident) const;
@@ -258,7 +258,7 @@ class SurfaceYCylinder : public Surface
 {
   double x0, z0, r;
 public:
-  SurfaceYCylinder(pugi::xml_node surf_node);
+  explicit SurfaceYCylinder(pugi::xml_node surf_node);
   double evaluate(const double xyz[3]) const;
   double distance(const double xyz[3], const double uvw[3],
                   bool coincident) const;
@@ -277,7 +277,7 @@ class SurfaceZCylinder : public Surface
 {
   double x0, y0, r;
 public:
-  SurfaceZCylinder(pugi::xml_node surf_node);
+  explicit SurfaceZCylinder(pugi::xml_node surf_node);
   double evaluate(const double xyz[3]) const;
   double distance(const double xyz[3], const double uvw[3],
                   bool coincident) const;
@@ -296,7 +296,7 @@ class SurfaceSphere : public Surface
 {
   double x0, y0, z0, r;
 public:
-  SurfaceSphere(pugi::xml_node surf_node);
+  explicit SurfaceSphere(pugi::xml_node surf_node);
   double evaluate(const double xyz[3]) const;
   double distance(const double xyz[3], const double uvw[3],
                   bool coincident) const;
@@ -315,7 +315,7 @@ class SurfaceXCone : public Surface
 {
   double x0, y0, z0, r_sq;
 public:
-  SurfaceXCone(pugi::xml_node surf_node);
+  explicit SurfaceXCone(pugi::xml_node surf_node);
   double evaluate(const double xyz[3]) const;
   double distance(const double xyz[3], const double uvw[3],
                   bool coincident) const;
@@ -334,7 +334,7 @@ class SurfaceYCone : public Surface
 {
   double x0, y0, z0, r_sq;
 public:
-  SurfaceYCone(pugi::xml_node surf_node);
+  explicit SurfaceYCone(pugi::xml_node surf_node);
   double evaluate(const double xyz[3]) const;
   double distance(const double xyz[3], const double uvw[3],
                   bool coincident) const;
@@ -353,7 +353,7 @@ class SurfaceZCone : public Surface
 {
   double x0, y0, z0, r_sq;
 public:
-  SurfaceZCone(pugi::xml_node surf_node);
+  explicit SurfaceZCone(pugi::xml_node surf_node);
   double evaluate(const double xyz[3]) const;
   double distance(const double xyz[3], const double uvw[3],
                   bool coincident) const;
@@ -372,7 +372,7 @@ class SurfaceQuadric : public Surface
   // Ax^2 + By^2 + Cz^2 + Dxy + Eyz + Fxz + Gx + Hy + Jz + K = 0
   double A, B, C, D, E, F, G, H, J, K;
 public:
-  SurfaceQuadric(pugi::xml_node surf_node);
+  explicit SurfaceQuadric(pugi::xml_node surf_node);
   double evaluate(const double xyz[3]) const;
   double distance(const double xyz[3], const double uvw[3],
                   bool coincident) const;

--- a/src/surface.h
+++ b/src/surface.h
@@ -3,32 +3,37 @@
 
 #include <map>
 #include <limits>  // For numeric_limits
+#include <string>
 
 #include "hdf5.h"
 #include "pugixml/pugixml.hpp"
+
+
+namespace openmc {
 
 //==============================================================================
 // Module constants
 //==============================================================================
 
-extern "C" const int BC_TRANSMIT{0};
-extern "C" const int BC_VACUUM{1};
-extern "C" const int BC_REFLECT{2};
-extern "C" const int BC_PERIODIC{3};
+extern "C" const int BC_TRANSMIT {0};
+extern "C" const int BC_VACUUM {1};
+extern "C" const int BC_REFLECT {2};
+extern "C" const int BC_PERIODIC {3};
 
 //==============================================================================
 // Constants that should eventually be moved out of this file
 //==============================================================================
 
 extern "C" double FP_COINCIDENT;
-const double INFTY{std::numeric_limits<double>::max()};
-const int C_NONE{-1};
+constexpr double INFTY{std::numeric_limits<double>::max()};
+constexpr int C_NONE {-1};
 
 //==============================================================================
 // Global variables
 //==============================================================================
 
-int n_surfaces{0};
+// Braces force n_surfaces to be defined here, not just declared.
+extern "C" {int32_t n_surfaces {0};}
 
 class Surface;
 Surface **surfaces_c;
@@ -63,6 +68,8 @@ public:
   std::string name{""};      //!< User-defined name
 
   Surface(pugi::xml_node surf_node);
+
+  virtual ~Surface() {}
 
   //! Determine which side of a surface a point lies on.
   //! @param xyz[3] The 3D Cartesian coordinate of a point.
@@ -411,9 +418,10 @@ extern "C" void free_memory_surfaces_c()
 {
   for (int i = 0; i < n_surfaces; i++) {delete surfaces_c[i];}
   delete surfaces_c;
-  surfaces_c = NULL;
+  surfaces_c = nullptr;
   n_surfaces = 0;
   surface_dict.clear();
 }
 
+} // namespace openmc
 #endif // SURFACE_H

--- a/src/surface_header.C
+++ b/src/surface_header.C
@@ -81,7 +81,8 @@ void read_coeffs(pugi::xml_node surf_node, double &c1, double &c2, double &c3,
 //! A geometry primitive used to define regions of 3D space.
 //==============================================================================
 
-class Surface {
+class Surface
+{
 public:
   int id;                    //!< Unique ID
   int neighbor_pos[],        //!< List of cells on positive side
@@ -128,7 +129,8 @@ public:
 };
 
 bool
-Surface::sense(const double xyz[3], const double uvw[3]) const {
+Surface::sense(const double xyz[3], const double uvw[3]) const
+{
   // Evaluate the surface equation at the particle's coordinates to determine
   // which side the particle is on.
   const double f = evaluate(xyz);
@@ -146,7 +148,8 @@ Surface::sense(const double xyz[3], const double uvw[3]) const {
 }
 
 void
-Surface::reflect(const double xyz[3], double uvw[3]) const {
+Surface::reflect(const double xyz[3], double uvw[3]) const
+{
   // Determine projection of direction onto normal and squared magnitude of
   // normal.
   double norm[3];
@@ -166,14 +169,16 @@ Surface::reflect(const double xyz[3], double uvw[3]) const {
 
 // The template parameter indicates the axis normal to the plane.
 template<int i> double
-axis_aligned_plane_evaluate(const double xyz[3], double offset) {
+axis_aligned_plane_evaluate(const double xyz[3], double offset)
+{
   return xyz[i] - offset;
 }
 
 // The template parameter indicates the axis normal to the plane.
 template<int i> double
 axis_aligned_plane_distance(const double xyz[3], const double uvw[3],
-                            bool coincident, double offset) {
+                            bool coincident, double offset)
+{
   const double f = offset - xyz[i];
   if (coincident or fabs(f) < FP_COINCIDENT or uvw[i] == 0.0) return INFTY;
   const double d = f / uvw[i];
@@ -184,7 +189,8 @@ axis_aligned_plane_distance(const double xyz[3], const double uvw[3],
 // The first template parameter indicates the axis normal to the plane.  The
 // other two parameters indicate the other two axes.
 template<int i1, int i2, int i3> void
-axis_aligned_plane_normal(const double xyz[3], double uvw[3]) {
+axis_aligned_plane_normal(const double xyz[3], double uvw[3])
+{
   uvw[i1] = 1.0;
   uvw[i2] = 0.0;
   uvw[i3] = 0.0;
@@ -197,7 +203,8 @@ axis_aligned_plane_normal(const double xyz[3], double uvw[3]) {
 //! The plane is described by the equation \f$x - x_0 = 0\f$
 //==============================================================================
 
-class SurfaceXPlane : public Surface {
+class SurfaceXPlane : public Surface
+{
   double x0;
 public:
   SurfaceXPlane(pugi::xml_node surf_node);
@@ -207,20 +214,24 @@ public:
   void normal(const double xyz[3], double uvw[3]) const;
 };
 
-SurfaceXPlane::SurfaceXPlane(pugi::xml_node surf_node) {
+SurfaceXPlane::SurfaceXPlane(pugi::xml_node surf_node)
+{
   read_coeffs(surf_node, x0);
 }
 
-inline double SurfaceXPlane::evaluate(const double xyz[3]) const {
+inline double SurfaceXPlane::evaluate(const double xyz[3]) const
+{
   return axis_aligned_plane_evaluate<0>(xyz, x0);
 }
 
 inline double SurfaceXPlane::distance(const double xyz[3], const double uvw[3],
-                                      bool coincident) const {
+                                      bool coincident) const
+{
   return axis_aligned_plane_distance<0>(xyz, uvw, coincident, x0);
 }
 
-inline void SurfaceXPlane::normal(const double xyz[3], double uvw[3]) const {
+inline void SurfaceXPlane::normal(const double xyz[3], double uvw[3]) const
+{
   axis_aligned_plane_normal<0, 1, 2>(xyz, uvw);
 }
 
@@ -231,7 +242,8 @@ inline void SurfaceXPlane::normal(const double xyz[3], double uvw[3]) const {
 //! The plane is described by the equation \f$y - y_0 = 0\f$
 //==============================================================================
 
-class SurfaceYPlane : public Surface {
+class SurfaceYPlane : public Surface
+{
   double y0;
 public:
   SurfaceYPlane(pugi::xml_node surf_node);
@@ -241,20 +253,24 @@ public:
   void normal(const double xyz[3], double uvw[3]) const;
 };
 
-SurfaceYPlane::SurfaceYPlane(pugi::xml_node surf_node) {
+SurfaceYPlane::SurfaceYPlane(pugi::xml_node surf_node)
+{
   read_coeffs(surf_node, y0);
 }
 
-inline double SurfaceYPlane::evaluate(const double xyz[3]) const {
+inline double SurfaceYPlane::evaluate(const double xyz[3]) const
+{
   return axis_aligned_plane_evaluate<1>(xyz, y0);
 }
 
 inline double SurfaceYPlane::distance(const double xyz[3], const double uvw[3],
-                                      bool coincident) const {
+                                      bool coincident) const
+{
   return axis_aligned_plane_distance<1>(xyz, uvw, coincident, y0);
 }
 
-inline void SurfaceYPlane::normal(const double xyz[3], double uvw[3]) const {
+inline void SurfaceYPlane::normal(const double xyz[3], double uvw[3]) const
+{
   axis_aligned_plane_normal<1, 0, 2>(xyz, uvw);
 }
 
@@ -265,7 +281,8 @@ inline void SurfaceYPlane::normal(const double xyz[3], double uvw[3]) const {
 //! The plane is described by the equation \f$z - z_0 = 0\f$
 //==============================================================================
 
-class SurfaceZPlane : public Surface {
+class SurfaceZPlane : public Surface
+{
   double z0;
 public:
   SurfaceZPlane(pugi::xml_node surf_node);
@@ -275,20 +292,24 @@ public:
   void normal(const double xyz[3], double uvw[3]) const;
 };
 
-SurfaceZPlane::SurfaceZPlane(pugi::xml_node surf_node) {
+SurfaceZPlane::SurfaceZPlane(pugi::xml_node surf_node)
+{
   read_coeffs(surf_node, z0);
 }
 
-inline double SurfaceZPlane::evaluate(const double xyz[3]) const {
+inline double SurfaceZPlane::evaluate(const double xyz[3]) const
+{
   return axis_aligned_plane_evaluate<2>(xyz, z0);
 }
 
 inline double SurfaceZPlane::distance(const double xyz[3], const double uvw[3],
-                                      bool coincident) const {
+                                      bool coincident) const
+{
   return axis_aligned_plane_distance<2>(xyz, uvw, coincident, z0);
 }
 
-inline void SurfaceZPlane::normal(const double xyz[3], double uvw[3]) const {
+inline void SurfaceZPlane::normal(const double xyz[3], double uvw[3]) const
+{
   axis_aligned_plane_normal<2, 0, 1>(xyz, uvw);
 }
 
@@ -299,7 +320,8 @@ inline void SurfaceZPlane::normal(const double xyz[3], double uvw[3]) const {
 //! The plane is described by the equation \f$A x + B y + C z - D = 0\f$
 //==============================================================================
 
-class SurfacePlane : public Surface {
+class SurfacePlane : public Surface
+{
   double A, B, C, D;
 public:
   SurfacePlane(pugi::xml_node surf_node);
@@ -309,18 +331,21 @@ public:
   void normal(const double xyz[3], double uvw[3]) const;
 };
 
-SurfacePlane::SurfacePlane(pugi::xml_node surf_node) {
+SurfacePlane::SurfacePlane(pugi::xml_node surf_node)
+{
   read_coeffs(surf_node, A, B, C, D);
 }
 
 double
-SurfacePlane::evaluate(const double xyz[3]) const {
+SurfacePlane::evaluate(const double xyz[3]) const
+{
   return A*xyz[0] + B*xyz[1] + C*xyz[2] - D;
 }
 
 double
 SurfacePlane::distance(const double xyz[3], const double uvw[3],
-                       bool coincident) const {
+                       bool coincident) const
+{
   const double f = A*xyz[0] + B*xyz[1] + C*xyz[2] - D;
   const double projection = A*uvw[0] + B*uvw[1] + C*uvw[2];
   if (coincident or fabs(f) < FP_COINCIDENT or projection == 0.0) {
@@ -333,7 +358,8 @@ SurfacePlane::distance(const double xyz[3], const double uvw[3],
 }
 
 void
-SurfacePlane::normal(const double xyz[3], double uvw[3]) const {
+SurfacePlane::normal(const double xyz[3], double uvw[3]) const
+{
   uvw[0] = A;
   uvw[1] = B;
   uvw[2] = C;
@@ -348,7 +374,8 @@ SurfacePlane::normal(const double xyz[3], double uvw[3]) const {
 // respectively.
 template<int i1, int i2> double
 axis_aligned_cylinder_evaluate(const double xyz[3], double offset1,
-                               double offset2, double radius) {
+                               double offset2, double radius)
+{
   const double xyz1 = xyz[i1] - offset1;
   const double xyz2 = xyz[i2] - offset2;
   return xyz1*xyz1 + xyz2*xyz2 - radius*radius;
@@ -359,7 +386,8 @@ axis_aligned_cylinder_evaluate(const double xyz[3], double offset1,
 // should correspond with i2 and i3, respectively.
 template<int i1, int i2, int i3> double
 axis_aligned_cylinder_distance(const double xyz[3], const double uvw[3],
-     bool coincident, double offset1, double offset2, double radius) {
+     bool coincident, double offset1, double offset2, double radius)
+{
   const double a = 1.0 - uvw[i1]*uvw[i1];  // u^2 + v^2
   if (a == 0.0) return INFTY;
 
@@ -404,7 +432,8 @@ axis_aligned_cylinder_distance(const double xyz[3], const double uvw[3],
 // should correspond with i2 and i3, respectively.
 template<int i1, int i2, int i3> void
 axis_aligned_cylinder_normal(const double xyz[3], double uvw[3], double offset1,
-                             double offset2) {
+                             double offset2)
+{
   uvw[i2] = 2.0 * (xyz[i2] - offset1);
   uvw[i3] = 2.0 * (xyz[i3] - offset2);
   uvw[i1] = 0.0;
@@ -418,7 +447,8 @@ axis_aligned_cylinder_normal(const double xyz[3], double uvw[3], double offset1,
 //! \f$(y - y_0)^2 + (z - z_0)^2 - R^2 = 0\f$
 //==============================================================================
 
-class SurfaceXCylinder : public Surface {
+class SurfaceXCylinder : public Surface
+{
   double y0, z0, r;
 public:
   SurfaceXCylinder(pugi::xml_node surf_node);
@@ -428,21 +458,25 @@ public:
   void normal(const double xyz[3], double uvw[3]) const;
 };
 
-SurfaceXCylinder::SurfaceXCylinder(pugi::xml_node surf_node) {
+SurfaceXCylinder::SurfaceXCylinder(pugi::xml_node surf_node)
+{
   read_coeffs(surf_node, y0, z0, r);
 }
 
-inline double SurfaceXCylinder::evaluate(const double xyz[3]) const {
+inline double SurfaceXCylinder::evaluate(const double xyz[3]) const
+{
   return axis_aligned_cylinder_evaluate<1, 2>(xyz, y0, z0, r);
 }
 
 inline double SurfaceXCylinder::distance(const double xyz[3],
-     const double uvw[3], bool coincident) const {
+     const double uvw[3], bool coincident) const
+{
   return axis_aligned_cylinder_distance<0, 1, 2>(xyz, uvw, coincident, y0, z0,
                                                  r);
 }
 
-inline void SurfaceXCylinder::normal(const double xyz[3], double uvw[3]) const {
+inline void SurfaceXCylinder::normal(const double xyz[3], double uvw[3]) const
+{
   axis_aligned_cylinder_normal<0, 1, 2>(xyz, uvw, y0, z0);
 }
 
@@ -454,7 +488,8 @@ inline void SurfaceXCylinder::normal(const double xyz[3], double uvw[3]) const {
 //! \f$(x - x_0)^2 + (z - z_0)^2 - R^2 = 0\f$
 //==============================================================================
 
-class SurfaceYCylinder : public Surface {
+class SurfaceYCylinder : public Surface
+{
   double x0, z0, r;
 public:
   SurfaceYCylinder(pugi::xml_node surf_node);
@@ -464,21 +499,25 @@ public:
   void normal(const double xyz[3], double uvw[3]) const;
 };
 
-SurfaceYCylinder::SurfaceYCylinder(pugi::xml_node surf_node) {
+SurfaceYCylinder::SurfaceYCylinder(pugi::xml_node surf_node)
+{
   read_coeffs(surf_node, x0, z0, r);
 }
 
-inline double SurfaceYCylinder::evaluate(const double xyz[3]) const {
+inline double SurfaceYCylinder::evaluate(const double xyz[3]) const
+{
   return axis_aligned_cylinder_evaluate<0, 2>(xyz, x0, z0, r);
 }
 
 inline double SurfaceYCylinder::distance(const double xyz[3],
-     const double uvw[3], bool coincident) const {
+     const double uvw[3], bool coincident) const
+{
   return axis_aligned_cylinder_distance<1, 0, 2>(xyz, uvw, coincident, x0, z0,
                                                  r);
 }
 
-inline void SurfaceYCylinder::normal(const double xyz[3], double uvw[3]) const {
+inline void SurfaceYCylinder::normal(const double xyz[3], double uvw[3]) const
+{
   axis_aligned_cylinder_normal<1, 0, 2>(xyz, uvw, x0, z0);
 }
 
@@ -490,7 +529,8 @@ inline void SurfaceYCylinder::normal(const double xyz[3], double uvw[3]) const {
 //! \f$(x - x_0)^2 + (y - y_0)^2 - R^2 = 0\f$
 //==============================================================================
 
-class SurfaceZCylinder : public Surface {
+class SurfaceZCylinder : public Surface
+{
   double x0, y0, r;
 public:
   SurfaceZCylinder(pugi::xml_node surf_node);
@@ -500,21 +540,25 @@ public:
   void normal(const double xyz[3], double uvw[3]) const;
 };
 
-SurfaceZCylinder::SurfaceZCylinder(pugi::xml_node surf_node) {
+SurfaceZCylinder::SurfaceZCylinder(pugi::xml_node surf_node)
+{
   read_coeffs(surf_node, x0, y0, r);
 }
 
-inline double SurfaceZCylinder::evaluate(const double xyz[3]) const {
+inline double SurfaceZCylinder::evaluate(const double xyz[3]) const
+{
   return axis_aligned_cylinder_evaluate<0, 1>(xyz, x0, y0, r);
 }
 
 inline double SurfaceZCylinder::distance(const double xyz[3],
-     const double uvw[3], bool coincident) const {
+     const double uvw[3], bool coincident) const
+{
   return axis_aligned_cylinder_distance<2, 0, 1>(xyz, uvw, coincident, x0, y0,
                                                  r);
 }
 
-inline void SurfaceZCylinder::normal(const double xyz[3], double uvw[3]) const {
+inline void SurfaceZCylinder::normal(const double xyz[3], double uvw[3]) const
+{
   axis_aligned_cylinder_normal<2, 0, 1>(xyz, uvw, x0, y0);
 }
 
@@ -526,7 +570,8 @@ inline void SurfaceZCylinder::normal(const double xyz[3], double uvw[3]) const {
 //! \f$(x - x_0)^2 + (y - y_0)^2 + (z - z_0)^2 - R^2 = 0\f$
 //==============================================================================
 
-class SurfaceSphere : public Surface {
+class SurfaceSphere : public Surface
+{
   double x0, y0, z0, r;
 public:
   SurfaceSphere(pugi::xml_node surf_node);
@@ -536,11 +581,13 @@ public:
   void normal(const double xyz[3], double uvw[3]) const;
 };
 
-SurfaceSphere::SurfaceSphere(pugi::xml_node surf_node) {
+SurfaceSphere::SurfaceSphere(pugi::xml_node surf_node)
+{
   read_coeffs(surf_node, x0, y0, z0, r);
 }
 
-double SurfaceSphere::evaluate(const double xyz[3]) const {
+double SurfaceSphere::evaluate(const double xyz[3]) const
+{
   const double x = xyz[0] - x0;
   const double y = xyz[1] - y0;
   const double z = xyz[2] - z0;
@@ -548,7 +595,8 @@ double SurfaceSphere::evaluate(const double xyz[3]) const {
 }
 
 double SurfaceSphere::distance(const double xyz[3], const double uvw[3],
-                               bool coincident) const {
+                               bool coincident) const
+{
   const double x = xyz[0] - x0;
   const double y = xyz[1] - y0;
   const double z = xyz[2] - z0;
@@ -585,7 +633,8 @@ double SurfaceSphere::distance(const double xyz[3], const double uvw[3],
   }
 }
 
-inline void SurfaceSphere::normal(const double xyz[3], double uvw[3]) const {
+inline void SurfaceSphere::normal(const double xyz[3], double uvw[3]) const
+{
   uvw[0] = 2.0 * (xyz[0] - x0);
   uvw[1] = 2.0 * (xyz[1] - y0);
   uvw[2] = 2.0 * (xyz[2] - z0);
@@ -600,7 +649,8 @@ inline void SurfaceSphere::normal(const double xyz[3], double uvw[3]) const {
 // and offset3 should correspond with i1, i2, and i3, respectively.
 template<int i1, int i2, int i3> double
 axis_aligned_cone_evaluate(const double xyz[3], double offset1,
-                           double offset2, double offset3, double radius_sq) {
+                           double offset2, double offset3, double radius_sq)
+{
   const double xyz1 = xyz[i1] - offset1;
   const double xyz2 = xyz[i2] - offset2;
   const double xyz3 = xyz[i3] - offset3;
@@ -613,7 +663,8 @@ axis_aligned_cone_evaluate(const double xyz[3], double offset1,
 template<int i1, int i2, int i3> double
 axis_aligned_cone_distance(const double xyz[3], const double uvw[3],
      bool coincident, double offset1, double offset2, double offset3,
-     double radius_sq) {
+     double radius_sq)
+{
   const double xyz1 = xyz[i1] - offset1;
   const double xyz2 = xyz[i2] - offset2;
   const double xyz3 = xyz[i3] - offset3;
@@ -665,7 +716,8 @@ axis_aligned_cone_distance(const double xyz[3], const double uvw[3],
 // and offset3 should correspond with i1, i2, and i3, respectively.
 template<int i1, int i2, int i3> void
 axis_aligned_cone_normal(const double xyz[3], double uvw[3], double offset1,
-                         double offset2, double offset3, double radius_sq) {
+                         double offset2, double offset3, double radius_sq)
+{
   uvw[i1] = -2.0 * radius_sq * (xyz[i1] - offset1);
   uvw[i2] = 2.0 * (xyz[i2] - offset2);
   uvw[i3] = 2.0 * (xyz[i3] - offset3);
@@ -679,7 +731,8 @@ axis_aligned_cone_normal(const double xyz[3], double uvw[3], double offset1,
 //! \f$(y - y_0)^2 + (z - z_0)^2 - R^2 (x - x_0)^2 = 0\f$
 //==============================================================================
 
-class SurfaceXCone : public Surface {
+class SurfaceXCone : public Surface
+{
   double x0, y0, z0, r_sq;
 public:
   SurfaceXCone(pugi::xml_node surf_node);
@@ -689,21 +742,25 @@ public:
   void normal(const double xyz[3], double uvw[3]) const;
 };
 
-SurfaceXCone::SurfaceXCone(pugi::xml_node surf_node) {
+SurfaceXCone::SurfaceXCone(pugi::xml_node surf_node)
+{
   read_coeffs(surf_node, x0, y0, z0, r_sq);
 }
 
-inline double SurfaceXCone::evaluate(const double xyz[3]) const {
+inline double SurfaceXCone::evaluate(const double xyz[3]) const
+{
   return axis_aligned_cone_evaluate<0, 1, 2>(xyz, x0, y0, z0, r_sq);
 }
 
 inline double SurfaceXCone::distance(const double xyz[3],
-     const double uvw[3], bool coincident) const {
+     const double uvw[3], bool coincident) const
+{
   return axis_aligned_cone_distance<0, 1, 2>(xyz, uvw, coincident, x0, y0, z0,
                                              r_sq);
 }
 
-inline void SurfaceXCone::normal(const double xyz[3], double uvw[3]) const {
+inline void SurfaceXCone::normal(const double xyz[3], double uvw[3]) const
+{
   axis_aligned_cone_normal<0, 1, 2>(xyz, uvw, x0, y0, z0, r_sq);
 }
 
@@ -715,7 +772,8 @@ inline void SurfaceXCone::normal(const double xyz[3], double uvw[3]) const {
 //! \f$(x - x_0)^2 + (z - z_0)^2 - R^2 (y - y_0)^2 = 0\f$
 //==============================================================================
 
-class SurfaceYCone : public Surface {
+class SurfaceYCone : public Surface
+{
   double x0, y0, z0, r_sq;
 public:
   SurfaceYCone(pugi::xml_node surf_node);
@@ -725,21 +783,25 @@ public:
   void normal(const double xyz[3], double uvw[3]) const;
 };
 
-SurfaceYCone::SurfaceYCone(pugi::xml_node surf_node) {
+SurfaceYCone::SurfaceYCone(pugi::xml_node surf_node)
+{
   read_coeffs(surf_node, x0, y0, z0, r_sq);
 }
 
-inline double SurfaceYCone::evaluate(const double xyz[3]) const {
+inline double SurfaceYCone::evaluate(const double xyz[3]) const
+{
   return axis_aligned_cone_evaluate<1, 0, 2>(xyz, y0, x0, z0, r_sq);
 }
 
 inline double SurfaceYCone::distance(const double xyz[3],
-     const double uvw[3], bool coincident) const {
+     const double uvw[3], bool coincident) const
+{
   return axis_aligned_cone_distance<1, 0, 2>(xyz, uvw, coincident, y0, x0, z0,
                                              r_sq);
 }
 
-inline void SurfaceYCone::normal(const double xyz[3], double uvw[3]) const {
+inline void SurfaceYCone::normal(const double xyz[3], double uvw[3]) const
+{
   axis_aligned_cone_normal<1, 0, 2>(xyz, uvw, y0, x0, z0, r_sq);
 }
 
@@ -751,7 +813,8 @@ inline void SurfaceYCone::normal(const double xyz[3], double uvw[3]) const {
 //! \f$(x - x_0)^2 + (y - y_0)^2 - R^2 (z - z_0)^2 = 0\f$
 //==============================================================================
 
-class SurfaceZCone : public Surface {
+class SurfaceZCone : public Surface
+{
   double x0, y0, z0, r_sq;
 public:
   SurfaceZCone(pugi::xml_node surf_node);
@@ -761,21 +824,25 @@ public:
   void normal(const double xyz[3], double uvw[3]) const;
 };
 
-SurfaceZCone::SurfaceZCone(pugi::xml_node surf_node) {
+SurfaceZCone::SurfaceZCone(pugi::xml_node surf_node)
+{
   read_coeffs(surf_node, x0, y0, z0, r_sq);
 }
 
-inline double SurfaceZCone::evaluate(const double xyz[3]) const {
+inline double SurfaceZCone::evaluate(const double xyz[3]) const
+{
   return axis_aligned_cone_evaluate<2, 0, 1>(xyz, z0, x0, y0, r_sq);
 }
 
 inline double SurfaceZCone::distance(const double xyz[3],
-     const double uvw[3], bool coincident) const {
+     const double uvw[3], bool coincident) const
+{
   return axis_aligned_cone_distance<2, 0, 1>(xyz, uvw, coincident, z0, x0, y0,
                                              r_sq);
 }
 
-inline void SurfaceZCone::normal(const double xyz[3], double uvw[3]) const {
+inline void SurfaceZCone::normal(const double xyz[3], double uvw[3]) const
+{
   axis_aligned_cone_normal<2, 0, 1>(xyz, uvw, z0, x0, y0, r_sq);
 }
 
@@ -786,7 +853,8 @@ inline void SurfaceZCone::normal(const double xyz[3], double uvw[3]) const {
 //! \f$A x^2 + B y^2 + C z^2 + D x y + E y z + F x z + G x + H y + J z + K = 0\f$
 //==============================================================================
 
-class SurfaceQuadric : public Surface {
+class SurfaceQuadric : public Surface
+{
   // Ax^2 + By^2 + Cz^2 + Dxy + Eyz + Fxz + Gx + Hy + Jz + K = 0
   double A, B, C, D, E, F, G, H, J, K;
 public:
@@ -797,12 +865,14 @@ public:
   void normal(const double xyz[3], double uvw[3]) const;
 };
 
-SurfaceQuadric::SurfaceQuadric(pugi::xml_node surf_node) {
+SurfaceQuadric::SurfaceQuadric(pugi::xml_node surf_node)
+{
   read_coeffs(surf_node, A, B, C, D, E, F, G, H, J, K);
 }
 
 double
-SurfaceQuadric::evaluate(const double xyz[3]) const {
+SurfaceQuadric::evaluate(const double xyz[3]) const
+{
   const double &x = xyz[0];
   const double &y = xyz[1];
   const double &z = xyz[2];
@@ -813,7 +883,8 @@ SurfaceQuadric::evaluate(const double xyz[3]) const {
 
 double
 SurfaceQuadric::distance(const double xyz[3],
-     const double uvw[3], bool coincident) const {
+     const double uvw[3], bool coincident) const
+{
   const double &x = xyz[0];
   const double &y = xyz[1];
   const double &z = xyz[2];
@@ -866,7 +937,8 @@ SurfaceQuadric::distance(const double xyz[3],
 }
 
 void
-SurfaceQuadric::normal(const double xyz[3], double uvw[3]) const {
+SurfaceQuadric::normal(const double xyz[3], double uvw[3]) const
+{
   const double &x = xyz[0];
   const double &y = xyz[1];
   const double &z = xyz[2];
@@ -878,7 +950,8 @@ SurfaceQuadric::normal(const double xyz[3], double uvw[3]) const {
 //==============================================================================
 
 extern "C" void
-read_surfaces(pugi::xml_node *node) {
+read_surfaces(pugi::xml_node *node)
+{
   // Count the number of surfaces.
   int n_surfaces = 0;
   for (pugi::xml_node surf_node = node->child("surface"); surf_node;
@@ -952,16 +1025,19 @@ read_surfaces(pugi::xml_node *node) {
 //==============================================================================
 
 extern "C" bool
-surface_sense(int surf_ind, double xyz[3], double uvw[3]) {
+surface_sense(int surf_ind, double xyz[3], double uvw[3])
+{
   return surfaces_c[surf_ind]->sense(xyz, uvw);
 }
 
 extern "C" double
-surface_distance(int surf_ind, double xyz[3], double uvw[3], bool coincident) {
+surface_distance(int surf_ind, double xyz[3], double uvw[3], bool coincident)
+{
   return surfaces_c[surf_ind]->distance(xyz, uvw, coincident);
 }
 
 extern "C" void
-surface_normal(int surf_ind, double xyz[3], double uvw[3]) {
+surface_normal(int surf_ind, double xyz[3], double uvw[3])
+{
   return surfaces_c[surf_ind]->normal(xyz, uvw);
 }

--- a/src/surface_header.C
+++ b/src/surface_header.C
@@ -74,55 +74,111 @@ Surface **surfaces_c;
 // Helper functions for reading the "coeffs" node of an XML surface element
 //==============================================================================
 
-const char* get_coeff_str(pugi::xml_node surf_node)
+int word_count(const std::string &text)
 {
-  if (surf_node.attribute("coeffs")) {
-    return surf_node.attribute("coeffs").value();
-  } else if (surf_node.child("coeffs")) {
-    return surf_node.child_value("coeffs");
-  } else {
-    std::cout << "ERROR: Found a surface with no coefficients" << std::endl;
-    return nullptr;
+  bool in_word = false;
+  int count{0};
+  for (auto c = text.begin(); c != text.end(); c++) {
+    switch(*c) {
+      case ' ' :
+      case '\t' :
+      case '\r' :
+      case '\n' :
+        if (in_word) {
+          in_word = false;
+          count++;
+        }
+        break;
+      default :
+        in_word = true;
+    }
   }
+  if (in_word) count++;
+  return count;
 }
 
-void read_coeffs(pugi::xml_node surf_node, double &c1)
+void read_coeffs(pugi::xml_node surf_node, int surf_id, double &c1)
 {
-  const char *coeffs = get_coeff_str(surf_node);
-  int stat = sscanf(coeffs, "%lf", &c1);
+  // Check the given number of coefficients.
+  std::string coeffs = get_node_value(surf_node, "coeffs");
+  int n_words = word_count(coeffs);
+  if (n_words != 1) {
+    std::string err_msg{"Surface "};
+    err_msg += std::to_string(surf_id);
+    err_msg += " expects 1 coeff but was given ";
+    err_msg += std::to_string(n_words);
+    fatal_error(err_msg);
+  }
+
+  // Parse the coefficients.
+  int stat = sscanf(coeffs.c_str(), "%lf", &c1);
   if (stat != 1) {
-    std::cout << "Something went wrong reading surface coeffs!" << std::endl;
+    fatal_error("Something went wrong reading surface coeffs");
   }
 }
 
-void read_coeffs(pugi::xml_node surf_node, double &c1, double &c2, double &c3)
+void read_coeffs(pugi::xml_node surf_node, int surf_id, double &c1, double &c2,
+                 double &c3)
 {
-  const char *coeffs = get_coeff_str(surf_node);
-  int stat = sscanf(coeffs, "%lf %lf %lf", &c1, &c2, &c3);
+  // Check the given number of coefficients.
+  std::string coeffs = get_node_value(surf_node, "coeffs");
+  int n_words = word_count(coeffs);
+  if (n_words != 3) {
+    std::string err_msg{"Surface "};
+    err_msg += std::to_string(surf_id);
+    err_msg += " expects 3 coeffs but was given ";
+    err_msg += std::to_string(n_words);
+    fatal_error(err_msg);
+  }
+
+  // Parse the coefficients.
+  int stat = sscanf(coeffs.c_str(), "%lf %lf %lf", &c1, &c2, &c3);
   if (stat != 3) {
-    std::cout << "Something went wrong reading surface coeffs!" << std::endl;
+    fatal_error("Something went wrong reading surface coeffs");
   }
 }
 
-void read_coeffs(pugi::xml_node surf_node, double &c1, double &c2, double &c3,
-                 double &c4)
+void read_coeffs(pugi::xml_node surf_node, int surf_id, double &c1, double &c2,
+                 double &c3, double &c4)
 {
-  const char *coeffs = get_coeff_str(surf_node);
-  int stat = sscanf(coeffs, "%lf %lf %lf %lf", &c1, &c2, &c3, &c4);
+  // Check the given number of coefficients.
+  std::string coeffs = get_node_value(surf_node, "coeffs");
+  int n_words = word_count(coeffs);
+  if (n_words != 4) {
+    std::string err_msg{"Surface "};
+    err_msg += std::to_string(surf_id);
+    err_msg += " expects 4 coeffs but was given ";
+    err_msg += std::to_string(n_words);
+    fatal_error(err_msg);
+  }
+
+  // Parse the coefficients.
+  int stat = sscanf(coeffs.c_str(), "%lf %lf %lf %lf", &c1, &c2, &c3, &c4);
   if (stat != 4) {
-    std::cout << "Something went wrong reading surface coeffs!" << std::endl;
+    fatal_error("Something went wrong reading surface coeffs");
   }
 }
 
-void read_coeffs(pugi::xml_node surf_node, double &c1, double &c2, double &c3,
-                 double &c4, double &c5, double &c6, double &c7, double &c8,
-                 double &c9, double &c10)
+void read_coeffs(pugi::xml_node surf_node, int surf_id, double &c1, double &c2,
+                 double &c3, double &c4, double &c5, double &c6, double &c7,
+                 double &c8, double &c9, double &c10)
 {
-  const char *coeffs = get_coeff_str(surf_node);
-  int stat = sscanf(coeffs, "%lf %lf %lf %lf %lf %lf %lf %lf %lf %lf",
+  // Check the given number of coefficients.
+  std::string coeffs = get_node_value(surf_node, "coeffs");
+  int n_words = word_count(coeffs);
+  if (n_words != 10) {
+    std::string err_msg{"Surface "};
+    err_msg += std::to_string(surf_id);
+    err_msg += " expects 10 coeffs but was given ";
+    err_msg += std::to_string(n_words);
+    fatal_error(err_msg);
+  }
+
+  // Parse the coefficients.
+  int stat = sscanf(coeffs.c_str(), "%lf %lf %lf %lf %lf %lf %lf %lf %lf %lf",
                     &c1, &c2, &c3, &c4, &c5, &c6, &c7, &c8, &c9, &c10);
   if (stat != 10) {
-    std::cout << "Something went wrong reading surface coeffs!" << std::endl;
+    fatal_error("Something went wrong reading surface coeffs");
   }
 }
 
@@ -377,7 +433,7 @@ public:
 SurfaceXPlane::SurfaceXPlane(pugi::xml_node surf_node)
   : PeriodicSurface(surf_node)
 {
-  read_coeffs(surf_node, x0);
+  read_coeffs(surf_node, id, x0);
 }
 
 inline double SurfaceXPlane::evaluate(const double xyz[3]) const
@@ -453,7 +509,7 @@ public:
 SurfaceYPlane::SurfaceYPlane(pugi::xml_node surf_node)
   : PeriodicSurface(surf_node)
 {
-  read_coeffs(surf_node, y0);
+  read_coeffs(surf_node, id, y0);
 }
 
 inline double SurfaceYPlane::evaluate(const double xyz[3]) const
@@ -529,7 +585,7 @@ public:
 SurfaceZPlane::SurfaceZPlane(pugi::xml_node surf_node)
   : PeriodicSurface(surf_node)
 {
-  read_coeffs(surf_node, z0);
+  read_coeffs(surf_node, id, z0);
 }
 
 inline double SurfaceZPlane::evaluate(const double xyz[3]) const
@@ -587,7 +643,7 @@ public:
 SurfacePlane::SurfacePlane(pugi::xml_node surf_node)
   : PeriodicSurface(surf_node)
 {
-  read_coeffs(surf_node, A, B, C, D);
+  read_coeffs(surf_node, id, A, B, C, D);
 }
 
 double
@@ -739,7 +795,7 @@ public:
 SurfaceXCylinder::SurfaceXCylinder(pugi::xml_node surf_node)
   : Surface(surf_node)
 {
-  read_coeffs(surf_node, y0, z0, r);
+  read_coeffs(surf_node, id, y0, z0, r);
 }
 
 inline double SurfaceXCylinder::evaluate(const double xyz[3]) const
@@ -790,7 +846,7 @@ public:
 SurfaceYCylinder::SurfaceYCylinder(pugi::xml_node surf_node)
   : Surface(surf_node)
 {
-  read_coeffs(surf_node, x0, z0, r);
+  read_coeffs(surf_node, id, x0, z0, r);
 }
 
 inline double SurfaceYCylinder::evaluate(const double xyz[3]) const
@@ -840,7 +896,7 @@ public:
 SurfaceZCylinder::SurfaceZCylinder(pugi::xml_node surf_node)
   : Surface(surf_node)
 {
-  read_coeffs(surf_node, x0, y0, r);
+  read_coeffs(surf_node, id, x0, y0, r);
 }
 
 inline double SurfaceZCylinder::evaluate(const double xyz[3]) const
@@ -890,7 +946,7 @@ public:
 SurfaceSphere::SurfaceSphere(pugi::xml_node surf_node)
   : Surface(surf_node)
 {
-  read_coeffs(surf_node, x0, y0, z0, r);
+  read_coeffs(surf_node, id, x0, y0, z0, r);
 }
 
 double SurfaceSphere::evaluate(const double xyz[3]) const
@@ -1060,7 +1116,7 @@ public:
 SurfaceXCone::SurfaceXCone(pugi::xml_node surf_node)
   : Surface(surf_node)
 {
-  read_coeffs(surf_node, x0, y0, z0, r_sq);
+  read_coeffs(surf_node, id, x0, y0, z0, r_sq);
 }
 
 inline double SurfaceXCone::evaluate(const double xyz[3]) const
@@ -1110,7 +1166,7 @@ public:
 SurfaceYCone::SurfaceYCone(pugi::xml_node surf_node)
   : Surface(surf_node)
 {
-  read_coeffs(surf_node, x0, y0, z0, r_sq);
+  read_coeffs(surf_node, id, x0, y0, z0, r_sq);
 }
 
 inline double SurfaceYCone::evaluate(const double xyz[3]) const
@@ -1160,7 +1216,7 @@ public:
 SurfaceZCone::SurfaceZCone(pugi::xml_node surf_node)
   : Surface(surf_node)
 {
-  read_coeffs(surf_node, x0, y0, z0, r_sq);
+  read_coeffs(surf_node, id, x0, y0, z0, r_sq);
 }
 
 inline double SurfaceZCone::evaluate(const double xyz[3]) const
@@ -1210,7 +1266,7 @@ public:
 SurfaceQuadric::SurfaceQuadric(pugi::xml_node surf_node)
   : Surface(surf_node)
 {
-  read_coeffs(surf_node, A, B, C, D, E, F, G, H, J, K);
+  read_coeffs(surf_node, id, A, B, C, D, E, F, G, H, J, K);
 }
 
 double

--- a/src/surface_header.C
+++ b/src/surface_header.C
@@ -33,7 +33,7 @@ const char* get_coeff_str(pugi::xml_node surf_node)
     return surf_node.child_value("coeffs");
   } else {
     std::cout << "ERROR: Found a surface with no coefficients" << std::endl;
-    return NULL;
+    return nullptr;
   }
 }
 

--- a/src/surface_header.C
+++ b/src/surface_header.C
@@ -903,3 +903,8 @@ extern "C" double
 surface_distance(int surf_ind, double xyz[3], double uvw[3], bool coincident) {
   return surfaces_c[surf_ind]->distance(xyz, uvw, coincident);
 }
+
+extern "C" void
+surface_normal(int surf_ind, double xyz[3], double uvw[3]) {
+  return surfaces_c[surf_ind]->normal(xyz, uvw);
+}

--- a/src/surface_header.C
+++ b/src/surface_header.C
@@ -33,36 +33,34 @@ class Surface {
   char name[104];            // User-defined name
 
 public:
-  bool sense(double xyz[3], double uvw[3]);
-  void reflect(double xyz[3], double uvw[3]);
-  virtual double evaluate(double xyz[3]) = 0;
-  virtual double distance(double xyz[3], double uvw[3], bool coincident) = 0;
-  virtual void normal(double xyz[3], double uvw[3]) = 0;
+  bool sense(const double xyz[3], const double uvw[3]) const;
+  void reflect(const double xyz[3], double uvw[3]) const;
+  virtual double evaluate(const double xyz[3]) const = 0;
+  virtual double distance(const double xyz[3], const double uvw[3],
+                          bool coincident) const = 0;
+  virtual void normal(const double xyz[3], double uvw[3]) const = 0;
 };
 
 bool
-Surface::sense(double xyz[3], double uvw[3]) {
+Surface::sense(const double xyz[3], const double uvw[3]) const {
   // Evaluate the surface equation at the particle's coordinates to determine
   // which side the particle is on.
   const double f = evaluate(xyz);
 
   // Check which side of surface the point is on.
-  bool s;
   if (fabs(f) < FP_COINCIDENT) {
     // Particle may be coincident with this surface. To determine the sense, we
     // look at the direction of the particle relative to the surface normal (by
     // default in the positive direction) via their dot product.
     double norm[3];
     normal(xyz, norm);
-    s = (uvw[0] * norm[0] + uvw[1] * norm[1] + uvw[2] * norm[2] > 0.0);
-  } else {
-    s = (f > 0.0);
+    return uvw[0] * norm[0] + uvw[1] * norm[1] + uvw[2] * norm[2] > 0.0;
   }
-  return s;
+  return f > 0.0;
 }
 
 void
-Surface::reflect(double xyz[3], double uvw[3]) {
+Surface::reflect(const double xyz[3], double uvw[3]) const {
   // Determine projection of direction onto normal and squared magnitude of
   // normal.
   double norm[3];
@@ -77,14 +75,112 @@ Surface::reflect(double xyz[3], double uvw[3]) {
 }
 
 //==============================================================================
+// Generic functions for X-, Y-, and Z-, planes
+//==============================================================================
+
+template<int i> double
+axis_aligned_plane_evaluate(const double xyz[3], double offset) {
+  return xyz[i] - offset;}
+
+template<int i> double
+axis_aligned_plane_distance(const double xyz[3], const double uvw[3],
+                            bool coincident, double offset) {
+  const double f = offset - xyz[i];
+  if (coincident or fabs(f) < FP_COINCIDENT or uvw[i] == 0.0) return INFTY;
+  const double d = f / uvw[i];
+  if (d < 0.0) return INFTY;
+  return d;
+}
+
+template<int i1, int i2, int i3> void
+axis_aligned_plane_normal(const double xyz[3], double uvw[3]) {
+  uvw[i1] = 1.0;
+  uvw[i2] = 0.0;
+  uvw[i3] = 0.0;
+}
+
+//==============================================================================
+// SurfaceXPlane
+//==============================================================================
+
+class SurfaceXPlane : public Surface {
+  double x0;
+public:
+  SurfaceXPlane(pugi::xml_node surf_node);
+  double evaluate(const double xyz[3]) const;
+  double distance(const double xyz[3], const double uvw[3],
+                  const bool coincident) const;
+  void normal(const double xyz[3], double uvw[3]) const;
+};
+
+SurfaceXPlane::SurfaceXPlane(pugi::xml_node surf_node) {
+  const char *coeffs = surf_node.attribute("coeffs").value();
+  int stat = sscanf(coeffs, "%lf", &x0);
+  if (stat != 1) {
+    std::cout << "Something went wrong reading surface coeffs!" << std::endl;
+  }
+}
+
+inline double SurfaceXPlane::evaluate(const double xyz[3]) const {
+  return axis_aligned_plane_evaluate<0>(xyz, x0);
+}
+
+inline double SurfaceXPlane::distance(const double xyz[3], const double uvw[3],
+                                      bool coincident) const {
+  return axis_aligned_plane_distance<0>(xyz, uvw, coincident, x0);
+}
+
+inline void SurfaceXPlane::normal(const double xyz[3], double uvw[3]) const {
+  axis_aligned_plane_normal<0, 1, 2>(xyz, uvw);
+}
+
+//==============================================================================
+// SurfaceYPlane
+//==============================================================================
+
+class SurfaceYPlane : public Surface {
+  double y0;
+public:
+  SurfaceYPlane(pugi::xml_node surf_node);
+  double evaluate(const double xyz[3]) const;
+  double distance(const double xyz[3], const double uvw[3],
+                  bool coincident) const;
+  void normal(const double xyz[3], double uvw[3]) const;
+};
+
+SurfaceYPlane::SurfaceYPlane(pugi::xml_node surf_node) {
+  const char *coeffs = surf_node.attribute("coeffs").value();
+  int stat = sscanf(coeffs, "%lf", &y0);
+  if (stat != 1) {
+    std::cout << "Something went wrong reading surface coeffs!" << std::endl;
+  }
+}
+
+inline double SurfaceYPlane::evaluate(const double xyz[3]) const {
+  return axis_aligned_plane_evaluate<1>(xyz, y0);
+}
+
+inline double SurfaceYPlane::distance(const double xyz[3], const double uvw[3],
+                                      bool coincident) const {
+  return axis_aligned_plane_distance<1>(xyz, uvw, coincident, y0);
+}
+
+inline void SurfaceYPlane::normal(const double xyz[3], double uvw[3]) const {
+  axis_aligned_plane_normal<1, 0, 2>(xyz, uvw);
+}
+
+//==============================================================================
+// SurfaceZPlane
+//==============================================================================
 
 class SurfaceZPlane : public Surface {
   double z0;
 public:
   SurfaceZPlane(pugi::xml_node surf_node);
-  double evaluate(double xyz[3]);
-  double distance(double xyz[3], double uvw[3], bool coincident);
-  void normal(double xyz[3], double uvw[3]);
+  double evaluate(const double xyz[3]) const;
+  double distance(const double xyz[3], const double uvw[3],
+                  bool coincident) const;
+  void normal(const double xyz[3], double uvw[3]) const;
 };
 
 SurfaceZPlane::SurfaceZPlane(pugi::xml_node surf_node) {
@@ -95,73 +191,49 @@ SurfaceZPlane::SurfaceZPlane(pugi::xml_node surf_node) {
   }
 }
 
-double
-SurfaceZPlane::evaluate(double xyz[3]) {
-  double f = xyz[2] - z0;
-  return f;
+inline double SurfaceZPlane::evaluate(const double xyz[3]) const {
+  return axis_aligned_plane_evaluate<2>(xyz, z0);
 }
 
-double
-SurfaceZPlane::distance(double xyz[3], double uvw[3], bool coincident) {
-  double f = z0 - xyz[2];
-  double d;
-  if (coincident or fabs(f) < FP_COINCIDENT or uvw[2] == 0.0)
-  {
-    d = INFTY;
-  }
-  else
-  {
-    d = f / uvw[2];
-    if (d < 0.0) d = INFTY;
-  }
-  return d;
+inline double SurfaceZPlane::distance(const double xyz[3], const double uvw[3],
+                                      bool coincident) const {
+  return axis_aligned_plane_distance<2>(xyz, uvw, coincident, z0);
 }
 
-void
-SurfaceZPlane::normal(double xyz[3], double uvw[3]) {
-  uvw[0] = 0.0;
-  uvw[1] = 0.0;
-  uvw[2] = 1.0;
+inline void SurfaceZPlane::normal(const double xyz[3], double uvw[3]) const {
+  axis_aligned_plane_normal<2, 0, 1>(xyz, uvw);
 }
 
 //==============================================================================
+// SurfacePlane
+//==============================================================================
 
-class SurfaceZCylinder : public Surface {
-  double x0, y0, r;
-public:
-  SurfaceZCylinder(pugi::xml_node surf_node);
-  double evaluate(double xyz[3]);
-  double distance(double xyz[3], double uvw[3], bool coincident);
-  void normal(double xyz[3], double uvw[3]);
-};
+// TODO
 
-SurfaceZCylinder::SurfaceZCylinder(pugi::xml_node surf_node) {
-  const char *coeffs = surf_node.attribute("coeffs").value();
-  int stat = sscanf(coeffs, "%lf %lf %lf", &x0, &y0, &r);
-  if (stat != 3) {
-    std::cout << "Something went wrong reading surface coeffs!" << std::endl;
-  }
+//==============================================================================
+// Generic functions for X-, Y-, and Z-, cylinders
+//==============================================================================
+
+template<int i1, int i2> double
+axis_aligned_cylinder_evaluate(const double xyz[3], double offset1,
+                               double offset2, double radius) {
+  const double xyz1 = xyz[i1] - offset1;
+  const double xyz2 = xyz[i2] - offset2;
+  return xyz1*xyz1 + xyz2*xyz2 - radius*radius;
 }
 
-double
-SurfaceZCylinder::evaluate(double xyz[3]) {
-  const double x = xyz[0] - x0;
-  const double y = xyz[1] - y0;
-  double f = x*x + y*y - r*r;
-  return f;
-}
-
-double
-SurfaceZCylinder::distance(double xyz[3], double uvw[3], bool coincident) {
-  double a = 1.0 - uvw[2]*uvw[2];  // u^2 + v^2
+template<int i1, int i2, int i3> double
+axis_aligned_cylinder_distance(const double xyz[3], const double uvw[3],
+     double offset1, double offset2, double radius, bool coincident) {
+  const double a = 1.0 - uvw[i1]*uvw[i1];  // u^2 + v^2
 
   if (a == 0.0) return INFTY;
 
-  double x = xyz[0] - x0;
-  double y = xyz[1] - y0;
-  double k = x*uvw[0] + y*uvw[1];
-  double c = x*x + y*y - r*r;
-  double quad = k*k - a*c;
+  const double xyz2 = xyz[i2] - offset1;
+  const double xyz3 = xyz[i3] - offset2;
+  const double k = xyz2 * uvw[i2] + xyz3 * uvw[i3];
+  const double c = xyz2*xyz2 + xyz3*xyz3 - radius*radius;
+  const double quad = k*k - a*c;
 
   if (quad < 0.0) {
     // No intersection with cylinder.
@@ -190,11 +262,123 @@ SurfaceZCylinder::distance(double xyz[3], double uvw[3], bool coincident) {
   }
 }
 
-void
-SurfaceZCylinder::normal(double xyz[3], double uvw[3]) {
-  uvw[0] = 2.0 * (xyz[0] - x0);
-  uvw[1] = 2.0 * (xyz[1] - y0);
-  uvw[2] = 0.0;
+template<int i1, int i2, int i3> void
+axis_aligned_cylinder_normal(const double xyz[3], double uvw[3], double offset1,
+                             double offset2) {
+  uvw[i2] = 2.0 * (xyz[i2] - offset1);
+  uvw[i3] = 2.0 * (xyz[i3] - offset2);
+  uvw[i1] = 0.0;
+}
+
+//==============================================================================
+// SurfaceXCylinder
+//==============================================================================
+
+class SurfaceXCylinder : public Surface {
+  double y0, z0, r;
+public:
+  SurfaceXCylinder(pugi::xml_node surf_node);
+  double evaluate(const double xyz[3]) const;
+  double distance(const double xyz[3], const double uvw[3],
+                  bool coincident) const;
+  void normal(const double xyz[3], double uvw[3]) const;
+};
+
+SurfaceXCylinder::SurfaceXCylinder(pugi::xml_node surf_node) {
+  const char *coeffs = surf_node.attribute("coeffs").value();
+  int stat = sscanf(coeffs, "%lf %lf %lf", &y0, &z0, &r);
+  if (stat != 3) {
+    std::cout << "Something went wrong reading surface coeffs!" << std::endl;
+  }
+}
+
+inline double
+SurfaceXCylinder::evaluate(const double xyz[3]) const {
+  return axis_aligned_cylinder_evaluate<1, 2>(xyz, y0, z0, r);
+}
+
+inline double SurfaceXCylinder::distance(const double xyz[3],
+     const double uvw[3], bool coincident) const {
+  return axis_aligned_cylinder_distance<0, 1, 2>(xyz, uvw, coincident, y0, z0,
+                                                 r);
+}
+
+inline void SurfaceXCylinder::normal(const double xyz[3], double uvw[3]) const {
+  axis_aligned_cylinder_normal<0, 1, 2>(xyz, uvw, y0, z0);
+}
+
+//==============================================================================
+// SurfaceYCylinder
+//==============================================================================
+
+class SurfaceYCylinder : public Surface {
+  double x0, z0, r;
+public:
+  SurfaceYCylinder(pugi::xml_node surf_node);
+  double evaluate(const double xyz[3]) const;
+  double distance(const double xyz[3], const double uvw[3],
+                  bool coincident) const;
+  void normal(const double xyz[3], double uvw[3]) const;
+};
+
+SurfaceYCylinder::SurfaceYCylinder(pugi::xml_node surf_node) {
+  const char *coeffs = surf_node.attribute("coeffs").value();
+  int stat = sscanf(coeffs, "%lf %lf %lf", &x0, &z0, &r);
+  if (stat != 3) {
+    std::cout << "Something went wrong reading surface coeffs!" << std::endl;
+  }
+}
+
+inline double
+SurfaceYCylinder::evaluate(const double xyz[3]) const {
+  return axis_aligned_cylinder_evaluate<0, 2>(xyz, x0, z0, r);
+}
+
+inline double SurfaceYCylinder::distance(const double xyz[3],
+     const double uvw[3], bool coincident) const {
+  return axis_aligned_cylinder_distance<1, 0, 2>(xyz, uvw, coincident, x0, z0,
+                                                 r);
+}
+
+inline void SurfaceYCylinder::normal(const double xyz[3], double uvw[3]) const {
+  axis_aligned_cylinder_normal<1, 0, 2>(xyz, uvw, x0, z0);
+}
+
+//==============================================================================
+// SurfaceZCylinder
+//==============================================================================
+
+class SurfaceZCylinder : public Surface {
+  double x0, y0, r;
+public:
+  SurfaceZCylinder(pugi::xml_node surf_node);
+  double evaluate(const double xyz[3]) const;
+  double distance(const double xyz[3], const double uvw[3],
+                  bool coincident) const;
+  void normal(const double xyz[3], double uvw[3]) const;
+};
+
+SurfaceZCylinder::SurfaceZCylinder(pugi::xml_node surf_node) {
+  const char *coeffs = surf_node.attribute("coeffs").value();
+  int stat = sscanf(coeffs, "%lf %lf %lf", &x0, &y0, &r);
+  if (stat != 3) {
+    std::cout << "Something went wrong reading surface coeffs!" << std::endl;
+  }
+}
+
+inline double
+SurfaceZCylinder::evaluate(const double xyz[3]) const {
+  return axis_aligned_cylinder_evaluate<0, 1>(xyz, x0, y0, r);
+}
+
+inline double SurfaceZCylinder::distance(const double xyz[3],
+     const double uvw[3], bool coincident) const {
+  return axis_aligned_cylinder_distance<2, 0, 1>(xyz, uvw, coincident, x0, y0,
+                                                 r);
+}
+
+inline void SurfaceZCylinder::normal(const double xyz[3], double uvw[3]) const {
+  axis_aligned_cylinder_normal<2, 0, 1>(xyz, uvw, x0, y0);
 }
 
 //==============================================================================
@@ -219,16 +403,26 @@ read_surfaces(pugi::xml_node *node) {
          surf_node = surf_node.next_sibling("surface"), i_surf++) {
       if (surf_node.attribute("type")) {
         const pugi::char_t *surf_type = surf_node.attribute("type").value();
-        if (strcmp(surf_type, "z-cylinder") == 0)
-        {
-          surfaces_c[i_surf] = new SurfaceZCylinder(surf_node);
-        }
-        else if (strcmp(surf_type, "z-plane") == 0)
-        {
+
+        if (strcmp(surf_type, "x-plane") == 0) {
+          surfaces_c[i_surf] = new SurfaceXPlane(surf_node);
+
+        } else if (strcmp(surf_type, "y-plane") == 0) {
+          surfaces_c[i_surf] = new SurfaceYPlane(surf_node);
+
+        } else if (strcmp(surf_type, "z-plane") == 0) {
           surfaces_c[i_surf] = new SurfaceZPlane(surf_node);
-        }
-        else
-        {
+
+        } else if (strcmp(surf_type, "x-cylinder") == 0) {
+          surfaces_c[i_surf] = new SurfaceXCylinder(surf_node);
+
+        } else if (strcmp(surf_type, "y-cylinder") == 0) {
+          surfaces_c[i_surf] = new SurfaceYCylinder(surf_node);
+
+        } else if (strcmp(surf_type, "z-cylinder") == 0) {
+          surfaces_c[i_surf] = new SurfaceZCylinder(surf_node);
+
+        } else {
           std::cout << "Call error or handle uppercase here!" << std::endl;
           std::cout << surf_type << std::endl;
         }

--- a/src/surface_header.C
+++ b/src/surface_header.C
@@ -23,8 +23,7 @@ Surface **surfaces_c;
 // construct closed volumes (cells)
 //==============================================================================
 
-class Surface
-{
+class Surface {
   int id;                    // Unique ID
   int neighbor_pos[],        // List of cells on positive side
       neighbor_neg[];        // List of cells on negative side
@@ -42,34 +41,28 @@ public:
 };
 
 bool
-Surface::sense(double xyz[3], double uvw[3])
-{
+Surface::sense(double xyz[3], double uvw[3]) {
   // Evaluate the surface equation at the particle's coordinates to determine
   // which side the particle is on.
   const double f = evaluate(xyz);
 
   // Check which side of surface the point is on.
   bool s;
-  if (fabs(f) < FP_COINCIDENT)
-  {
+  if (fabs(f) < FP_COINCIDENT) {
     // Particle may be coincident with this surface. To determine the sense, we
     // look at the direction of the particle relative to the surface normal (by
     // default in the positive direction) via their dot product.
     double norm[3];
     normal(xyz, norm);
     s = (uvw[0] * norm[0] + uvw[1] * norm[1] + uvw[2] * norm[2] > 0.0);
-  }
-  else
-  {
+  } else {
     s = (f > 0.0);
   }
   return s;
 }
 
 void
-Surface::reflect(double xyz[3], double uvw[3])
-{
-
+Surface::reflect(double xyz[3], double uvw[3]) {
   // Determine projection of direction onto normal and squared magnitude of
   // normal.
   double norm[3];
@@ -85,8 +78,7 @@ Surface::reflect(double xyz[3], double uvw[3])
 
 //==============================================================================
 
-class SurfaceZPlane : public Surface
-{
+class SurfaceZPlane : public Surface {
   double z0;
 public:
   SurfaceZPlane(pugi::xml_node surf_node);
@@ -95,26 +87,22 @@ public:
   void normal(double xyz[3], double uvw[3]);
 };
 
-SurfaceZPlane::SurfaceZPlane(pugi::xml_node surf_node)
-{
+SurfaceZPlane::SurfaceZPlane(pugi::xml_node surf_node) {
   const char *coeffs = surf_node.attribute("coeffs").value();
   int stat = sscanf(coeffs, "%lf", &z0);
-  if (stat != 1)
-  {
+  if (stat != 1) {
     std::cout << "Something went wrong reading surface coeffs!" << std::endl;
   }
 }
 
 double
-SurfaceZPlane::evaluate(double xyz[3])
-{
+SurfaceZPlane::evaluate(double xyz[3]) {
   double f = xyz[2] - z0;
   return f;
 }
 
 double
-SurfaceZPlane::distance(double xyz[3], double uvw[3], bool coincident)
-{
+SurfaceZPlane::distance(double xyz[3], double uvw[3], bool coincident) {
   double f = z0 - xyz[2];
   double d;
   if (coincident or fabs(f) < FP_COINCIDENT or uvw[2] == 0.0)
@@ -130,8 +118,7 @@ SurfaceZPlane::distance(double xyz[3], double uvw[3], bool coincident)
 }
 
 void
-SurfaceZPlane::normal(double xyz[3], double uvw[3])
-{
+SurfaceZPlane::normal(double xyz[3], double uvw[3]) {
   uvw[0] = 0.0;
   uvw[1] = 0.0;
   uvw[2] = 1.0;
@@ -139,8 +126,7 @@ SurfaceZPlane::normal(double xyz[3], double uvw[3])
 
 //==============================================================================
 
-class SurfaceZCylinder : public Surface
-{
+class SurfaceZCylinder : public Surface {
   double x0, y0, r;
 public:
   SurfaceZCylinder(pugi::xml_node surf_node);
@@ -149,19 +135,16 @@ public:
   void normal(double xyz[3], double uvw[3]);
 };
 
-SurfaceZCylinder::SurfaceZCylinder(pugi::xml_node surf_node)
-{
+SurfaceZCylinder::SurfaceZCylinder(pugi::xml_node surf_node) {
   const char *coeffs = surf_node.attribute("coeffs").value();
   int stat = sscanf(coeffs, "%lf %lf %lf", &x0, &y0, &r);
-  if (stat != 3)
-  {
+  if (stat != 3) {
     std::cout << "Something went wrong reading surface coeffs!" << std::endl;
   }
 }
 
 double
-SurfaceZCylinder::evaluate(double xyz[3])
-{
+SurfaceZCylinder::evaluate(double xyz[3]) {
   const double x = xyz[0] - x0;
   const double y = xyz[1] - y0;
   double f = x*x + y*y - r*r;
@@ -169,8 +152,7 @@ SurfaceZCylinder::evaluate(double xyz[3])
 }
 
 double
-SurfaceZCylinder::distance(double xyz[3], double uvw[3], bool coincident)
-{
+SurfaceZCylinder::distance(double xyz[3], double uvw[3], bool coincident) {
   double a = 1.0 - uvw[2]*uvw[2];  // u^2 + v^2
 
   if (a == 0.0) return INFTY;
@@ -181,32 +163,27 @@ SurfaceZCylinder::distance(double xyz[3], double uvw[3], bool coincident)
   double c = x*x + y*y - r*r;
   double quad = k*k - a*c;
 
-  if (quad < 0.0)
-  {
+  if (quad < 0.0) {
     // No intersection with cylinder.
     return INFTY;
-  }
-  else if (coincident or fabs(c) < FP_COINCIDENT)
-  {
+
+  } else if (coincident or fabs(c) < FP_COINCIDENT) {
     // Particle is on the cylinder, thus one distance is positive/negative
     // and the other is zero. The sign of k determines if we are facing in or
     // out.
     if (k >= 0.0) return INFTY;
     else return (-k + sqrt(quad)) / a;
-  }
-  else if (c < 0.0)
-  {
+
+  } else if (c < 0.0) {
     // Particle is inside the cylinder, thus one distance must be negative
     // and one must be positive. The positive distance will be the one with
     // negative sign on sqrt(quad)
     return (-k + sqrt(quad)) / a;
-  }
-  else
-  {
+
+  } else {
     // Particle is outside the cylinder, thus both distances are either
     // positive or negative. If positive, the smaller distance is the one
     // with positive sign on sqrt(quad)
-
     double d = (-k - sqrt(quad)) / a;
     if (d < 0.0) return INFTY;
     return d;
@@ -214,8 +191,7 @@ SurfaceZCylinder::distance(double xyz[3], double uvw[3], bool coincident)
 }
 
 void
-SurfaceZCylinder::normal(double xyz[3], double uvw[3])
-{
+SurfaceZCylinder::normal(double xyz[3], double uvw[3]) {
   uvw[0] = 2.0 * (xyz[0] - x0);
   uvw[1] = 2.0 * (xyz[1] - y0);
   uvw[2] = 0.0;
@@ -224,13 +200,11 @@ SurfaceZCylinder::normal(double xyz[3], double uvw[3])
 //==============================================================================
 
 extern "C" void
-read_surfaces(pugi::xml_node *node)
-{
+read_surfaces(pugi::xml_node *node) {
   // Count the number of surfaces.
   int n_surfaces = 0;
   for (pugi::xml_node surf_node = node->child("surface"); surf_node;
-       surf_node = surf_node.next_sibling("surface"))
-  {
+       surf_node = surf_node.next_sibling("surface")) {
     n_surfaces += 1;
   }
 
@@ -242,10 +216,8 @@ read_surfaces(pugi::xml_node *node)
     pugi::xml_node surf_node;
     int i_surf;
     for (surf_node = node->child("surface"), i_surf = 0; surf_node;
-         surf_node = surf_node.next_sibling("surface"), i_surf++)
-    {
-      if (surf_node.attribute("type"))
-      {
+         surf_node = surf_node.next_sibling("surface"), i_surf++) {
+      if (surf_node.attribute("type")) {
         const pugi::char_t *surf_type = surf_node.attribute("type").value();
         if (strcmp(surf_type, "z-cylinder") == 0)
         {
@@ -268,13 +240,11 @@ read_surfaces(pugi::xml_node *node)
 //==============================================================================
 
 extern "C" bool
-surface_sense(int surf_ind, double xyz[3], double uvw[3])
-{
+surface_sense(int surf_ind, double xyz[3], double uvw[3]) {
   return surfaces_c[surf_ind]->sense(xyz, uvw);
 }
 
 extern "C" double
-surface_distance(int surf_ind, double xyz[3], double uvw[3], bool coincident)
-{
+surface_distance(int surf_ind, double xyz[3], double uvw[3], bool coincident) {
   return surfaces_c[surf_ind]->distance(xyz, uvw, coincident);
 }

--- a/src/surface_header.C
+++ b/src/surface_header.C
@@ -19,6 +19,82 @@ class Surface;
 Surface **surfaces_c;
 
 //==============================================================================
+// Helper functions
+//==============================================================================
+
+void read_coeffs(pugi::xml_node surf_node, double &c1)
+{
+  const char *coeffs;
+  if (surf_node.attribute("coeffs")) {
+    coeffs = surf_node.attribute("coeffs").value();
+  } else if (surf_node.child("coeffs")) {
+    coeffs = surf_node.child_value("coeffs");
+  } else {
+    std::cout << "ERROR: Found a surface with no coefficients" << std::endl;
+  }
+
+  int stat = sscanf(coeffs, "%lf", &c1);
+  if (stat != 1) {
+    std::cout << "Something went wrong reading surface coeffs!" << std::endl;
+  }
+}
+
+void read_coeffs(pugi::xml_node surf_node, double &c1, double &c2, double &c3)
+{
+  const char *coeffs;
+  if (surf_node.attribute("coeffs")) {
+    coeffs = surf_node.attribute("coeffs").value();
+  } else if (surf_node.child("coeffs")) {
+    coeffs = surf_node.child_value("coeffs");
+  } else {
+    std::cout << "ERROR: Found a surface with no coefficients" << std::endl;
+  }
+
+  int stat = sscanf(coeffs, "%lf %lf %lf", &c1, &c2, &c3);
+  if (stat != 3) {
+    std::cout << "Something went wrong reading surface coeffs!" << std::endl;
+  }
+}
+
+void read_coeffs(pugi::xml_node surf_node, double &c1, double &c2, double &c3,
+                 double &c4)
+{
+  const char *coeffs;
+  if (surf_node.attribute("coeffs")) {
+    coeffs = surf_node.attribute("coeffs").value();
+  } else if (surf_node.child("coeffs")) {
+    coeffs = surf_node.child_value("coeffs");
+  } else {
+    std::cout << "ERROR: Found a surface with no coefficients" << std::endl;
+  }
+
+  int stat = sscanf(coeffs, "%lf %lf %lf %lf", &c1, &c2, &c3, &c4);
+  if (stat != 4) {
+    std::cout << "Something went wrong reading surface coeffs!" << std::endl;
+  }
+}
+
+void read_coeffs(pugi::xml_node surf_node, double &c1, double &c2, double &c3,
+                 double &c4, double &c5, double &c6, double &c7, double &c8,
+                 double &c9, double &c10)
+{
+  const char *coeffs;
+  if (surf_node.attribute("coeffs")) {
+    coeffs = surf_node.attribute("coeffs").value();
+  } else if (surf_node.child("coeffs")) {
+    coeffs = surf_node.child_value("coeffs");
+  } else {
+    std::cout << "ERROR: Found a surface with no coefficients" << std::endl;
+  }
+
+  int stat = sscanf(coeffs, "%lf %lf %lf %lf %lf %lf %lf %lf %lf %lf",
+                    &c1, &c2, &c3, &c4, &c5, &c6, &c7, &c8, &c9, &c10);
+  if (stat != 10) {
+    std::cout << "Something went wrong reading surface coeffs!" << std::endl;
+  }
+}
+
+//==============================================================================
 // SURFACE type defines a first- or second-order surface that can be used to
 // construct closed volumes (cells)
 //==============================================================================
@@ -115,11 +191,7 @@ public:
 };
 
 SurfaceXPlane::SurfaceXPlane(pugi::xml_node surf_node) {
-  const char *coeffs = surf_node.attribute("coeffs").value();
-  int stat = sscanf(coeffs, "%lf", &x0);
-  if (stat != 1) {
-    std::cout << "Something went wrong reading surface coeffs!" << std::endl;
-  }
+  read_coeffs(surf_node, x0);
 }
 
 inline double SurfaceXPlane::evaluate(const double xyz[3]) const {
@@ -151,11 +223,7 @@ public:
 };
 
 SurfaceYPlane::SurfaceYPlane(pugi::xml_node surf_node) {
-  const char *coeffs = surf_node.attribute("coeffs").value();
-  int stat = sscanf(coeffs, "%lf", &y0);
-  if (stat != 1) {
-    std::cout << "Something went wrong reading surface coeffs!" << std::endl;
-  }
+  read_coeffs(surf_node, y0);
 }
 
 inline double SurfaceYPlane::evaluate(const double xyz[3]) const {
@@ -187,11 +255,7 @@ public:
 };
 
 SurfaceZPlane::SurfaceZPlane(pugi::xml_node surf_node) {
-  const char *coeffs = surf_node.attribute("coeffs").value();
-  int stat = sscanf(coeffs, "%lf", &z0);
-  if (stat != 1) {
-    std::cout << "Something went wrong reading surface coeffs!" << std::endl;
-  }
+  read_coeffs(surf_node, z0);
 }
 
 inline double SurfaceZPlane::evaluate(const double xyz[3]) const {
@@ -223,11 +287,7 @@ public:
 };
 
 SurfacePlane::SurfacePlane(pugi::xml_node surf_node) {
-  const char *coeffs = surf_node.attribute("coeffs").value();
-  int stat = sscanf(coeffs, "%lf %lf %lf %lf", &A, &B, &C, &D);
-  if (stat != 4) {
-    std::cout << "Something went wrong reading surface coeffs!" << std::endl;
-  }
+  read_coeffs(surf_node, A, B, C, D);
 }
 
 double
@@ -336,11 +396,7 @@ public:
 };
 
 SurfaceXCylinder::SurfaceXCylinder(pugi::xml_node surf_node) {
-  const char *coeffs = surf_node.attribute("coeffs").value();
-  int stat = sscanf(coeffs, "%lf %lf %lf", &y0, &z0, &r);
-  if (stat != 3) {
-    std::cout << "Something went wrong reading surface coeffs!" << std::endl;
-  }
+  read_coeffs(surf_node, y0, z0, r);
 }
 
 inline double SurfaceXCylinder::evaluate(const double xyz[3]) const {
@@ -375,11 +431,7 @@ public:
 };
 
 SurfaceYCylinder::SurfaceYCylinder(pugi::xml_node surf_node) {
-  const char *coeffs = surf_node.attribute("coeffs").value();
-  int stat = sscanf(coeffs, "%lf %lf %lf", &x0, &z0, &r);
-  if (stat != 3) {
-    std::cout << "Something went wrong reading surface coeffs!" << std::endl;
-  }
+  read_coeffs(surf_node, x0, z0, r);
 }
 
 inline double SurfaceYCylinder::evaluate(const double xyz[3]) const {
@@ -412,11 +464,7 @@ public:
 };
 
 SurfaceZCylinder::SurfaceZCylinder(pugi::xml_node surf_node) {
-  const char *coeffs = surf_node.attribute("coeffs").value();
-  int stat = sscanf(coeffs, "%lf %lf %lf", &x0, &y0, &r);
-  if (stat != 3) {
-    std::cout << "Something went wrong reading surface coeffs!" << std::endl;
-  }
+  read_coeffs(surf_node, x0, y0, r);
 }
 
 inline double SurfaceZCylinder::evaluate(const double xyz[3]) const {
@@ -449,11 +497,7 @@ public:
 };
 
 SurfaceSphere::SurfaceSphere(pugi::xml_node surf_node) {
-  const char *coeffs = surf_node.attribute("coeffs").value();
-  int stat = sscanf(coeffs, "%lf %lf %lf %lf", &x0, &y0, &z0, &r);
-  if (stat != 4) {
-    std::cout << "Something went wrong reading surface coeffs!" << std::endl;
-  }
+  read_coeffs(surf_node, x0, y0, z0, r);
 }
 
 double SurfaceSphere::evaluate(const double xyz[3]) const {
@@ -596,11 +640,7 @@ public:
 };
 
 SurfaceXCone::SurfaceXCone(pugi::xml_node surf_node) {
-  const char *coeffs = surf_node.attribute("coeffs").value();
-  int stat = sscanf(coeffs, "%lf %lf %lf %lf", &x0, &y0, &z0, &r_sq);
-  if (stat != 4) {
-    std::cout << "Something went wrong reading surface coeffs!" << std::endl;
-  }
+  read_coeffs(surf_node, x0, y0, z0, r_sq);
 }
 
 inline double SurfaceXCone::evaluate(const double xyz[3]) const {
@@ -635,11 +675,7 @@ public:
 };
 
 SurfaceYCone::SurfaceYCone(pugi::xml_node surf_node) {
-  const char *coeffs = surf_node.attribute("coeffs").value();
-  int stat = sscanf(coeffs, "%lf %lf %lf %lf", &x0, &y0, &z0, &r_sq);
-  if (stat != 4) {
-    std::cout << "Something went wrong reading surface coeffs!" << std::endl;
-  }
+  read_coeffs(surf_node, x0, y0, z0, r_sq);
 }
 
 inline double SurfaceYCone::evaluate(const double xyz[3]) const {
@@ -672,11 +708,7 @@ public:
 };
 
 SurfaceZCone::SurfaceZCone(pugi::xml_node surf_node) {
-  const char *coeffs = surf_node.attribute("coeffs").value();
-  int stat = sscanf(coeffs, "%lf %lf %lf %lf", &x0, &y0, &z0, &r_sq);
-  if (stat != 4) {
-    std::cout << "Something went wrong reading surface coeffs!" << std::endl;
-  }
+  read_coeffs(surf_node, x0, y0, z0, r_sq);
 }
 
 inline double SurfaceZCone::evaluate(const double xyz[3]) const {
@@ -709,12 +741,7 @@ public:
 };
 
 SurfaceQuadric::SurfaceQuadric(pugi::xml_node surf_node) {
-  const char *coeffs = surf_node.attribute("coeffs").value();
-  int stat = sscanf(coeffs, "%lf %lf %lf %lf %lf %lf %lf %lf %lf %lf",
-                    &A, &B, &C, &D, &E, &F, &G, &H, &J, &K);
-  if (stat != 10) {
-    std::cout << "Something went wrong reading surface coeffs!" << std::endl;
-  }
+  read_coeffs(surf_node, A, B, C, D, E, F, G, H, J, K);
 }
 
 double
@@ -811,49 +838,55 @@ read_surfaces(pugi::xml_node *node) {
     int i_surf;
     for (surf_node = node->child("surface"), i_surf = 0; surf_node;
          surf_node = surf_node.next_sibling("surface"), i_surf++) {
+      const pugi::char_t *surf_type;
       if (surf_node.attribute("type")) {
-        const pugi::char_t *surf_type = surf_node.attribute("type").value();
+        surf_type = surf_node.attribute("type").value();
+      } else if (surf_node.child("type")) {
+        surf_type = surf_node.child_value("type");
+      } else {
+        std::cout << "ERROR: Found a surface with no type attribute/node"
+             << std::endl;
+      }
 
-        if (strcmp(surf_type, "x-plane") == 0) {
-          surfaces_c[i_surf] = new SurfaceXPlane(surf_node);
+      if (strcmp(surf_type, "x-plane") == 0) {
+        surfaces_c[i_surf] = new SurfaceXPlane(surf_node);
 
-        } else if (strcmp(surf_type, "y-plane") == 0) {
-          surfaces_c[i_surf] = new SurfaceYPlane(surf_node);
+      } else if (strcmp(surf_type, "y-plane") == 0) {
+        surfaces_c[i_surf] = new SurfaceYPlane(surf_node);
 
-        } else if (strcmp(surf_type, "z-plane") == 0) {
-          surfaces_c[i_surf] = new SurfaceZPlane(surf_node);
+      } else if (strcmp(surf_type, "z-plane") == 0) {
+        surfaces_c[i_surf] = new SurfaceZPlane(surf_node);
 
-        } else if (strcmp(surf_type, "plane") == 0) {
-          surfaces_c[i_surf] = new SurfacePlane(surf_node);
+      } else if (strcmp(surf_type, "plane") == 0) {
+        surfaces_c[i_surf] = new SurfacePlane(surf_node);
 
-        } else if (strcmp(surf_type, "x-cylinder") == 0) {
-          surfaces_c[i_surf] = new SurfaceXCylinder(surf_node);
+      } else if (strcmp(surf_type, "x-cylinder") == 0) {
+        surfaces_c[i_surf] = new SurfaceXCylinder(surf_node);
 
-        } else if (strcmp(surf_type, "y-cylinder") == 0) {
-          surfaces_c[i_surf] = new SurfaceYCylinder(surf_node);
+      } else if (strcmp(surf_type, "y-cylinder") == 0) {
+        surfaces_c[i_surf] = new SurfaceYCylinder(surf_node);
 
-        } else if (strcmp(surf_type, "z-cylinder") == 0) {
-          surfaces_c[i_surf] = new SurfaceZCylinder(surf_node);
+      } else if (strcmp(surf_type, "z-cylinder") == 0) {
+        surfaces_c[i_surf] = new SurfaceZCylinder(surf_node);
 
-        } else if (strcmp(surf_type, "sphere") == 0) {
-          surfaces_c[i_surf] = new SurfaceSphere(surf_node);
+      } else if (strcmp(surf_type, "sphere") == 0) {
+        surfaces_c[i_surf] = new SurfaceSphere(surf_node);
 
-        } else if (strcmp(surf_type, "x-cone") == 0) {
-          surfaces_c[i_surf] = new SurfaceXCone(surf_node);
+      } else if (strcmp(surf_type, "x-cone") == 0) {
+        surfaces_c[i_surf] = new SurfaceXCone(surf_node);
 
-        } else if (strcmp(surf_type, "y-cone") == 0) {
-          surfaces_c[i_surf] = new SurfaceYCone(surf_node);
+      } else if (strcmp(surf_type, "y-cone") == 0) {
+        surfaces_c[i_surf] = new SurfaceYCone(surf_node);
 
-        } else if (strcmp(surf_type, "z-cone") == 0) {
-          surfaces_c[i_surf] = new SurfaceZCone(surf_node);
+      } else if (strcmp(surf_type, "z-cone") == 0) {
+        surfaces_c[i_surf] = new SurfaceZCone(surf_node);
 
-        } else if (strcmp(surf_type, "quadric") == 0) {
-          surfaces_c[i_surf] = new SurfaceQuadric(surf_node);
+      } else if (strcmp(surf_type, "quadric") == 0) {
+        surfaces_c[i_surf] = new SurfaceQuadric(surf_node);
 
-        } else {
-          std::cout << "Call error or handle uppercase here!" << std::endl;
-          std::cout << surf_type << std::endl;
-        }
+      } else {
+        std::cout << "Call error or handle uppercase here!" << std::endl;
+        std::cout << surf_type << std::endl;
       }
     }
   }

--- a/src/surface_header.C
+++ b/src/surface_header.C
@@ -233,8 +233,8 @@ class SurfaceXPlane : public PeriodicSurface
 public:
   SurfaceXPlane(pugi::xml_node surf_node);
   double evaluate(const double xyz[3]) const;
-  double distance(const double xyz[3], const double uvw[3],
-                  const bool coincident) const;
+  double distance(const double xyz[3], const double uvw[3], bool coincident)
+         const;
   void normal(const double xyz[3], double uvw[3]) const;
   bool periodic_translate(PeriodicSurface *other, double xyz[3], double uvw[3])
        const;
@@ -416,8 +416,8 @@ class SurfacePlane : public PeriodicSurface
 public:
   SurfacePlane(pugi::xml_node surf_node);
   double evaluate(const double xyz[3]) const;
-  double distance(const double xyz[3], const double uvw[3],
-                  const bool coincident) const;
+  double distance(const double xyz[3], const double uvw[3], bool coincident)
+         const;
   void normal(const double xyz[3], double uvw[3]) const;
   bool periodic_translate(PeriodicSurface *other, double xyz[3], double uvw[3])
        const;
@@ -1136,6 +1136,12 @@ extern "C" bool
 surface_sense(int surf_ind, double xyz[3], double uvw[3])
 {
   return surfaces_c[surf_ind]->sense(xyz, uvw);
+}
+
+extern "C" void
+surface_reflect(int surf_ind, double xyz[3], double uvw[3])
+{
+  surfaces_c[surf_ind]->reflect(xyz, uvw);
 }
 
 extern "C" double

--- a/src/surface_header.C
+++ b/src/surface_header.C
@@ -1,0 +1,280 @@
+#include <cstring>  // For strcmp
+#include <iostream>
+#include <limits>  // For numeric_limits
+#include <math.h>  // For fabs
+#include "pugixml/pugixml.hpp"
+
+//==============================================================================
+// Constants
+//==============================================================================
+
+const double FP_COINCIDENT = 1e-12;
+const double INFTY = std::numeric_limits<double>::max();
+
+//==============================================================================
+// Global array of surfaces
+//==============================================================================
+
+class Surface;
+Surface **surfaces_c;
+
+//==============================================================================
+// SURFACE type defines a first- or second-order surface that can be used to
+// construct closed volumes (cells)
+//==============================================================================
+
+class Surface
+{
+  int id;                    // Unique ID
+  int neighbor_pos[],        // List of cells on positive side
+      neighbor_neg[];        // List of cells on negative side
+  int bc;                    // Boundary condition
+  //TODO: swith that zero to a NONE constant.
+  int i_periodic = 0;        // Index of corresponding periodic surface
+  char name[104];            // User-defined name
+
+public:
+  bool sense(double xyz[3], double uvw[3]);
+  void reflect(double xyz[3], double uvw[3]);
+  virtual double evaluate(double xyz[3]) = 0;
+  virtual double distance(double xyz[3], double uvw[3], bool coincident) = 0;
+  virtual void normal(double xyz[3], double uvw[3]) = 0;
+};
+
+bool
+Surface::sense(double xyz[3], double uvw[3])
+{
+  // Evaluate the surface equation at the particle's coordinates to determine
+  // which side the particle is on.
+  const double f = evaluate(xyz);
+
+  // Check which side of surface the point is on.
+  bool s;
+  if (fabs(f) < FP_COINCIDENT)
+  {
+    // Particle may be coincident with this surface. To determine the sense, we
+    // look at the direction of the particle relative to the surface normal (by
+    // default in the positive direction) via their dot product.
+    double norm[3];
+    normal(xyz, norm);
+    s = (uvw[0] * norm[0] + uvw[1] * norm[1] + uvw[2] * norm[2] > 0.0);
+  }
+  else
+  {
+    s = (f > 0.0);
+  }
+  return s;
+}
+
+void
+Surface::reflect(double xyz[3], double uvw[3])
+{
+
+  // Determine projection of direction onto normal and squared magnitude of
+  // normal.
+  double norm[3];
+  normal(xyz, norm);
+  const double projection = norm[0]*uvw[0] + norm[1]*uvw[1] + norm[2]*uvw[2];
+  const double magnitude = norm[0]*norm[0] + norm[1]*norm[1] + norm[2]*norm[2];
+
+  // Reflect direction according to normal.
+  uvw[0] -= 2.0 * projection / magnitude * norm[0];
+  uvw[1] -= 2.0 * projection / magnitude * norm[1];
+  uvw[2] -= 2.0 * projection / magnitude * norm[2];
+}
+
+//==============================================================================
+
+class SurfaceZPlane : public Surface
+{
+  double z0;
+public:
+  SurfaceZPlane(pugi::xml_node surf_node);
+  double evaluate(double xyz[3]);
+  double distance(double xyz[3], double uvw[3], bool coincident);
+  void normal(double xyz[3], double uvw[3]);
+};
+
+SurfaceZPlane::SurfaceZPlane(pugi::xml_node surf_node)
+{
+  const char *coeffs = surf_node.attribute("coeffs").value();
+  int stat = sscanf(coeffs, "%lf", &z0);
+  if (stat != 1)
+  {
+    std::cout << "Something went wrong reading surface coeffs!" << std::endl;
+  }
+}
+
+double
+SurfaceZPlane::evaluate(double xyz[3])
+{
+  double f = xyz[2] - z0;
+  return f;
+}
+
+double
+SurfaceZPlane::distance(double xyz[3], double uvw[3], bool coincident)
+{
+  double f = z0 - xyz[2];
+  double d;
+  if (coincident or fabs(f) < FP_COINCIDENT or uvw[2] == 0.0)
+  {
+    d = INFTY;
+  }
+  else
+  {
+    d = f / uvw[2];
+    if (d < 0.0) d = INFTY;
+  }
+  return d;
+}
+
+void
+SurfaceZPlane::normal(double xyz[3], double uvw[3])
+{
+  uvw[0] = 0.0;
+  uvw[1] = 0.0;
+  uvw[2] = 1.0;
+}
+
+//==============================================================================
+
+class SurfaceZCylinder : public Surface
+{
+  double x0, y0, r;
+public:
+  SurfaceZCylinder(pugi::xml_node surf_node);
+  double evaluate(double xyz[3]);
+  double distance(double xyz[3], double uvw[3], bool coincident);
+  void normal(double xyz[3], double uvw[3]);
+};
+
+SurfaceZCylinder::SurfaceZCylinder(pugi::xml_node surf_node)
+{
+  const char *coeffs = surf_node.attribute("coeffs").value();
+  int stat = sscanf(coeffs, "%lf %lf %lf", &x0, &y0, &r);
+  if (stat != 3)
+  {
+    std::cout << "Something went wrong reading surface coeffs!" << std::endl;
+  }
+}
+
+double
+SurfaceZCylinder::evaluate(double xyz[3])
+{
+  const double x = xyz[0] - x0;
+  const double y = xyz[1] - y0;
+  double f = x*x + y*y - r*r;
+  return f;
+}
+
+double
+SurfaceZCylinder::distance(double xyz[3], double uvw[3], bool coincident)
+{
+  double a = 1.0 - uvw[2]*uvw[2];  // u^2 + v^2
+
+  if (a == 0.0) return INFTY;
+
+  double x = xyz[0] - x0;
+  double y = xyz[1] - y0;
+  double k = x*uvw[0] + y*uvw[1];
+  double c = x*x + y*y - r*r;
+  double quad = k*k - a*c;
+
+  if (quad < 0.0)
+  {
+    // No intersection with cylinder.
+    return INFTY;
+  }
+  else if (coincident or fabs(c) < FP_COINCIDENT)
+  {
+    // Particle is on the cylinder, thus one distance is positive/negative
+    // and the other is zero. The sign of k determines if we are facing in or
+    // out.
+    if (k >= 0.0) return INFTY;
+    else return (-k + sqrt(quad)) / a;
+  }
+  else if (c < 0.0)
+  {
+    // Particle is inside the cylinder, thus one distance must be negative
+    // and one must be positive. The positive distance will be the one with
+    // negative sign on sqrt(quad)
+    return (-k + sqrt(quad)) / a;
+  }
+  else
+  {
+    // Particle is outside the cylinder, thus both distances are either
+    // positive or negative. If positive, the smaller distance is the one
+    // with positive sign on sqrt(quad)
+
+    double d = (-k - sqrt(quad)) / a;
+    if (d < 0.0) return INFTY;
+    return d;
+  }
+}
+
+void
+SurfaceZCylinder::normal(double xyz[3], double uvw[3])
+{
+  uvw[0] = 2.0 * (xyz[0] - x0);
+  uvw[1] = 2.0 * (xyz[1] - y0);
+  uvw[2] = 0.0;
+}
+
+//==============================================================================
+
+extern "C" void
+read_surfaces(pugi::xml_node *node)
+{
+  // Count the number of surfaces.
+  int n_surfaces = 0;
+  for (pugi::xml_node surf_node = node->child("surface"); surf_node;
+       surf_node = surf_node.next_sibling("surface"))
+  {
+    n_surfaces += 1;
+  }
+
+  // Allocate the array of Surface pointers.
+  surfaces_c = new Surface* [n_surfaces];
+
+  // Loop over XML surface elements and populate the array.
+  {
+    pugi::xml_node surf_node;
+    int i_surf;
+    for (surf_node = node->child("surface"), i_surf = 0; surf_node;
+         surf_node = surf_node.next_sibling("surface"), i_surf++)
+    {
+      if (surf_node.attribute("type"))
+      {
+        const pugi::char_t *surf_type = surf_node.attribute("type").value();
+        if (strcmp(surf_type, "z-cylinder") == 0)
+        {
+          surfaces_c[i_surf] = new SurfaceZCylinder(surf_node);
+        }
+        else if (strcmp(surf_type, "z-plane") == 0)
+        {
+          surfaces_c[i_surf] = new SurfaceZPlane(surf_node);
+        }
+        else
+        {
+          std::cout << "Call error or handle uppercase here!" << std::endl;
+          std::cout << surf_type << std::endl;
+        }
+      }
+    }
+  }
+}
+
+//==============================================================================
+
+extern "C" bool
+surface_sense(int surf_ind, double xyz[3], double uvw[3])
+{
+  return surfaces_c[surf_ind]->sense(xyz, uvw);
+}
+
+extern "C" double
+surface_distance(int surf_ind, double xyz[3], double uvw[3], bool coincident)
+{
+  return surfaces_c[surf_ind]->distance(xyz, uvw, coincident);
+}

--- a/src/surface_header.F90
+++ b/src/surface_header.F90
@@ -2,7 +2,7 @@ module surface_header
 
   use, intrinsic :: ISO_C_BINDING
 
-  use constants, only: NONE, ONE, TWO, ZERO, HALF, INFINITY, FP_COINCIDENT
+  use constants, only: NONE
   use dict_header, only: DictIntInt
 
   implicit none
@@ -20,19 +20,7 @@ module surface_header
     integer :: bc                     ! Boundary condition
     integer :: i_periodic = NONE      ! Index of corresponding periodic surface
     character(len=104) :: name = ""   ! User-defined name
-  contains
-    procedure :: reflect
-    procedure(surface_normal_),   deferred :: normal
   end type Surface
-
-  abstract interface
-    pure function surface_normal_(this, xyz) result(uvw)
-      import Surface
-      class(Surface), intent(in) :: this
-      real(8), intent(in) :: xyz(3)
-      real(8) :: uvw(3)
-    end function surface_normal_
-  end interface
 
 !===============================================================================
 ! SURFACECONTAINER allows us to store an array of different types of surfaces
@@ -50,22 +38,16 @@ module surface_header
   type, extends(Surface) :: SurfaceXPlane
     ! x = x0
     real(8) :: x0
-  contains
-    procedure :: normal => x_plane_normal
   end type SurfaceXPlane
 
   type, extends(Surface) :: SurfaceYPlane
     ! y = y0
     real(8) :: y0
-  contains
-    procedure :: normal => y_plane_normal
   end type SurfaceYPlane
 
   type, extends(Surface) :: SurfaceZPlane
     ! z = z0
     real(8) :: z0
-  contains
-    procedure :: normal => z_plane_normal
   end type SurfaceZPlane
 
   type, extends(Surface) :: SurfacePlane
@@ -74,8 +56,6 @@ module surface_header
     real(8) :: B
     real(8) :: C
     real(8) :: D
-  contains
-    procedure :: normal => plane_normal
   end type SurfacePlane
 
   type, extends(Surface) :: SurfaceXCylinder
@@ -83,8 +63,6 @@ module surface_header
     real(8) :: y0
     real(8) :: z0
     real(8) :: r
-  contains
-    procedure :: normal => x_cylinder_normal
   end type SurfaceXCylinder
 
   type, extends(Surface) :: SurfaceYCylinder
@@ -92,8 +70,6 @@ module surface_header
     real(8) :: x0
     real(8) :: z0
     real(8) :: r
-  contains
-    procedure :: normal => y_cylinder_normal
   end type SurfaceYCylinder
 
   type, extends(Surface) :: SurfaceZCylinder
@@ -101,8 +77,6 @@ module surface_header
     real(8) :: x0
     real(8) :: y0
     real(8) :: r
-  contains
-    procedure :: normal => z_cylinder_normal
   end type SurfaceZCylinder
 
   type, extends(Surface) :: SurfaceSphere
@@ -111,8 +85,6 @@ module surface_header
     real(8) :: y0
     real(8) :: z0
     real(8) :: r
-  contains
-    procedure :: normal => sphere_normal
   end type SurfaceSphere
 
   type, extends(Surface) :: SurfaceXCone
@@ -121,8 +93,6 @@ module surface_header
     real(8) :: y0
     real(8) :: z0
     real(8) :: r2
-  contains
-    procedure :: normal => x_cone_normal
   end type SurfaceXCone
 
   type, extends(Surface) :: SurfaceYCone
@@ -131,8 +101,6 @@ module surface_header
     real(8) :: y0
     real(8) :: z0
     real(8) :: r2
-  contains
-    procedure :: normal => y_cone_normal
   end type SurfaceYCone
 
   type, extends(Surface) :: SurfaceZCone
@@ -141,15 +109,11 @@ module surface_header
     real(8) :: y0
     real(8) :: z0
     real(8) :: r2
-  contains
-    procedure :: normal => z_cone_normal
   end type SurfaceZCone
 
   type, extends(Surface) :: SurfaceQuadric
     ! Ax^2 + By^2 + Cz^2 + Dxy + Eyz + Fxz + Gx + Hy + Jz + K = 0
     real(8) :: A, B, C, D, E, F, G, H, J, K
-  contains
-    procedure :: normal => quadric_normal
   end type SurfaceQuadric
 
   integer(C_INT32_T), bind(C) :: n_surfaces  ! # of surfaces
@@ -160,194 +124,6 @@ module surface_header
   type(DictIntInt) :: surface_dict
 
 contains
-
-!===============================================================================
-! REFLECT determines the direction a particle will travel if it is specularly
-! reflected from the surface at a given position and direction. The position is
-! needed because the reflection is performed using the surface normal, which
-! depends on the position for second-order surfaces.
-!===============================================================================
-
-  pure subroutine reflect(this, xyz, uvw)
-    class(Surface), intent(in) :: this
-    real(8), intent(in) :: xyz(3)
-    real(8), intent(inout) :: uvw(3)
-
-    real(8) :: projection
-    real(8) :: magnitude
-    real(8) :: n(3)
-
-    ! Construct normal vector
-    n(:) = this%normal(xyz)
-
-    ! Determine projection of direction onto normal and squared magnitude of
-    ! normal
-    projection = n(1)*uvw(1) + n(2)*uvw(2) + n(3)*uvw(3)
-    magnitude = n(1)*n(1) + n(2)*n(2) + n(3)*n(3)
-
-    ! Reflect direction according to normal
-    uvw(:) = uvw - TWO*projection/magnitude * n
-  end subroutine reflect
-
-!===============================================================================
-! SurfaceXPlane Implementation
-!===============================================================================
-
-  pure function x_plane_normal(this, xyz) result(uvw)
-    class(SurfaceXPlane), intent(in) :: this
-    real(8), intent(in) :: xyz(3)
-    real(8) :: uvw(3)
-
-    uvw(:) = [ONE, ZERO, ZERO]
-  end function x_plane_normal
-
-!===============================================================================
-! SurfaceYPlane Implementation
-!===============================================================================
-
-  pure function y_plane_normal(this, xyz) result(uvw)
-    class(SurfaceYPlane), intent(in) :: this
-    real(8), intent(in) :: xyz(3)
-    real(8) :: uvw(3)
-
-    uvw(:) = [ZERO, ONE, ZERO]
-  end function y_plane_normal
-
-!===============================================================================
-! SurfaceZPlane Implementation
-!===============================================================================
-
-  pure function z_plane_normal(this, xyz) result(uvw)
-    class(SurfaceZPlane), intent(in) :: this
-    real(8), intent(in) :: xyz(3)
-    real(8) :: uvw(3)
-
-    uvw(:) = [ZERO, ZERO, ONE]
-  end function z_plane_normal
-
-!===============================================================================
-! SurfacePlane Implementation
-!===============================================================================
-
-  pure function plane_normal(this, xyz) result(uvw)
-    class(SurfacePlane), intent(in) :: this
-    real(8), intent(in) :: xyz(3)
-    real(8) :: uvw(3)
-
-    uvw(:) = [this%A, this%B, this%C]
-  end function plane_normal
-
-!===============================================================================
-! SurfaceXCylinder Implementation
-!===============================================================================
-
-  pure function x_cylinder_normal(this, xyz) result(uvw)
-    class(SurfaceXCylinder), intent(in) :: this
-    real(8), intent(in) :: xyz(3)
-    real(8) :: uvw(3)
-
-    uvw(1) = ZERO
-    uvw(2) = TWO*(xyz(2) - this%y0)
-    uvw(3) = TWO*(xyz(3) - this%z0)
-  end function x_cylinder_normal
-
-!===============================================================================
-! SurfaceYCylinder Implementation
-!===============================================================================
-
-  pure function y_cylinder_normal(this, xyz) result(uvw)
-    class(SurfaceYCylinder), intent(in) :: this
-    real(8), intent(in) :: xyz(3)
-    real(8) :: uvw(3)
-
-    uvw(1) = TWO*(xyz(1) - this%x0)
-    uvw(2) = ZERO
-    uvw(3) = TWO*(xyz(3) - this%z0)
-  end function y_cylinder_normal
-
-!===============================================================================
-! SurfaceZCylinder Implementation
-!===============================================================================
-
-  pure function z_cylinder_normal(this, xyz) result(uvw)
-    class(SurfaceZCylinder), intent(in) :: this
-    real(8), intent(in) :: xyz(3)
-    real(8) :: uvw(3)
-
-    uvw(1) = TWO*(xyz(1) - this%x0)
-    uvw(2) = TWO*(xyz(2) - this%y0)
-    uvw(3) = ZERO
-  end function z_cylinder_normal
-
-!===============================================================================
-! SurfaceSphere Implementation
-!===============================================================================
-
-  pure function sphere_normal(this, xyz) result(uvw)
-    class(SurfaceSphere), intent(in) :: this
-    real(8), intent(in) :: xyz(3)
-    real(8) :: uvw(3)
-
-    uvw(:) = TWO*(xyz - [this%x0, this%y0, this%z0])
-  end function sphere_normal
-
-!===============================================================================
-! SurfaceXCone Implementation
-!===============================================================================
-
-  pure function x_cone_normal(this, xyz) result(uvw)
-    class(SurfaceXCone), intent(in) :: this
-    real(8), intent(in) :: xyz(3)
-    real(8) :: uvw(3)
-
-    uvw(1) = -TWO*this%r2*(xyz(1) - this%x0)
-    uvw(2) = TWO*(xyz(2) - this%y0)
-    uvw(3) = TWO*(xyz(3) - this%z0)
-  end function x_cone_normal
-
-!===============================================================================
-! SurfaceYCone Implementation
-!===============================================================================
-
-  pure function y_cone_normal(this, xyz) result(uvw)
-    class(SurfaceYCone), intent(in) :: this
-    real(8), intent(in) :: xyz(3)
-    real(8) :: uvw(3)
-
-    uvw(1) = TWO*(xyz(1) - this%x0)
-    uvw(2) = -TWO*this%r2*(xyz(2) - this%y0)
-    uvw(3) = TWO*(xyz(3) - this%z0)
-  end function y_cone_normal
-
-!===============================================================================
-! SurfaceZCone Implementation
-!===============================================================================
-
-  pure function z_cone_normal(this, xyz) result(uvw)
-    class(SurfaceZCone), intent(in) :: this
-    real(8), intent(in) :: xyz(3)
-    real(8) :: uvw(3)
-
-    uvw(1) = TWO*(xyz(1) - this%x0)
-    uvw(2) = TWO*(xyz(2) - this%y0)
-    uvw(3) = -TWO*this%r2*(xyz(3) - this%z0)
-  end function z_cone_normal
-
-!===============================================================================
-! SurfaceQuadric Implementation
-!===============================================================================
-
-  pure function quadric_normal(this, xyz) result(uvw)
-    class(SurfaceQuadric), intent(in) :: this
-    real(8), intent(in) :: xyz(3)
-    real(8) :: uvw(3)
-
-    associate (x => xyz(1), y => xyz(2), z => xyz(3))
-      uvw(1) = TWO*this%A*x + this%D*y + this%F*z + this%G
-      uvw(2) = TWO*this%B*y + this%D*x + this%E*z + this%H
-      uvw(3) = TWO*this%C*z + this%E*y + this%F*x + this%J
-    end associate
-  end function quadric_normal
 
 !===============================================================================
 ! FREE_MEMORY_SURFACES deallocates global arrays defined in this module

--- a/src/surface_header.F90
+++ b/src/surface_header.F90
@@ -22,18 +22,10 @@ module surface_header
     character(len=104) :: name = ""   ! User-defined name
   contains
     procedure :: reflect
-    procedure(surface_evaluate_), deferred :: evaluate
     procedure(surface_normal_),   deferred :: normal
   end type Surface
 
   abstract interface
-    pure function surface_evaluate_(this, xyz) result(f)
-      import Surface
-      class(Surface), intent(in) :: this
-      real(8), intent(in) :: xyz(3)
-      real(8) :: f
-    end function surface_evaluate_
-
     pure function surface_normal_(this, xyz) result(uvw)
       import Surface
       class(Surface), intent(in) :: this
@@ -52,15 +44,13 @@ module surface_header
 
 !===============================================================================
 ! All the derived types below are extensions of the abstract Surface type. They
-! inherent the reflect() type-bound procedure and must implement evaluate(),
-! and normal()
+! inherent the reflect() type-bound procedure and must implement normal()
 !===============================================================================
 
   type, extends(Surface) :: SurfaceXPlane
     ! x = x0
     real(8) :: x0
   contains
-    procedure :: evaluate => x_plane_evaluate
     procedure :: normal => x_plane_normal
   end type SurfaceXPlane
 
@@ -68,7 +58,6 @@ module surface_header
     ! y = y0
     real(8) :: y0
   contains
-    procedure :: evaluate => y_plane_evaluate
     procedure :: normal => y_plane_normal
   end type SurfaceYPlane
 
@@ -76,7 +65,6 @@ module surface_header
     ! z = z0
     real(8) :: z0
   contains
-    procedure :: evaluate => z_plane_evaluate
     procedure :: normal => z_plane_normal
   end type SurfaceZPlane
 
@@ -87,7 +75,6 @@ module surface_header
     real(8) :: C
     real(8) :: D
   contains
-    procedure :: evaluate => plane_evaluate
     procedure :: normal => plane_normal
   end type SurfacePlane
 
@@ -97,7 +84,6 @@ module surface_header
     real(8) :: z0
     real(8) :: r
   contains
-    procedure :: evaluate => x_cylinder_evaluate
     procedure :: normal => x_cylinder_normal
   end type SurfaceXCylinder
 
@@ -107,7 +93,6 @@ module surface_header
     real(8) :: z0
     real(8) :: r
   contains
-    procedure :: evaluate => y_cylinder_evaluate
     procedure :: normal => y_cylinder_normal
   end type SurfaceYCylinder
 
@@ -117,7 +102,6 @@ module surface_header
     real(8) :: y0
     real(8) :: r
   contains
-    procedure :: evaluate => z_cylinder_evaluate
     procedure :: normal => z_cylinder_normal
   end type SurfaceZCylinder
 
@@ -128,7 +112,6 @@ module surface_header
     real(8) :: z0
     real(8) :: r
   contains
-    procedure :: evaluate => sphere_evaluate
     procedure :: normal => sphere_normal
   end type SurfaceSphere
 
@@ -139,7 +122,6 @@ module surface_header
     real(8) :: z0
     real(8) :: r2
   contains
-    procedure :: evaluate => x_cone_evaluate
     procedure :: normal => x_cone_normal
   end type SurfaceXCone
 
@@ -150,7 +132,6 @@ module surface_header
     real(8) :: z0
     real(8) :: r2
   contains
-    procedure :: evaluate => y_cone_evaluate
     procedure :: normal => y_cone_normal
   end type SurfaceYCone
 
@@ -161,7 +142,6 @@ module surface_header
     real(8) :: z0
     real(8) :: r2
   contains
-    procedure :: evaluate => z_cone_evaluate
     procedure :: normal => z_cone_normal
   end type SurfaceZCone
 
@@ -169,7 +149,6 @@ module surface_header
     ! Ax^2 + By^2 + Cz^2 + Dxy + Eyz + Fxz + Gx + Hy + Jz + K = 0
     real(8) :: A, B, C, D, E, F, G, H, J, K
   contains
-    procedure :: evaluate => quadric_evaluate
     procedure :: normal => quadric_normal
   end type SurfaceQuadric
 
@@ -214,14 +193,6 @@ contains
 ! SurfaceXPlane Implementation
 !===============================================================================
 
-  pure function x_plane_evaluate(this, xyz) result(f)
-    class(SurfaceXPlane), intent(in) :: this
-    real(8), intent(in) :: xyz(3)
-    real(8) :: f
-
-    f = xyz(1) - this%x0
-  end function x_plane_evaluate
-
   pure function x_plane_normal(this, xyz) result(uvw)
     class(SurfaceXPlane), intent(in) :: this
     real(8), intent(in) :: xyz(3)
@@ -233,14 +204,6 @@ contains
 !===============================================================================
 ! SurfaceYPlane Implementation
 !===============================================================================
-
-  pure function y_plane_evaluate(this, xyz) result(f)
-    class(SurfaceYPlane), intent(in) :: this
-    real(8), intent(in) :: xyz(3)
-    real(8) :: f
-
-    f = xyz(2) - this%y0
-  end function y_plane_evaluate
 
   pure function y_plane_normal(this, xyz) result(uvw)
     class(SurfaceYPlane), intent(in) :: this
@@ -254,16 +217,6 @@ contains
 ! SurfaceZPlane Implementation
 !===============================================================================
 
-  pure function z_plane_evaluate(this, xyz) result(f)
-
-    class(SurfaceZPlane), intent(in) :: this
-    real(8),        intent(in) :: xyz(3)
-    real(8)             :: f
-
-    f = xyz(3) - this%z0
-
-  end function z_plane_evaluate
-
   pure function z_plane_normal(this, xyz) result(uvw)
     class(SurfaceZPlane), intent(in) :: this
     real(8), intent(in) :: xyz(3)
@@ -276,14 +229,6 @@ contains
 ! SurfacePlane Implementation
 !===============================================================================
 
-  pure function plane_evaluate(this, xyz) result(f)
-    class(SurfacePlane), intent(in) :: this
-    real(8), intent(in) :: xyz(3)
-    real(8) :: f
-
-    f = this%A*xyz(1) + this%B*xyz(2) + this%C*xyz(3) - this%D
-  end function plane_evaluate
-
   pure function plane_normal(this, xyz) result(uvw)
     class(SurfacePlane), intent(in) :: this
     real(8), intent(in) :: xyz(3)
@@ -295,18 +240,6 @@ contains
 !===============================================================================
 ! SurfaceXCylinder Implementation
 !===============================================================================
-
-  pure function x_cylinder_evaluate(this, xyz) result(f)
-    class(SurfaceXCylinder), intent(in) :: this
-    real(8), intent(in) :: xyz(3)
-    real(8) :: f
-
-    real(8) :: y, z
-
-    y = xyz(2) - this%y0
-    z = xyz(3) - this%z0
-    f = y*y + z*z - this%r*this%r
-  end function x_cylinder_evaluate
 
   pure function x_cylinder_normal(this, xyz) result(uvw)
     class(SurfaceXCylinder), intent(in) :: this
@@ -322,18 +255,6 @@ contains
 ! SurfaceYCylinder Implementation
 !===============================================================================
 
-  pure function y_cylinder_evaluate(this, xyz) result(f)
-    class(SurfaceYCylinder), intent(in) :: this
-    real(8), intent(in) :: xyz(3)
-    real(8) :: f
-
-    real(8) :: x, z
-
-    x = xyz(1) - this%x0
-    z = xyz(3) - this%z0
-    f = x*x + z*z - this%r*this%r
-  end function y_cylinder_evaluate
-
   pure function y_cylinder_normal(this, xyz) result(uvw)
     class(SurfaceYCylinder), intent(in) :: this
     real(8), intent(in) :: xyz(3)
@@ -347,18 +268,6 @@ contains
 !===============================================================================
 ! SurfaceZCylinder Implementation
 !===============================================================================
-
-  pure function z_cylinder_evaluate(this, xyz) result(f)
-    class(SurfaceZCylinder), intent(in) :: this
-    real(8), intent(in) :: xyz(3)
-    real(8) :: f
-
-    real(8) :: x, y
-
-    x = xyz(1) - this%x0
-    y = xyz(2) - this%y0
-    f = x*x + y*y - this%r*this%r
-  end function z_cylinder_evaluate
 
   pure function z_cylinder_normal(this, xyz) result(uvw)
     class(SurfaceZCylinder), intent(in) :: this
@@ -374,19 +283,6 @@ contains
 ! SurfaceSphere Implementation
 !===============================================================================
 
-  pure function sphere_evaluate(this, xyz) result(f)
-    class(SurfaceSphere), intent(in) :: this
-    real(8), intent(in) :: xyz(3)
-    real(8) :: f
-
-    real(8) :: x, y, z
-
-    x = xyz(1) - this%x0
-    y = xyz(2) - this%y0
-    z = xyz(3) - this%z0
-    f = x*x + y*y + z*z - this%r*this%r
-  end function sphere_evaluate
-
   pure function sphere_normal(this, xyz) result(uvw)
     class(SurfaceSphere), intent(in) :: this
     real(8), intent(in) :: xyz(3)
@@ -398,19 +294,6 @@ contains
 !===============================================================================
 ! SurfaceXCone Implementation
 !===============================================================================
-
-  pure function x_cone_evaluate(this, xyz) result(f)
-    class(SurfaceXCone), intent(in) :: this
-    real(8), intent(in) :: xyz(3)
-    real(8) :: f
-
-    real(8) :: x, y, z
-
-    x = xyz(1) - this%x0
-    y = xyz(2) - this%y0
-    z = xyz(3) - this%z0
-    f = y*y + z*z - this%r2*x*x
-  end function x_cone_evaluate
 
   pure function x_cone_normal(this, xyz) result(uvw)
     class(SurfaceXCone), intent(in) :: this
@@ -426,19 +309,6 @@ contains
 ! SurfaceYCone Implementation
 !===============================================================================
 
-  pure function y_cone_evaluate(this, xyz) result(f)
-    class(SurfaceYCone), intent(in) :: this
-    real(8), intent(in) :: xyz(3)
-    real(8) :: f
-
-    real(8) :: x, y, z
-
-    x = xyz(1) - this%x0
-    y = xyz(2) - this%y0
-    z = xyz(3) - this%z0
-    f = x*x + z*z - this%r2*y*y
-  end function y_cone_evaluate
-
   pure function y_cone_normal(this, xyz) result(uvw)
     class(SurfaceYCone), intent(in) :: this
     real(8), intent(in) :: xyz(3)
@@ -453,19 +323,6 @@ contains
 ! SurfaceZCone Implementation
 !===============================================================================
 
-  pure function z_cone_evaluate(this, xyz) result(f)
-    class(SurfaceZCone), intent(in) :: this
-    real(8), intent(in) :: xyz(3)
-    real(8) :: f
-
-    real(8) :: x, y, z
-
-    x = xyz(1) - this%x0
-    y = xyz(2) - this%y0
-    z = xyz(3) - this%z0
-    f = x*x + y*y - this%r2*z*z
-  end function z_cone_evaluate
-
   pure function z_cone_normal(this, xyz) result(uvw)
     class(SurfaceZCone), intent(in) :: this
     real(8), intent(in) :: xyz(3)
@@ -479,18 +336,6 @@ contains
 !===============================================================================
 ! SurfaceQuadric Implementation
 !===============================================================================
-
-  pure function quadric_evaluate(this, xyz) result(f)
-    class(SurfaceQuadric), intent(in) :: this
-    real(8), intent(in) :: xyz(3)
-    real(8) :: f
-
-    associate (x => xyz(1), y => xyz(2), z => xyz(3))
-      f = x*(this%A*x + this%D*y + this%G) + &
-           y*(this%B*y + this%E*z + this%H) + &
-           z*(this%C*z + this%F*x + this%J) + this%K
-    end associate
-  end function quadric_evaluate
 
   pure function quadric_normal(this, xyz) result(uvw)
     class(SurfaceQuadric), intent(in) :: this

--- a/src/surface_header.F90
+++ b/src/surface_header.F90
@@ -126,7 +126,7 @@ module surface_header
 
   end type Surface
 
-  integer(C_INT), bind(C) :: n_surfaces  ! # of surfaces
+  integer(C_INT32_T), bind(C) :: n_surfaces  ! # of surfaces
 
   type(Surface), allocatable, target :: surfaces(:)
 

--- a/src/surface_header.F90
+++ b/src/surface_header.F90
@@ -12,68 +12,17 @@ module surface_header
 ! construct closed volumes (cells)
 !===============================================================================
 
-  type, abstract :: Surface
+  type :: Surface
     integer :: id                     ! Unique ID
     integer, allocatable :: &
          neighbor_pos(:), &           ! List of cells on positive side
          neighbor_neg(:)              ! List of cells on negative side
     integer :: bc                     ! Boundary condition
-    integer :: i_periodic = NONE      ! Index of corresponding periodic surface
-    character(len=104) :: name = ""   ! User-defined name
   end type Surface
-
-!===============================================================================
-! SURFACECONTAINER allows us to store an array of different types of surfaces
-!===============================================================================
-
-  type :: SurfaceContainer
-    class(Surface), allocatable :: obj
-  end type SurfaceContainer
-
-!===============================================================================
-! All the derived types below are extensions of the abstract Surface type. They
-! inherent the reflect() type-bound procedure and must implement normal()
-!===============================================================================
-
-  type, extends(Surface) :: SurfaceXPlane
-  end type SurfaceXPlane
-
-  type, extends(Surface) :: SurfaceYPlane
-  end type SurfaceYPlane
-
-  type, extends(Surface) :: SurfaceZPlane
-  end type SurfaceZPlane
-
-  type, extends(Surface) :: SurfacePlane
-  end type SurfacePlane
-
-  type, extends(Surface) :: SurfaceXCylinder
-  end type SurfaceXCylinder
-
-  type, extends(Surface) :: SurfaceYCylinder
-  end type SurfaceYCylinder
-
-  type, extends(Surface) :: SurfaceZCylinder
-  end type SurfaceZCylinder
-
-  type, extends(Surface) :: SurfaceSphere
-  end type SurfaceSphere
-
-  type, extends(Surface) :: SurfaceXCone
-  end type SurfaceXCone
-
-  type, extends(Surface) :: SurfaceYCone
-  end type SurfaceYCone
-
-  type, extends(Surface) :: SurfaceZCone
-  end type SurfaceZCone
-
-  type, extends(Surface) :: SurfaceQuadric
-  end type SurfaceQuadric
 
   integer(C_INT32_T), bind(C) :: n_surfaces  ! # of surfaces
 
-  type(SurfaceContainer), allocatable, target :: surfaces(:)
+  type(Surface), allocatable, target :: surfaces(:)
 
   ! Dictionary that maps user IDs to indices in 'surfaces'
   type(DictIntInt) :: surface_dict

--- a/src/surface_header.F90
+++ b/src/surface_header.F90
@@ -1,11 +1,105 @@
 module surface_header
 
   use, intrinsic :: ISO_C_BINDING
+  use hdf5
 
-  use constants, only: NONE
   use dict_header, only: DictIntInt
 
   implicit none
+
+  interface
+    pure function surface_pointer_c(surf_ind) &
+         bind(C, name='surface_pointer') result(ptr)
+      use ISO_C_BINDING
+      implicit none
+      integer(C_INT), intent(in), value :: surf_ind
+      type(C_PTR)                       :: ptr
+    end function surface_pointer_c
+
+    pure function surface_id_c(surf_ptr) bind(C, name='surface_id') result(id)
+      use ISO_C_BINDING
+      implicit none
+      type(C_PTR), intent(in), value :: surf_ptr
+      integer(C_INT)                 :: id
+    end function surface_id_c
+
+    pure function surface_bc_c(surf_ptr) bind(C, name='surface_bc') result(bc)
+      use ISO_C_BINDING
+      implicit none
+      type(C_PTR), intent(in), value :: surf_ptr
+      integer(C_INT)                 :: bc
+    end function surface_bc_c
+
+    pure function surface_sense_c(surf_ptr, xyz, uvw) &
+         bind(C, name='surface_sense') result(sense)
+      use ISO_C_BINDING
+      implicit none
+      type(C_PTR),    intent(in), value :: surf_ptr
+      real(C_DOUBLE), intent(in)        :: xyz(3)
+      real(C_DOUBLE), intent(in)        :: uvw(3)
+      logical(C_BOOL)                   :: sense
+    end function surface_sense_c
+
+    pure subroutine surface_reflect_c(surf_ptr, xyz, uvw) &
+         bind(C, name='surface_reflect')
+      use ISO_C_BINDING
+      implicit none
+      type(C_PTR),    intent(in), value :: surf_ptr
+      real(C_DOUBLE), intent(in)        :: xyz(3);
+      real(C_DOUBLE), intent(inout)     :: uvw(3);
+    end subroutine surface_reflect_c
+
+    pure function surface_distance_c(surf_ptr, xyz, uvw, coincident) &
+         bind(C, name='surface_distance') result(d)
+      use ISO_C_BINDING
+      implicit none
+      type(C_PTR),     intent(in), value :: surf_ptr
+      real(C_DOUBLE),  intent(in)        :: xyz(3);
+      real(C_DOUBLE),  intent(in)        :: uvw(3);
+      logical(C_BOOL), intent(in), value :: coincident;
+      real(C_DOUBLE)                     :: d;
+    end function surface_distance_c
+
+    pure subroutine surface_normal_c(surf_ptr, xyz, uvw) &
+         bind(C, name='surface_normal')
+      use ISO_C_BINDING
+      implicit none
+      type(C_PTR),    intent(in), value :: surf_ptr
+      real(C_DOUBLE), intent(in)        :: xyz(3);
+      real(C_DOUBLE), intent(out)       :: uvw(3);
+    end subroutine surface_normal_c
+
+    subroutine surface_to_hdf5_c(surf_ptr, group) &
+         bind(C, name='surface_to_hdf5')
+      use ISO_C_BINDING
+      use hdf5
+      implicit none
+      type(C_PTR),    intent(in), value :: surf_ptr
+      integer(HID_T), intent(in), value :: group
+    end subroutine surface_to_hdf5_c
+
+    pure function surface_i_periodic_c(surf_ptr) &
+         bind(C, name="surface_i_periodic") result(i_periodic)
+      use ISO_C_BINDING
+      implicit none
+      type(C_PTR),    intent(in), value :: surf_ptr
+      integer(C_INT)                    :: i_periodic
+    end function surface_i_periodic_c
+
+    function surface_periodic_c(surf_ptr, other_ptr, xyz, uvw) &
+         bind(C, name="surface_periodic") result(rotational)
+      use ISO_C_BINDING
+      implicit none
+      type(C_PTR),    intent(in), value :: surf_ptr
+      type(C_PTR),    intent(in), value :: other_ptr
+      real(C_DOUBLE), intent(inout)     :: xyz(3);
+      real(C_DOUBLE), intent(inout)     :: uvw(3);
+      logical(C_BOOL)                   :: rotational
+    end function surface_periodic_c
+
+    subroutine free_memory_surfaces_c() bind(C)
+    end subroutine free_memory_surfaces_c
+  end interface
 
 !===============================================================================
 ! SURFACE type defines a first- or second-order surface that can be used to
@@ -13,14 +107,26 @@ module surface_header
 !===============================================================================
 
   type :: Surface
-    integer :: id                     ! Unique ID
     integer, allocatable :: &
          neighbor_pos(:), &           ! List of cells on positive side
          neighbor_neg(:)              ! List of cells on negative side
-    integer :: bc                     ! Boundary condition
+    type(C_PTR) :: ptr
+
+  contains
+
+    procedure :: id => surface_id
+    procedure :: bc => surface_bc
+    procedure :: sense => surface_sense
+    procedure :: reflect => surface_reflect
+    procedure :: distance => surface_distance
+    procedure :: normal => surface_normal
+    procedure :: to_hdf5 => surface_to_hdf5
+    procedure :: i_periodic => surface_i_periodic
+    procedure :: periodic_translate => surface_periodic
+
   end type Surface
 
-  integer(C_INT32_T), bind(C) :: n_surfaces  ! # of surfaces
+  integer(C_INT), bind(C) :: n_surfaces  ! # of surfaces
 
   type(Surface), allocatable, target :: surfaces(:)
 
@@ -29,14 +135,78 @@ module surface_header
 
 contains
 
+  pure function surface_id(this) result(id)
+    class(Surface), intent(in) :: this
+    integer(C_INT)             :: id
+    id = surface_id_c(this % ptr)
+  end function surface_id
+
+  pure function surface_bc(this) result(bc)
+    class(Surface), intent(in) :: this
+    integer(C_INT)             :: bc
+    bc = surface_bc_c(this % ptr)
+  end function surface_bc
+
+  pure function surface_sense(this, xyz, uvw) result(sense)
+    class(Surface), intent(in) :: this
+    real(C_DOUBLE), intent(in) :: xyz(3)
+    real(C_DOUBLE), intent(in) :: uvw(3)
+    logical(C_BOOL)            :: sense
+    sense = surface_sense_c(this % ptr, xyz, uvw)
+  end function surface_sense
+
+  pure subroutine surface_reflect(this, xyz, uvw)
+    class(Surface), intent(in)    :: this
+    real(C_DOUBLE), intent(in)    :: xyz(3);
+    real(C_DOUBLE), intent(inout) :: uvw(3);
+    call surface_reflect_c(this % ptr, xyz, uvw)
+  end subroutine surface_reflect
+
+  pure function surface_distance(this, xyz, uvw, coincident) result(d)
+    class(Surface),  intent(in) :: this
+    real(C_DOUBLE),  intent(in) :: xyz(3);
+    real(C_DOUBLE),  intent(in) :: uvw(3);
+    logical(C_BOOL), intent(in) :: coincident;
+    real(C_DOUBLE)              :: d;
+    d = surface_distance_c(this % ptr, xyz, uvw, coincident)
+  end function surface_distance
+
+  pure subroutine surface_normal(this, xyz, uvw)
+    class(Surface), intent(in)  :: this
+    real(C_DOUBLE), intent(in)  :: xyz(3);
+    real(C_DOUBLE), intent(out) :: uvw(3);
+    call surface_normal_c(this % ptr, xyz, uvw)
+  end subroutine surface_normal
+
+  subroutine surface_to_hdf5(this, group)
+    class(Surface), intent(in) :: this
+    integer(HID_T), intent(in) :: group
+    call surface_to_hdf5_c(this % ptr, group)
+  end subroutine surface_to_hdf5
+
+  pure function surface_i_periodic(this) result(i_periodic)
+    class(Surface), intent(in)  :: this
+    integer(C_INT)              :: i_periodic
+    i_periodic = surface_i_periodic_c(this % ptr)
+  end function surface_i_periodic
+
+  function surface_periodic(this, other, xyz, uvw) result(rotational)
+    class(Surface), intent(in)    :: this
+    class(Surface), intent(in)    :: other
+    real(C_DOUBLE), intent(inout) :: xyz(3);
+    real(C_DOUBLE), intent(inout) :: uvw(3);
+    logical(C_BOOL)               :: rotational
+    rotational = surface_periodic_c(this % ptr, other % ptr, xyz, uvw)
+  end function surface_periodic
+
 !===============================================================================
 ! FREE_MEMORY_SURFACES deallocates global arrays defined in this module
 !===============================================================================
 
   subroutine free_memory_surfaces()
-    n_surfaces = 0
     if (allocated(surfaces)) deallocate(surfaces)
     call surface_dict % clear()
+    call free_memory_surfaces_c()
   end subroutine free_memory_surfaces
 
 end module surface_header

--- a/src/surface_header.F90
+++ b/src/surface_header.F90
@@ -21,10 +21,8 @@ module surface_header
     integer :: i_periodic = NONE      ! Index of corresponding periodic surface
     character(len=104) :: name = ""   ! User-defined name
   contains
-    procedure :: sense
     procedure :: reflect
     procedure(surface_evaluate_), deferred :: evaluate
-    procedure(surface_distance_), deferred :: distance
     procedure(surface_normal_),   deferred :: normal
   end type Surface
 
@@ -35,15 +33,6 @@ module surface_header
       real(8), intent(in) :: xyz(3)
       real(8) :: f
     end function surface_evaluate_
-
-    pure function surface_distance_(this, xyz, uvw, coincident) result(d)
-      import Surface
-      class(Surface), intent(in) :: this
-      real(8), intent(in) :: xyz(3)
-      real(8), intent(in) :: uvw(3)
-      logical, intent(in) :: coincident
-      real(8) :: d
-    end function surface_distance_
 
     pure function surface_normal_(this, xyz) result(uvw)
       import Surface
@@ -63,8 +52,8 @@ module surface_header
 
 !===============================================================================
 ! All the derived types below are extensions of the abstract Surface type. They
-! inherent the reflect() and sense() type-bound procedures and must implement
-! evaluate(), distance(), and normal()
+! inherent the reflect() type-bound procedure and must implement evaluate(),
+! and normal()
 !===============================================================================
 
   type, extends(Surface) :: SurfaceXPlane
@@ -72,7 +61,6 @@ module surface_header
     real(8) :: x0
   contains
     procedure :: evaluate => x_plane_evaluate
-    procedure :: distance => x_plane_distance
     procedure :: normal => x_plane_normal
   end type SurfaceXPlane
 
@@ -81,7 +69,6 @@ module surface_header
     real(8) :: y0
   contains
     procedure :: evaluate => y_plane_evaluate
-    procedure :: distance => y_plane_distance
     procedure :: normal => y_plane_normal
   end type SurfaceYPlane
 
@@ -90,7 +77,6 @@ module surface_header
     real(8) :: z0
   contains
     procedure :: evaluate => z_plane_evaluate
-    procedure :: distance => z_plane_distance
     procedure :: normal => z_plane_normal
   end type SurfaceZPlane
 
@@ -102,7 +88,6 @@ module surface_header
     real(8) :: D
   contains
     procedure :: evaluate => plane_evaluate
-    procedure :: distance => plane_distance
     procedure :: normal => plane_normal
   end type SurfacePlane
 
@@ -113,7 +98,6 @@ module surface_header
     real(8) :: r
   contains
     procedure :: evaluate => x_cylinder_evaluate
-    procedure :: distance => x_cylinder_distance
     procedure :: normal => x_cylinder_normal
   end type SurfaceXCylinder
 
@@ -124,7 +108,6 @@ module surface_header
     real(8) :: r
   contains
     procedure :: evaluate => y_cylinder_evaluate
-    procedure :: distance => y_cylinder_distance
     procedure :: normal => y_cylinder_normal
   end type SurfaceYCylinder
 
@@ -135,7 +118,6 @@ module surface_header
     real(8) :: r
   contains
     procedure :: evaluate => z_cylinder_evaluate
-    procedure :: distance => z_cylinder_distance
     procedure :: normal => z_cylinder_normal
   end type SurfaceZCylinder
 
@@ -147,7 +129,6 @@ module surface_header
     real(8) :: r
   contains
     procedure :: evaluate => sphere_evaluate
-    procedure :: distance => sphere_distance
     procedure :: normal => sphere_normal
   end type SurfaceSphere
 
@@ -159,7 +140,6 @@ module surface_header
     real(8) :: r2
   contains
     procedure :: evaluate => x_cone_evaluate
-    procedure :: distance => x_cone_distance
     procedure :: normal => x_cone_normal
   end type SurfaceXCone
 
@@ -171,7 +151,6 @@ module surface_header
     real(8) :: r2
   contains
     procedure :: evaluate => y_cone_evaluate
-    procedure :: distance => y_cone_distance
     procedure :: normal => y_cone_normal
   end type SurfaceYCone
 
@@ -183,7 +162,6 @@ module surface_header
     real(8) :: r2
   contains
     procedure :: evaluate => z_cone_evaluate
-    procedure :: distance => z_cone_distance
     procedure :: normal => z_cone_normal
   end type SurfaceZCone
 
@@ -192,7 +170,6 @@ module surface_header
     real(8) :: A, B, C, D, E, F, G, H, J, K
   contains
     procedure :: evaluate => quadric_evaluate
-    procedure :: distance => quadric_distance
     procedure :: normal => quadric_normal
   end type SurfaceQuadric
 
@@ -204,36 +181,6 @@ module surface_header
   type(DictIntInt) :: surface_dict
 
 contains
-
-!===============================================================================
-! SENSE determines whether a point is on the 'positive' or 'negative' side of a
-! surface. This routine is crucial for determining what cell a particular point
-! is in. The positive side is indicated by a returned value of .true. and the
-! negative side is indicated by a returned value of .false.
-!===============================================================================
-
-  pure function sense(this, xyz, uvw) result(s)
-    class(Surface), intent(in) :: this  ! surface
-    real(8), intent(in) :: xyz(3)
-    real(8), intent(in) :: uvw(3)
-    logical :: s  ! sense of particle
-
-    real(8) :: f  ! surface function evaluated at point
-
-    ! Evaluate the surface equation at the particle's coordinates to determine
-    ! which side the particle is on
-    f = this%evaluate(xyz)
-
-    ! Check which side of surface the point is on
-    if (abs(f) < FP_COINCIDENT) then
-      ! Particle may be coincident with this surface. To determine the sense, we
-      ! look at the direction of the particle relative to the surface normal (by
-      ! default in the positive direction) via their dot product.
-      s = (dot_product(uvw, this%normal(xyz)) > ZERO)
-    else
-      s = (f > ZERO)
-    end if
-  end function sense
 
 !===============================================================================
 ! REFLECT determines the direction a particle will travel if it is specularly
@@ -275,24 +222,6 @@ contains
     f = xyz(1) - this%x0
   end function x_plane_evaluate
 
-  pure function x_plane_distance(this, xyz, uvw, coincident) result(d)
-    class(SurfaceXPlane), intent(in) :: this
-    real(8), intent(in) :: xyz(3)
-    real(8), intent(in) :: uvw(3)
-    logical, intent(in) :: coincident
-    real(8) :: d
-
-    real(8) :: f
-
-    f = this%x0 - xyz(1)
-    if (coincident .or. abs(f) < FP_COINCIDENT .or. uvw(1) == ZERO) then
-      d = INFINITY
-    else
-      d = f/uvw(1)
-      if (d < ZERO) d = INFINITY
-    end if
-  end function x_plane_distance
-
   pure function x_plane_normal(this, xyz) result(uvw)
     class(SurfaceXPlane), intent(in) :: this
     real(8), intent(in) :: xyz(3)
@@ -312,24 +241,6 @@ contains
 
     f = xyz(2) - this%y0
   end function y_plane_evaluate
-
-  pure function y_plane_distance(this, xyz, uvw, coincident) result(d)
-    class(SurfaceYPlane), intent(in) :: this
-    real(8), intent(in) :: xyz(3)
-    real(8), intent(in) :: uvw(3)
-    logical, intent(in) :: coincident
-    real(8) :: d
-
-    real(8) :: f
-
-    f = this%y0 - xyz(2)
-    if (coincident .or. abs(f) < FP_COINCIDENT .or. uvw(2) == ZERO) then
-      d = INFINITY
-    else
-      d = f/uvw(2)
-      if (d < ZERO) d = INFINITY
-    end if
-  end function y_plane_distance
 
   pure function y_plane_normal(this, xyz) result(uvw)
     class(SurfaceYPlane), intent(in) :: this
@@ -353,24 +264,6 @@ contains
 
   end function z_plane_evaluate
 
-  pure function z_plane_distance(this, xyz, uvw, coincident) result(d)
-    class(SurfaceZPlane), intent(in) :: this
-    real(8), intent(in) :: xyz(3)
-    real(8), intent(in) :: uvw(3)
-    logical, intent(in) :: coincident
-    real(8) :: d
-
-    real(8) :: f
-
-    f = this%z0 - xyz(3)
-    if (coincident .or. abs(f) < FP_COINCIDENT .or. uvw(3) == ZERO) then
-      d = INFINITY
-    else
-      d = f/uvw(3)
-      if (d < ZERO) d = INFINITY
-    end if
-  end function z_plane_distance
-
   pure function z_plane_normal(this, xyz) result(uvw)
     class(SurfaceZPlane), intent(in) :: this
     real(8), intent(in) :: xyz(3)
@@ -390,26 +283,6 @@ contains
 
     f = this%A*xyz(1) + this%B*xyz(2) + this%C*xyz(3) - this%D
   end function plane_evaluate
-
-  pure function plane_distance(this, xyz, uvw, coincident) result(d)
-    class(SurfacePlane), intent(in) :: this
-    real(8), intent(in) :: xyz(3)
-    real(8), intent(in) :: uvw(3)
-    logical, intent(in) :: coincident
-    real(8) :: d
-
-    real(8) :: f
-    real(8) :: projection
-
-    f = this%A*xyz(1) + this%B*xyz(2) + this%C*xyz(3) - this%D
-    projection = this%A*uvw(1) + this%B*uvw(2) + this%C*uvw(3)
-    if (coincident .or. abs(f) < FP_COINCIDENT .or. projection == ZERO) then
-      d = INFINITY
-    else
-      d = -f/projection
-      if (d < ZERO) d = INFINITY
-    end if
-  end function plane_distance
 
   pure function plane_normal(this, xyz) result(uvw)
     class(SurfacePlane), intent(in) :: this
@@ -434,60 +307,6 @@ contains
     z = xyz(3) - this%z0
     f = y*y + z*z - this%r*this%r
   end function x_cylinder_evaluate
-
-  pure function x_cylinder_distance(this, xyz, uvw, coincident) result(d)
-    class(SurfaceXCylinder), intent(in) :: this
-    real(8), intent(in) :: xyz(3)
-    real(8), intent(in) :: uvw(3)
-    logical, intent(in) :: coincident
-    real(8) :: d
-
-    real(8) :: y, z, k, a, c, quad
-
-    a = ONE - uvw(1)*uvw(1)  ! v^2 + w^2
-    if (a == ZERO) then
-      d = INFINITY
-    else
-      y = xyz(2) - this%y0
-      z = xyz(3) - this%z0
-      k = y*uvw(2) + z*uvw(3)
-      c = y*y + z*z - this%r*this%r
-      quad = k*k - a*c
-
-      if (quad < ZERO) then
-        ! no intersection with cylinder
-
-        d = INFINITY
-
-      elseif (coincident .or. abs(c) < FP_COINCIDENT) then
-        ! particle is on the cylinder, thus one distance is positive/negative
-        ! and the other is zero. The sign of k determines if we are facing in or
-        ! out
-
-        if (k >= ZERO) then
-          d = INFINITY
-        else
-          d = (-k + sqrt(quad))/a
-        end if
-
-      elseif (c < ZERO) then
-        ! particle is inside the cylinder, thus one distance must be negative
-        ! and one must be positive. The positive distance will be the one with
-        ! negative sign on sqrt(quad)
-
-        d = (-k + sqrt(quad))/a
-
-      else
-        ! particle is outside the cylinder, thus both distances are either
-        ! positive or negative. If positive, the smaller distance is the one
-        ! with positive sign on sqrt(quad)
-
-        d = (-k - sqrt(quad))/a
-        if (d < ZERO) d = INFINITY
-
-      end if
-    end if
-  end function x_cylinder_distance
 
   pure function x_cylinder_normal(this, xyz) result(uvw)
     class(SurfaceXCylinder), intent(in) :: this
@@ -515,60 +334,6 @@ contains
     f = x*x + z*z - this%r*this%r
   end function y_cylinder_evaluate
 
-  pure function y_cylinder_distance(this, xyz, uvw, coincident) result(d)
-    class(SurfaceYCylinder), intent(in) :: this
-    real(8), intent(in) :: xyz(3)
-    real(8), intent(in) :: uvw(3)
-    logical, intent(in) :: coincident
-    real(8) :: d
-
-    real(8) :: x, z, k, a, c, quad
-
-    a = ONE - uvw(2)*uvw(2)  ! u^2 + w^2
-    if (a == ZERO) then
-      d = INFINITY
-    else
-      x = xyz(1) - this%x0
-      z = xyz(3) - this%z0
-      k = x*uvw(1) + z*uvw(3)
-      c = x*x + z*z - this%r*this%r
-      quad = k*k - a*c
-
-      if (quad < ZERO) then
-        ! no intersection with cylinder
-
-        d = INFINITY
-
-      elseif (coincident .or. abs(c) < FP_COINCIDENT) then
-        ! particle is on the cylinder, thus one distance is positive/negative
-        ! and the other is zero. The sign of k determines if we are facing in or
-        ! out
-
-        if (k >= ZERO) then
-          d = INFINITY
-        else
-          d = (-k + sqrt(quad))/a
-        end if
-
-      elseif (c < ZERO) then
-        ! particle is inside the cylinder, thus one distance must be negative
-        ! and one must be positive. The positive distance will be the one with
-        ! negative sign on sqrt(quad)
-
-        d = (-k + sqrt(quad))/a
-
-      else
-        ! particle is outside the cylinder, thus both distances are either
-        ! positive or negative. If positive, the smaller distance is the one
-        ! with positive sign on sqrt(quad)
-
-        d = (-k - sqrt(quad))/a
-        if (d < ZERO) d = INFINITY
-
-      end if
-    end if
-  end function y_cylinder_distance
-
   pure function y_cylinder_normal(this, xyz) result(uvw)
     class(SurfaceYCylinder), intent(in) :: this
     real(8), intent(in) :: xyz(3)
@@ -594,60 +359,6 @@ contains
     y = xyz(2) - this%y0
     f = x*x + y*y - this%r*this%r
   end function z_cylinder_evaluate
-
-  pure function z_cylinder_distance(this, xyz, uvw, coincident) result(d)
-    class(SurfaceZCylinder), intent(in) :: this
-    real(8), intent(in) :: xyz(3)
-    real(8), intent(in) :: uvw(3)
-    logical, intent(in) :: coincident
-    real(8) :: d
-
-    real(8) :: x, y, k, a, c, quad
-
-    a = ONE - uvw(3)*uvw(3)  ! u^2 + v^2
-    if (a == ZERO) then
-      d = INFINITY
-    else
-      x = xyz(1) - this%x0
-      y = xyz(2) - this%y0
-      k = x*uvw(1) + y*uvw(2)
-      c = x*x + y*y - this%r*this%r
-      quad = k*k - a*c
-
-      if (quad < ZERO) then
-        ! no intersection with cylinder
-
-        d = INFINITY
-
-      elseif (coincident .or. abs(c) < FP_COINCIDENT) then
-        ! particle is on the cylinder, thus one distance is positive/negative
-        ! and the other is zero. The sign of k determines if we are facing in or
-        ! out
-
-        if (k >= ZERO) then
-          d = INFINITY
-        else
-          d = (-k + sqrt(quad))/a
-        end if
-
-      elseif (c < ZERO) then
-        ! particle is inside the cylinder, thus one distance must be negative
-        ! and one must be positive. The positive distance will be the one with
-        ! negative sign on sqrt(quad)
-
-        d = (-k + sqrt(quad))/a
-
-      else
-        ! particle is outside the cylinder, thus both distances are either
-        ! positive or negative. If positive, the smaller distance is the one
-        ! with positive sign on sqrt(quad)
-
-        d = (-k - sqrt(quad))/a
-        if (d < ZERO) d = INFINITY
-
-      end if
-    end if
-  end function z_cylinder_distance
 
   pure function z_cylinder_normal(this, xyz) result(uvw)
     class(SurfaceZCylinder), intent(in) :: this
@@ -676,55 +387,6 @@ contains
     f = x*x + y*y + z*z - this%r*this%r
   end function sphere_evaluate
 
-  pure function sphere_distance(this, xyz, uvw, coincident) result(d)
-    class(SurfaceSphere), intent(in) :: this
-    real(8), intent(in) :: xyz(3)
-    real(8), intent(in) :: uvw(3)
-    logical, intent(in) :: coincident
-    real(8) :: d
-
-    real(8) :: x, y, z, k, c, quad
-
-    x = xyz(1) - this%x0
-    y = xyz(2) - this%y0
-    z = xyz(3) - this%z0
-    k = x*uvw(1) + y*uvw(2) + z*uvw(3)
-    c = x*x + y*y + z*z - this%r*this%r
-    quad = k*k - c
-
-    if (quad < ZERO) then
-      ! no intersection with sphere
-
-      d = INFINITY
-
-    elseif (coincident .or. abs(c) < FP_COINCIDENT) then
-      ! particle is on the sphere, thus one distance is positive/negative and
-      ! the other is zero. The sign of k determines if we are facing in or out
-
-      if (k >= ZERO) then
-        d = INFINITY
-      else
-        d = -k + sqrt(quad)
-      end if
-
-    elseif (c < ZERO) then
-      ! particle is inside the sphere, thus one distance must be negative and
-      ! one must be positive. The positive distance will be the one with
-      ! negative sign on sqrt(quad)
-
-      d = -k + sqrt(quad)
-
-    else
-      ! particle is outside the sphere, thus both distances are either positive
-      ! or negative. If positive, the smaller distance is the one with positive
-      ! sign on sqrt(quad)
-
-      d = -k - sqrt(quad)
-      if (d < ZERO) d = INFINITY
-
-    end if
-  end function sphere_distance
-
   pure function sphere_normal(this, xyz) result(uvw)
     class(SurfaceSphere), intent(in) :: this
     real(8), intent(in) :: xyz(3)
@@ -749,59 +411,6 @@ contains
     z = xyz(3) - this%z0
     f = y*y + z*z - this%r2*x*x
   end function x_cone_evaluate
-
-  pure function x_cone_distance(this, xyz, uvw, coincident) result(d)
-    class(SurfaceXCone), intent(in) :: this
-    real(8), intent(in) :: xyz(3)
-    real(8), intent(in) :: uvw(3)
-    logical, intent(in) :: coincident
-    real(8) :: d
-
-    real(8) :: x, y, z, k, a, b, c, quad
-
-    x = xyz(1) - this%x0
-    y = xyz(2) - this%y0
-    z = xyz(3) - this%z0
-    a = uvw(2)*uvw(2) + uvw(3)*uvw(3) - this%r2*uvw(1)*uvw(1)
-    k = y*uvw(2) + z*uvw(3) - this%r2*x*uvw(1)
-    c = y*y + z*z - this%r2*x*x
-    quad = k*k - a*c
-
-    if (quad < ZERO) then
-      ! no intersection with cone
-
-      d = INFINITY
-
-    elseif (coincident .or. abs(c) < FP_COINCIDENT) then
-      ! particle is on the cone, thus one distance is positive/negative and the
-      ! other is zero. The sign of k determines which distance is zero and which
-      ! is not.
-
-      if (k >= ZERO) then
-        d = (-k - sqrt(quad))/a
-      else
-        d = (-k + sqrt(quad))/a
-      end if
-
-    else
-      ! calculate both solutions to the quadratic
-      quad = sqrt(quad)
-      d = (-k - quad)/a
-      b = (-k + quad)/a
-
-      ! determine the smallest positive solution
-      if (d < ZERO) then
-        if (b > ZERO) then
-          d = b
-        end if
-      else
-        if (b > ZERO) d = min(d, b)
-      end if
-    end if
-
-    ! If the distance was negative, set boundary distance to infinity
-    if (d <= ZERO) d = INFINITY
-  end function x_cone_distance
 
   pure function x_cone_normal(this, xyz) result(uvw)
     class(SurfaceXCone), intent(in) :: this
@@ -830,59 +439,6 @@ contains
     f = x*x + z*z - this%r2*y*y
   end function y_cone_evaluate
 
-  pure function y_cone_distance(this, xyz, uvw, coincident) result(d)
-    class(SurfaceYCone), intent(in) :: this
-    real(8), intent(in) :: xyz(3)
-    real(8), intent(in) :: uvw(3)
-    logical, intent(in) :: coincident
-    real(8) :: d
-
-    real(8) :: x, y, z, k, a, b, c, quad
-
-    x = xyz(1) - this%x0
-    y = xyz(2) - this%y0
-    z = xyz(3) - this%z0
-    a = uvw(1)*uvw(1) + uvw(3)*uvw(3) - this%r2*uvw(2)*uvw(2)
-    k = x*uvw(1) + z*uvw(3) - this%r2*y*uvw(2)
-    c = x*x + z*z - this%r2*y*y
-    quad = k*k - a*c
-
-    if (quad < ZERO) then
-      ! no intersection with cone
-
-      d = INFINITY
-
-    elseif (coincident .or. abs(c) < FP_COINCIDENT) then
-      ! particle is on the cone, thus one distance is positive/negative and the
-      ! other is zero. The sign of k determines which distance is zero and which
-      ! is not.
-
-      if (k >= ZERO) then
-        d = (-k - sqrt(quad))/a
-      else
-        d = (-k + sqrt(quad))/a
-      end if
-
-    else
-      ! calculate both solutions to the quadratic
-      quad = sqrt(quad)
-      d = (-k - quad)/a
-      b = (-k + quad)/a
-
-      ! determine the smallest positive solution
-      if (d < ZERO) then
-        if (b > ZERO) then
-          d = b
-        end if
-      else
-        if (b > ZERO) d = min(d, b)
-      end if
-    end if
-
-    ! If the distance was negative, set boundary distance to infinity
-    if (d <= ZERO) d = INFINITY
-  end function y_cone_distance
-
   pure function y_cone_normal(this, xyz) result(uvw)
     class(SurfaceYCone), intent(in) :: this
     real(8), intent(in) :: xyz(3)
@@ -910,59 +466,6 @@ contains
     f = x*x + y*y - this%r2*z*z
   end function z_cone_evaluate
 
-  pure function z_cone_distance(this, xyz, uvw, coincident) result(d)
-    class(SurfaceZCone), intent(in) :: this
-    real(8), intent(in) :: xyz(3)
-    real(8), intent(in) :: uvw(3)
-    logical, intent(in) :: coincident
-    real(8) :: d
-
-    real(8) :: x, y, z, k, a, b, c, quad
-
-    x = xyz(1) - this%x0
-    y = xyz(2) - this%y0
-    z = xyz(3) - this%z0
-    a = uvw(1)*uvw(1) + uvw(2)*uvw(2) - this%r2*uvw(3)*uvw(3)
-    k = x*uvw(1) + y*uvw(2) - this%r2*z*uvw(3)
-    c = x*x + y*y - this%r2*z*z
-    quad = k*k - a*c
-
-    if (quad < ZERO) then
-      ! no intersection with cone
-
-      d = INFINITY
-
-    elseif (coincident .or. abs(c) < FP_COINCIDENT) then
-      ! particle is on the cone, thus one distance is positive/negative and the
-      ! other is zero. The sign of k determines which distance is zero and which
-      ! is not.
-
-      if (k >= ZERO) then
-        d = (-k - sqrt(quad))/a
-      else
-        d = (-k + sqrt(quad))/a
-      end if
-
-    else
-      ! calculate both solutions to the quadratic
-      quad = sqrt(quad)
-      d = (-k - quad)/a
-      b = (-k + quad)/a
-
-      ! determine the smallest positive solution
-      if (d < ZERO) then
-        if (b > ZERO) then
-          d = b
-        end if
-      else
-        if (b > ZERO) d = min(d, b)
-      end if
-    end if
-
-    ! If the distance was negative, set boundary distance to infinity
-    if (d <= ZERO) d = INFINITY
-  end function z_cone_distance
-
   pure function z_cone_normal(this, xyz) result(uvw)
     class(SurfaceZCone), intent(in) :: this
     real(8), intent(in) :: xyz(3)
@@ -988,65 +491,6 @@ contains
            z*(this%C*z + this%F*x + this%J) + this%K
     end associate
   end function quadric_evaluate
-
-  pure function quadric_distance(this, xyz, uvw, coincident) result(d)
-    class(SurfaceQuadric), intent(in) :: this
-    real(8), intent(in) :: xyz(3)
-    real(8), intent(in) :: uvw(3)
-    logical, intent(in) :: coincident
-    real(8) :: d
-
-    real(8) :: a, k, c
-    real(8) :: quad, b
-
-    associate (x => xyz(1), y => xyz(2), z => xyz(3), &
-         u => uvw(1), v => uvw(2), w => uvw(3))
-
-      a = this%A*u*u + this%B*v*v + this%C*w*w + this%D*u*v + this%E*v*w + &
-           this%F*u*w
-      k = (this%A*u*x + this%B*v*y + this%C*w*z + HALF*(this%D*(u*y + v*x) + &
-           this%E*(v*z + w*y) + this%F*(w*x + u*z) + this%G*u + this%H*v + &
-           this%J*w))
-      c = this%A*x*x + this%B*y*y + this%C*z*z + this%D*x*y + this%E*y*z + &
-           this%F*x*z + this%G*x + this%H*y + this%J*z + this%K
-      quad = k*k - a*c
-
-      if (quad < ZERO) then
-        ! no intersection with surface
-
-        d = INFINITY
-
-      elseif (coincident .or. abs(c) < FP_COINCIDENT) then
-        ! particle is on the surface, thus one distance is positive/negative and
-        ! the other is zero. The sign of k determines which distance is zero and
-        ! which is not.
-
-        if (k >= ZERO) then
-          d = (-k - sqrt(quad))/a
-        else
-          d = (-k + sqrt(quad))/a
-        end if
-
-      else
-        ! calculate both solutions to the quadratic
-        quad = sqrt(quad)
-        d = (-k - quad)/a
-        b = (-k + quad)/a
-
-        ! determine the smallest positive solution
-        if (d < ZERO) then
-          if (b > ZERO) then
-            d = b
-          end if
-        else
-          if (b > ZERO) d = min(d, b)
-        end if
-      end if
-
-      ! If the distance was negative, set boundary distance to infinity
-      if (d <= ZERO) d = INFINITY
-    end associate
-  end function quadric_distance
 
   pure function quadric_normal(this, xyz) result(uvw)
     class(SurfaceQuadric), intent(in) :: this

--- a/src/surface_header.F90
+++ b/src/surface_header.F90
@@ -36,84 +36,39 @@ module surface_header
 !===============================================================================
 
   type, extends(Surface) :: SurfaceXPlane
-    ! x = x0
-    real(8) :: x0
   end type SurfaceXPlane
 
   type, extends(Surface) :: SurfaceYPlane
-    ! y = y0
-    real(8) :: y0
   end type SurfaceYPlane
 
   type, extends(Surface) :: SurfaceZPlane
-    ! z = z0
-    real(8) :: z0
   end type SurfaceZPlane
 
   type, extends(Surface) :: SurfacePlane
-    ! Ax + By + Cz = D
-    real(8) :: A
-    real(8) :: B
-    real(8) :: C
-    real(8) :: D
   end type SurfacePlane
 
   type, extends(Surface) :: SurfaceXCylinder
-    ! (y - y0)^2 + (z - z0)^2 = R^2
-    real(8) :: y0
-    real(8) :: z0
-    real(8) :: r
   end type SurfaceXCylinder
 
   type, extends(Surface) :: SurfaceYCylinder
-    ! (x - x0)^2 + (z - z0)^2 = R^2
-    real(8) :: x0
-    real(8) :: z0
-    real(8) :: r
   end type SurfaceYCylinder
 
   type, extends(Surface) :: SurfaceZCylinder
-    ! (x - x0)^2 + (y - y0)^2 = R^2
-    real(8) :: x0
-    real(8) :: y0
-    real(8) :: r
   end type SurfaceZCylinder
 
   type, extends(Surface) :: SurfaceSphere
-    ! (x - x0)^2 + (y - y0)^2 + (z - z0)^2 = R^2
-    real(8) :: x0
-    real(8) :: y0
-    real(8) :: z0
-    real(8) :: r
   end type SurfaceSphere
 
   type, extends(Surface) :: SurfaceXCone
-    ! (y - y0)^2 + (z - z0)^2 = R^2*(x - x0)^2
-    real(8) :: x0
-    real(8) :: y0
-    real(8) :: z0
-    real(8) :: r2
   end type SurfaceXCone
 
   type, extends(Surface) :: SurfaceYCone
-    ! (x - x0)^2 + (z - z0)^2 = R^2*(y - y0)^2
-    real(8) :: x0
-    real(8) :: y0
-    real(8) :: z0
-    real(8) :: r2
   end type SurfaceYCone
 
   type, extends(Surface) :: SurfaceZCone
-    ! (x - x0)^2 + (y - y0)^2 = R^2*(z - z0)^2
-    real(8) :: x0
-    real(8) :: y0
-    real(8) :: z0
-    real(8) :: r2
   end type SurfaceZCone
 
   type, extends(Surface) :: SurfaceQuadric
-    ! Ax^2 + By^2 + Cz^2 + Dxy + Eyz + Fxz + Gx + Hy + Jz + K = 0
-    real(8) :: A, B, C, D, E, F, G, H, J, K
   end type SurfaceQuadric
 
   integer(C_INT32_T), bind(C) :: n_surfaces  ! # of surfaces

--- a/src/tallies/tally.F90
+++ b/src/tallies/tally.F90
@@ -4241,7 +4241,7 @@ contains
     real(C_DOUBLE) :: k_tra ! Copy of batch tracklength estimate of keff
     real(C_DOUBLE) :: val
 
-#ifdef MPI
+#ifdef OPENMC_MPI
     ! Combine tally results onto master process
     if (reduce_tallies) call reduce_tally_results()
 #endif
@@ -4289,7 +4289,7 @@ contains
 ! REDUCE_TALLY_RESULTS collects all the results from tallies onto one processor
 !===============================================================================
 
-#ifdef MPI
+#ifdef OPENMC_MPI
   subroutine reduce_tally_results()
 
     integer :: i

--- a/src/tallies/tally_filter_surface.F90
+++ b/src/tallies/tally_filter_surface.F90
@@ -105,7 +105,7 @@ contains
     integer,              intent(in) :: bin
     character(MAX_LINE_LEN)          :: label
 
-    label = "Surface " // to_str(surfaces(this % surfaces(bin)) % obj % id)
+    label = "Surface " // to_str(surfaces(this % surfaces(bin)) % id)
   end function text_label_surface
 
 end module tally_filter_surface

--- a/src/tallies/tally_filter_surface.F90
+++ b/src/tallies/tally_filter_surface.F90
@@ -105,7 +105,7 @@ contains
     integer,              intent(in) :: bin
     character(MAX_LINE_LEN)          :: label
 
-    label = "Surface " // to_str(surfaces(this % surfaces(bin)) % id)
+    label = "Surface " // to_str(surfaces(this % surfaces(bin)) % id())
   end function text_label_surface
 
 end module tally_filter_surface

--- a/src/tallies/trigger.F90
+++ b/src/tallies/trigger.F90
@@ -2,7 +2,7 @@ module trigger
 
   use, intrinsic :: ISO_C_BINDING
 
-#ifdef MPI
+#ifdef OPENMC_MPI
   use message_passing
 #endif
 

--- a/src/tracking.F90
+++ b/src/tracking.F90
@@ -6,7 +6,7 @@ module tracking
   use geometry_header,    only: cells
   use geometry,           only: find_cell, distance_to_boundary, cross_lattice, &
                                 check_cell_overlap, surface_reflect_c, &
-                                surface_periodic_c
+                                surface_periodic_c, surface_i_periodic_c
   use message_passing
   use mgxs_header
   use nuclide_header
@@ -298,7 +298,7 @@ contains
     class(Surface), pointer :: surf
 
     i_surface = abs(p % surface)
-    surf => surfaces(i_surface)%obj
+    surf => surfaces(i_surface)
     if (verbosity >= 10 .or. trace) then
       call write_message("    Crossing surface " // trim(to_str(surf % id)))
     end if
@@ -412,14 +412,14 @@ contains
         p % coord(1) % xyz = xyz
       end if
 
-      rotational = surface_periodic_c(i_surface-1, surf % i_periodic-1, &
-                                       p % coord(1) % xyz, p % coord(1) % uvw)
+      rotational = surface_periodic_c(i_surface-1, p % coord(1) % xyz, &
+                                      p % coord(1) % uvw)
 
       ! Reassign particle's surface
       if (rotational) then
-        p % surface = surf % i_periodic
+        p % surface = surface_i_periodic_c(i_surface-1) + 1
       else
-        p % surface = sign(surf % i_periodic, p % surface)
+        p % surface = sign(surface_i_periodic_c(i_surface-1) + 1, p % surface)
       end if
 
       ! Figure out what cell particle is in now

--- a/src/tracking.F90
+++ b/src/tracking.F90
@@ -5,7 +5,8 @@ module tracking
   use error,              only: fatal_error, warning, write_message
   use geometry_header,    only: cells
   use geometry,           only: find_cell, distance_to_boundary, cross_lattice, &
-                                check_cell_overlap, surface_periodic_c
+                                check_cell_overlap, surface_reflect_c, &
+                                surface_periodic_c
   use message_passing
   use mgxs_header
   use nuclide_header
@@ -354,7 +355,7 @@ contains
       end if
 
       ! Reflect particle off surface
-      call surf%reflect(p%coord(1)%xyz, p%coord(1)%uvw)
+      call surface_reflect_c(i_surface-1, p%coord(1)%xyz, p%coord(1)%uvw)
 
       ! Make sure new particle direction is normalized
       u = p%coord(1)%uvw(1)

--- a/src/volume_calc.F90
+++ b/src/volume_calc.F90
@@ -136,7 +136,7 @@ contains
     integer :: total_hits  ! total hits for a single domain (summed over materials)
     integer :: min_samples ! minimum number of samples per process
     integer :: remainder   ! leftover samples from uneven divide
-#ifdef MPI
+#ifdef OPENMC_MPI
     integer :: mpi_err ! MPI error code
     integer :: m  ! index over materials
     integer :: n  ! number of materials
@@ -279,7 +279,7 @@ contains
       total_hits = 0
 
       if (master) then
-#ifdef MPI
+#ifdef OPENMC_MPI
         do j = 1, n_procs - 1
           call MPI_RECV(n, 1, MPI_INTEGER, j, 0, mpi_intracomm, &
                MPI_STATUS_IGNORE, mpi_err)
@@ -341,7 +341,7 @@ contains
         end do
 
       else
-#ifdef MPI
+#ifdef OPENMC_MPI
         n = master_indices(i_domain) % size()
         allocate(data(2*n))
         do k = 0, n - 1

--- a/src/xml_interface.h
+++ b/src/xml_interface.h
@@ -1,0 +1,52 @@
+#ifndef XML_INTERFACE_H
+#define XML_INTERFACE_H
+
+#include <algorithm>  // for std::transform
+#include <string>
+
+#include "pugixml/pugixml.hpp"
+
+
+bool
+check_for_node(const pugi::xml_node &node, const char *name)
+{
+  if (node.attribute(name)) {
+    return true;
+  } else if (node.child(name)) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+
+std::string
+get_node_value(const pugi::xml_node &node, const char *name)
+{
+  // Search for either an attribute or child tag and get the data as a char*.
+  const pugi::char_t *value_char;
+  if (node.attribute(name)) {
+    value_char = node.attribute(name).value();
+  } else if (node.child(name)) {
+    value_char = node.child_value(name);
+  } else {
+    std::string err_msg("Node \"");
+    err_msg += name;
+    err_msg += "\" is not a memeber of the \"";
+    err_msg += node.name();
+    err_msg += "\" XML node";
+    fatal_error(err_msg);
+  }
+
+  // Convert to lowercase string.
+  std::string value(value_char);
+  std::transform(value.begin(), value.end(), value.begin(), ::tolower);
+
+  // Remove whitespace.
+  value.erase(0, value.find_first_not_of(" \t\r\n"));
+  value.erase(value.find_last_not_of(" \t\r\n") + 1);
+
+  return value;
+}
+
+#endif // XML_INTERFACE_H

--- a/src/xml_interface.h
+++ b/src/xml_interface.h
@@ -2,26 +2,23 @@
 #define XML_INTERFACE_H
 
 #include <algorithm>  // for std::transform
+#include <sstream>
 #include <string>
 
 #include "pugixml/pugixml.hpp"
 
 
+namespace openmc {
+
 bool
-check_for_node(const pugi::xml_node &node, const char *name)
+check_for_node(pugi::xml_node node, const char *name)
 {
-  if (node.attribute(name)) {
-    return true;
-  } else if (node.child(name)) {
-    return true;
-  } else {
-    return false;
-  }
+  return node.attribute(name) || node.child(name);
 }
 
 
 std::string
-get_node_value(const pugi::xml_node &node, const char *name)
+get_node_value(pugi::xml_node node, const char *name)
 {
   // Search for either an attribute or child tag and get the data as a char*.
   const pugi::char_t *value_char;
@@ -30,11 +27,9 @@ get_node_value(const pugi::xml_node &node, const char *name)
   } else if (node.child(name)) {
     value_char = node.child_value(name);
   } else {
-    std::string err_msg("Node \"");
-    err_msg += name;
-    err_msg += "\" is not a memeber of the \"";
-    err_msg += node.name();
-    err_msg += "\" XML node";
+    std::stringstream err_msg;
+    err_msg << "Node \"" << name << "\" is not a member of the \""
+            << node.name() << "\" XML node";
     fatal_error(err_msg);
   }
 
@@ -49,4 +44,5 @@ get_node_value(const pugi::xml_node &node, const char *name)
   return value;
 }
 
+} // namespace openmc
 #endif // XML_INTERFACE_H

--- a/tests/unit_tests/test_capi.py
+++ b/tests/unit_tests/test_capi.py
@@ -29,11 +29,11 @@ def pincell_model():
     yield
 
     # Delete generated files
-    files = ['geometry.xml', 'materials.xml', 'settings.xml', 'tallies.xml',
-             'statepoint.10.h5', 'summary.h5', 'test_sp.h5']
-    for f in files:
-        if os.path.exists(f):
-            os.remove(f)
+    #files = ['geometry.xml', 'materials.xml', 'settings.xml', 'tallies.xml',
+    #         'statepoint.10.h5', 'summary.h5', 'test_sp.h5']
+    #for f in files:
+    #    if os.path.exists(f):
+    #        os.remove(f)
 
 
 @pytest.fixture(scope='module')

--- a/tests/unit_tests/test_capi.py
+++ b/tests/unit_tests/test_capi.py
@@ -29,11 +29,11 @@ def pincell_model():
     yield
 
     # Delete generated files
-    #files = ['geometry.xml', 'materials.xml', 'settings.xml', 'tallies.xml',
-    #         'statepoint.10.h5', 'summary.h5', 'test_sp.h5']
-    #for f in files:
-    #    if os.path.exists(f):
-    #        os.remove(f)
+    files = ['geometry.xml', 'materials.xml', 'settings.xml', 'tallies.xml',
+             'statepoint.10.h5', 'summary.h5', 'test_sp.h5']
+    for f in files:
+        if os.path.exists(f):
+            os.remove(f)
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
This PR brings us a little further down the road of #603.  It removes virtually all of the surface-related Fortran code and replaces it with C++.

Except for periodic boundary conditions, the translation of our OO Fortran surface code to C++ was fairly straightforward.  The new C++ classes and methods almost identically match the old Fortran ones.  For interoperability, Fortran retains the `Surface` class which only contains the neighbor lists and a pointer to the C++ object.  I've tried to move as much as possible to C++ so even the IDs now need to be accessed by a type-bound method which wraps C++ code.

I've been pretty thorough at testing the `sense`, `normal`, and `distance` methods of each surface type and so far I've found that this new code precisely reproduces the old version.  In theory, this could be slower due to extra function call overhead (that will disappear as more code gets converted to C++), but it looks negligible in my timing tests.

Implementation notes:
* The Fortran surface code had a lot of redundancy e.g. with the distance functions of `SurfaceXCylinder`, `SurfaceYCylinder`, and `SurfaceZCylinder`.  Here we're able to cut that down with templated functions.
* We use the `select type` constructs in the periodic BC code, and they are rather difficult to translate to C++ cleanly.  Apparently that sort of runtime type information encourages bad code.  I tried channeling my inner Stroustrup and writing the periodic BC code without using `dynamic_cast` to inspect surface types, but the end result in this case essentially works out to implicit type checking with things like the `normal()` method.  There are probably much cleaner ways to implement periodic BCs, but I think this code will do fine for now.
* This is the first of our C++ code to deal with XML and HDF5.  Accordingly, I've made an xml_interface.h and hdf5_interface.h.  They're small and limited now, but I'm sure we can grow them later as needed.  For example, I haven't touched the details of MPI I/O in hdf5_interface.h since surfaces only go in the summary.h5 file which is written from the master process.
* Note that I needed to change the `MPI` definition to `OPENMC_MPI` because `MPI` is defined by mpi.h

@paulromano, I'm not attached to many of the design decisions here so do feel free to suggest major changes.  At some point I think I would like to make a surface namespace and make the change
```C++
// Old:
int n_surfaces{0};
Surface **surfaces_c;
std::map<int, int> surface_dict;
// New:
std::vector<std::shared_ptr<Surface>> surfaces_c;
std::map<int, std::weak_ptr<Surface>> surface_dict;
```
but at the moment it feels like we might be breaking some contracts due to Fortran holding ownership of some `Surface` pointers without a destructor.