### PR TITLE
disallow target energy greater than is used in SIGMA1

### DIFF
--- a/src/physics.F90
+++ b/src/physics.F90
@@ -931,7 +931,7 @@ contains
               E_rel = dot_product((v_neut - v_target), (v_neut - v_target))
               if (E_rel < E_up) exit TARGET_ENERGY_LOOP
             end do TARGET_ENERGY_LOOP
-            
+
             ! perform Doppler broadening rejection correction (dbrc)
             xs_0K = elastic_xs_0K(E_rel, nuc)
             R = xs_0K / xs_max

--- a/src/physics.F90
+++ b/src/physics.F90
@@ -925,11 +925,14 @@ contains
                maxval(nuc % elastic_0K(i_E_low + 1 : i_E_up)), xs_up)
 
           DBRC_REJECT_LOOP: do
-            ! sample target velocity with the constant cross section (cxs) approx.
-            call sample_cxs_target_velocity(nuc, v_target, E, uvw, kT)
-
+            TARGET_ENERGY_LOOP: do
+              ! sample target velocity with the constant cross section (cxs) approx.
+              call sample_cxs_target_velocity(nuc, v_target, E, uvw, kT)
+              E_rel = dot_product((v_neut - v_target), (v_neut - v_target))
+              if (E_rel < E_up) exit TARGET_ENERGY_LOOP
+            end do TARGET_ENERGY_LOOP
+            
             ! perform Doppler broadening rejection correction (dbrc)
-            E_rel = dot_product((v_neut - v_target), (v_neut - v_target))
             xs_0K = elastic_xs_0K(E_rel, nuc)
             R = xs_0K / xs_max
             if (prn() < R) exit DBRC_REJECT_LOOP


### PR DESCRIPTION
This PR fixes a bug in the interplay between the constant cross section free gas sampling subroutine and the DBRC rejection step when resonance scattering is enabled.  The current implementation of the free gas algorithm does not, as far as I can tell, place any maximum on sampled target energies.  Nuclear data processing codes, however, commonly limit effective target energies to 16kT.  So, we're currently allowing scattering events with target energies that were not included when Doppler broadening cross sections.

An alternate way of enforcing consistency would be to do a uniform target energy sampling on [0,16kT) and then accept with Prob = M(E_sample) / M(kT/2).  It would be less efficient in terms of the number of rejections but require fewer flops per rejection.