### PR TITLE
Cmfd output

### DIFF
--- a/src/output.F90
+++ b/src/output.F90
@@ -368,7 +368,7 @@ contains
     ! write out entropy info
     if (entropy_on) write(UNIT=OUTPUT_UNIT, FMT='(3X, F8.5)', ADVANCE='NO') &
          entropy % data(i)
-    
+
     ! write out accumulated k-effective if after first active batch
     if (n > 1) then
       write(UNIT=OUTPUT_UNIT, FMT='(3X, F8.5," +/-",F8.5)', ADVANCE='NO') &
@@ -380,8 +380,9 @@ contains
   end subroutine print_batch_keff
 
 !===============================================================================
-! PRINT_BATCH_KEFF displays the last batch's tallied value of the neutron
-! multiplication factor as well as the average value if we're in active batches
+! PRINT_CMFD displays the CMFD related information to output after CMFD is 
+! executed. Will print blank line if CMFD is not on, to ensure consistent 
+! formatting of output columns
 !===============================================================================
 
   subroutine print_cmfd()
@@ -405,9 +406,10 @@ contains
                cmfd % dom(current_batch)
       end select
     end if
+
     ! next line
     write(UNIT=OUTPUT_UNIT, FMT=*)
-      
+ 
   end subroutine print_cmfd
 
 !===============================================================================

--- a/src/output.F90
+++ b/src/output.F90
@@ -368,7 +368,7 @@ contains
     ! write out entropy info
     if (entropy_on) write(UNIT=OUTPUT_UNIT, FMT='(3X, F8.5)', ADVANCE='NO') &
          entropy % data(i)
-
+    
     ! write out accumulated k-effective if after first active batch
     if (n > 1) then
       write(UNIT=OUTPUT_UNIT, FMT='(3X, F8.5," +/-",F8.5)', ADVANCE='NO') &
@@ -376,6 +376,15 @@ contains
     else
       write(UNIT=OUTPUT_UNIT, FMT='(23X)', ADVANCE='NO')
     end if
+      
+  end subroutine print_batch_keff
+
+!===============================================================================
+! PRINT_BATCH_KEFF displays the last batch's tallied value of the neutron
+! multiplication factor as well as the average value if we're in active batches
+!===============================================================================
+
+  subroutine print_cmfd()
 
     ! write out cmfd keff if it is active and other display info
     if (cmfd_on) then
@@ -396,11 +405,10 @@ contains
                cmfd % dom(current_batch)
       end select
     end if
-
     ! next line
     write(UNIT=OUTPUT_UNIT, FMT=*)
-
-  end subroutine print_batch_keff
+      
+  end subroutine print_cmfd
 
 !===============================================================================
 ! PRINT_PLOT displays selected options for plotting

--- a/src/output.F90
+++ b/src/output.F90
@@ -376,7 +376,7 @@ contains
     else
       write(UNIT=OUTPUT_UNIT, FMT='(23X)', ADVANCE='NO')
     end if
-      
+
     ! write out cmfd keff if it is active and other display info
     if (cmfd_on) then
       write(UNIT=OUTPUT_UNIT, FMT='(3X, F8.5)', ADVANCE='NO') &

--- a/src/output.F90
+++ b/src/output.F90
@@ -409,7 +409,7 @@ contains
 
     ! next line
     write(UNIT=OUTPUT_UNIT, FMT=*)
- 
+
   end subroutine print_cmfd
 
 !===============================================================================

--- a/src/output.F90
+++ b/src/output.F90
@@ -358,7 +358,7 @@ contains
     ! Determine overall generation and number of active generations
     i = overall_generation() - 1
     n = i - n_inactive*gen_per_batch
-    
+
     ! write out information batch and option independent output
     write(UNIT=OUTPUT_UNIT, FMT='(2X,A9)', ADVANCE='NO') &
          trim(to_str(current_batch)) // "/" // trim(to_str(gen_per_batch))

--- a/src/output.F90
+++ b/src/output.F90
@@ -356,9 +356,9 @@ contains
     integer :: n  ! number of active generations
 
     ! Determine overall generation and number of active generations
-    i = overall_generation()
+    i = overall_generation() - 1
     n = i - n_inactive*gen_per_batch
-
+    
     ! write out information batch and option independent output
     write(UNIT=OUTPUT_UNIT, FMT='(2X,A9)', ADVANCE='NO') &
          trim(to_str(current_batch)) // "/" // trim(to_str(gen_per_batch))
@@ -377,16 +377,6 @@ contains
       write(UNIT=OUTPUT_UNIT, FMT='(23X)', ADVANCE='NO')
     end if
       
-  end subroutine print_batch_keff
-
-!===============================================================================
-! PRINT_CMFD displays the CMFD related information to output after CMFD is 
-! executed. Will print blank line if CMFD is not on, to ensure consistent 
-! formatting of output columns
-!===============================================================================
-
-  subroutine print_cmfd()
-
     ! write out cmfd keff if it is active and other display info
     if (cmfd_on) then
       write(UNIT=OUTPUT_UNIT, FMT='(3X, F8.5)', ADVANCE='NO') &
@@ -410,7 +400,7 @@ contains
     ! next line
     write(UNIT=OUTPUT_UNIT, FMT=*)
 
-  end subroutine print_cmfd
+  end subroutine print_batch_keff
 
 !===============================================================================
 ! PRINT_PLOT displays selected options for plotting

--- a/src/output.F90
+++ b/src/output.F90
@@ -356,7 +356,7 @@ contains
     integer :: n  ! number of active generations
 
     ! Determine overall generation and number of active generations
-    i = overall_generation() - 1
+    i = current_batch*gen_per_batch
     n = i - n_inactive*gen_per_batch
 
     ! write out information batch and option independent output

--- a/src/simulation.F90
+++ b/src/simulation.F90
@@ -24,7 +24,8 @@ module simulation
   use nuclide_header,  only: micro_xs, n_nuclides
   use output,          only: header, print_columns, &
                              print_batch_keff, print_generation, print_runtime, &
-                             print_results, print_overlap_check, write_tallies
+                             print_results, print_overlap_check, write_tallies, &
+                             print_cmfd
   use particle_header, only: Particle
   use random_lcg,      only: set_particle_seed
   use settings
@@ -338,6 +339,7 @@ contains
     if (run_mode == MODE_EIGENVALUE) then
       ! Perform CMFD calculation if on
       if (cmfd_on) call execute_cmfd()
+      call print_cmfd()
     end if
 
     ! Check_triggers

--- a/src/simulation.F90
+++ b/src/simulation.F90
@@ -24,8 +24,7 @@ module simulation
   use nuclide_header,  only: micro_xs, n_nuclides
   use output,          only: header, print_columns, &
                              print_batch_keff, print_generation, print_runtime, &
-                             print_results, print_overlap_check, write_tallies, &
-                             print_cmfd
+                             print_results, print_overlap_check, write_tallies
   use particle_header, only: Particle
   use random_lcg,      only: set_particle_seed
   use settings
@@ -295,8 +294,6 @@ contains
       if (master .and. verbosity >= 7) then
         if (current_gen /= gen_per_batch) then
           call print_generation()
-        else
-          call print_batch_keff()
         end if
       end if
 
@@ -339,7 +336,8 @@ contains
     if (run_mode == MODE_EIGENVALUE) then
       ! Perform CMFD calculation if on
       if (cmfd_on) call execute_cmfd()
-      call print_cmfd()
+      ! Write batch output
+      if (master .and. verbosity >= 7) call print_batch_keff()
     end if
 
     ! Check_triggers


### PR DESCRIPTION
This PR addresses issue #961 to output CMFD parameters correctly. Initially what was happening was that all output was being displayed to output buffer in method finalize_generation in output.F90. However, CMFD was not called by then and so CMFD parameters would not be set and display as 0.

To fix this, a separate "print_cmfd" routine was created and called during finalize_batch, after CMFD has actually finished running. print_cmfd outputs necessary CMFD output and prints a new line to ensure consistent formatting. The new line is printed regardless of whether CMFD is on or not.

PR can be tested on CMFD test functions, to see that CMFD output is correct and not printing just 0's anymore.

Some things that might require some further discussion/modification:
  1) Naming of print_cmfd routine - Should it be something more general to signify output of any batch-level parameters?
  2) Placement of print_cmfd routine - Currently called right after execute_cmfd, should routine be placed later?
  3) Code conventions - Do let me know if there are any code conventions I might have missed