### PR TITLE
Fix bug with clearing generation-wise k values

### DIFF
--- a/src/simulation.F90
+++ b/src/simulation.F90
@@ -434,6 +434,13 @@ contains
     allocate(filter_matches(n_filters))
 !$omp end parallel
 
+    ! Reset global variables -- this is done before loading state point (as that
+    ! will potentially populate k_generation and entropy)
+    current_batch = 0
+    call k_generation % clear()
+    call entropy % clear()
+    need_depletion_rx = .false.
+
     ! If this is a restart run, load the state point data and binary source
     ! file
     if (restart_run) then
@@ -451,12 +458,6 @@ contains
         if (verbosity >= 7) call print_columns()
       end if
     end if
-
-    ! Reset global variables
-    current_batch = 0
-    call k_generation % clear()
-    call entropy % clear()
-    need_depletion_rx = .false.
 
     ! Set flag indicating initialization is done
     simulation_initialized = .true.

--- a/src/simulation.F90
+++ b/src/simulation.F90
@@ -454,6 +454,8 @@ contains
 
     ! Reset global variables
     current_batch = 0
+    call k_generation % clear()
+    call entropy % clear()
     need_depletion_rx = .false.
 
     ! Set flag indicating initialization is done

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,15 @@
+from contextlib import contextmanager
+import os
+import tempfile
+
+
+@contextmanager
+def cdtemp():
+    """Context manager to change to/return from a tmpdir."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cwd = os.getcwd()
+        try:
+            os.chdir(tmpdir)
+            yield
+        finally:
+            os.chdir(cwd)

--- a/tests/unit_tests/test_capi.py
+++ b/tests/unit_tests/test_capi.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from collections import Mapping
 import os
 
@@ -8,12 +6,15 @@ import pytest
 import openmc
 import openmc.capi
 
+from tests import cdtemp
+
 
 @pytest.fixture(scope='module')
 def pincell_model():
     """Set up a model to test with and delete files when done"""
     openmc.reset_auto_ids()
     pincell = openmc.examples.pwr_pin_cell()
+    pincell.settings.verbosity = 1
 
     # Add a tally
     filter1 = openmc.MaterialFilter(pincell.materials)
@@ -24,17 +25,10 @@ def pincell_model():
     mat_tally.scores = ['total', 'elastic', '(n,gamma)']
     pincell.tallies.append(mat_tally)
 
-    # Write XML files
-    pincell.export_to_xml()
-
-    yield
-
-    # Delete generated files
-    files = ['geometry.xml', 'materials.xml', 'settings.xml', 'tallies.xml',
-             'statepoint.10.h5', 'summary.h5', 'test_sp.h5']
-    for f in files:
-        if os.path.exists(f):
-            os.remove(f)
+    # Write XML files in tmpdir
+    with cdtemp():
+        pincell.export_to_xml()
+        yield
 
 
 @pytest.fixture(scope='module')
@@ -227,6 +221,19 @@ def test_by_batch(capi_run):
         openmc.capi.next_batch()
     assert openmc.capi.num_realizations() == 8
     openmc.capi.simulation_finalize()
+
+
+def test_reproduce_keff(capi_init):
+    # Get k-effective after run
+    openmc.capi.hard_reset()
+    openmc.capi.run()
+    keff0 = openmc.capi.keff()
+
+    # Reset, run again, and get k-effective again. they should match
+    openmc.capi.hard_reset()
+    openmc.capi.run()
+    keff1 = openmc.capi.keff()
+    assert keff0 == pytest.approx(keff1)
 
 
 def test_find_cell(capi_init):

--- a/tools/ci/travis-install.sh
+++ b/tools/ci/travis-install.sh
@@ -4,8 +4,11 @@ set -ex
 # Install NJOY 2016
 ./tools/ci/travis-install-njoy.sh
 
-# Running OpenMC's setup.py requires numpy/cython already
-pip install numpy cython
+# Running OpenMC's setup.py requires numpy/cython already. NumPy float
+# formatting changed in version 1.14, so stick with a lower version until we can
+# handle it in our test suite
+pip install 'numpy<1.14'
+pip install cython
 
 # pytest installed by default -- make sure we get latest
 pip install --upgrade pytest


### PR DESCRIPTION
This PR fixes a subtle bug with getting k-effective using the C bindings. If you perform a run, and then reset (using either `reset()` or `hard_reset()`) and run again and ask for `keff()`, right now you actually get the wrong value because on the second simulation, the `k_generation` vector is never cleared. I added a unit test that specifically checks this (I've confirmed it fails without the fix in simulation.F90).