### PR TITLE
Avoid overflow when broadcasting tally results

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,9 @@ if($ENV{FC} MATCHES "(mpi[^/]*|ftn)$")
   message("-- Detected MPI wrapper: $ENV{FC}")
   add_definitions(-DMPI)
   set(MPI_ENABLED TRUE)
+
+  # Get directory containing MPI wrapper
+  get_filename_component(MPI_DIR $ENV{FC} DIRECTORY)
 endif()
 
 # Check for Fortran 2008 MPI interface
@@ -552,7 +555,7 @@ foreach(test ${TESTS})
       add_test(NAME ${TEST_NAME}
         WORKING_DIRECTORY ${TEST_PATH}
         COMMAND ${PYTHON_EXECUTABLE} ${TEST_NAME} --exe $<TARGET_FILE:openmc>
-        --mpi_exec $ENV{MPI_DIR}/bin/mpiexec)
+        --mpi_exec ${MPI_DIR}/mpiexec)
     else()
       # Perform a serial test
       add_test(NAME ${TEST_NAME}

--- a/src/simulation.F90
+++ b/src/simulation.F90
@@ -472,8 +472,14 @@ contains
 #ifdef MPI
     integer    :: n       ! size of arrays
     integer    :: mpi_err  ! MPI error code
+    integer    :: count_per_filter ! number of result values for one filter bin
     integer(8) :: temp
     real(8)    :: tempr(3) ! temporary array for communication
+#ifdef MPIF08
+    type(MPI_Datatype) :: result_block
+#else
+    integer :: result_block
+#endif
 #endif
 
     ! Skip if simulation was never run
@@ -498,9 +504,18 @@ contains
     ! Broadcast tally results so that each process has access to results
     if (allocated(tallies)) then
       do i = 1, size(tallies)
-        n = size(tallies(i) % obj % results)
-        call MPI_BCAST(tallies(i) % obj % results, n, MPI_DOUBLE, 0, &
-             mpi_intracomm, mpi_err)
+        associate (results => tallies(i) % obj % results)
+          ! Create a new datatype that consists of all values for a given filter
+          ! bin and then use that to broadcast. This is done to minimize the
+          ! chance of the 'count' argument of MPI_BCAST exceeding 2**31
+          n = size(results, 3)
+          count_per_filter = size(results, 1) * size(results, 2)
+          call MPI_TYPE_CONTIGUOUS(count_per_filter, MPI_DOUBLE, &
+               result_block, mpi_err)
+          call MPI_TYPE_COMMIT(result_block, mpi_err)
+          call MPI_BCAST(results, n, result_block, 0, mpi_intracomm, mpi_err)
+          call MPI_TYPE_FREE(result_block, mpi_err)
+        end associate
       end do
     end if
 

--- a/src/simulation.F90
+++ b/src/simulation.F90
@@ -475,7 +475,7 @@ contains
     integer    :: count_per_filter ! number of result values for one filter bin
     integer(8) :: temp
     real(8)    :: tempr(3) ! temporary array for communication
-#ifdef MPIF08
+#ifdef OPENMC_MPIF08
     type(MPI_Datatype) :: result_block
 #else
     integer :: result_block


### PR DESCRIPTION
As described in #914, at the end of a simulation all tally results are broadcasted to all processes so that each process has a consistent state. However, if the tally is huge and the total number of tally bins reaches into the millions or billions, this can cause an overflow in the `count` argument of `MPI_BCAST`, which is expected to be a C `int`. This pull request creates a contiguous MPI derived type on the fly that consists of all nuclides/scores for a single filter bin, which should significantly decrease the chance of an overflow.

@liangjg I'm requesting your review since you identified this issue. I've tried this out and confirmed that it fixes the issue you were seeing on our finely detailed single assembly model, but in order to do so I had to switch to OpenMPI. It still fails with MPICH due to the bug in MPICH itself. If you want to try this out on JLSE, I installed OpenMPI at /home/romano/openmpi/3.0.0-gnu-6.3.