### PR TITLE
Added a python example for depletion

### DIFF
--- a/examples/python/pincell_depletion/chain_simple.xml
+++ b/examples/python/pincell_depletion/chain_simple.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<depletion_chain>
+  <nuclide name="I135" decay_modes="1" reactions="1" half_life="2.36520E+04">
+    <decay type="beta" target="Xe135" branching_ratio="1.0" />
+    <reaction type="(n,gamma)" Q="0.0" target="Xe136" /> <!-- Not precisely true, but whatever -->
+  </nuclide>
+  <nuclide name="Xe135" decay_modes="1" reactions="1" half_life="3.29040E+04">
+    <decay type=" beta" target="Cs135" branching_ratio="1.0" />
+    <reaction type="(n,gamma)" Q="0.0" target="Xe136" />
+  </nuclide>
+  <nuclide name="Xe136" decay_modes="0" reactions="0" />
+  <nuclide name="Cs135" decay_modes="0" reactions="0" />
+  <nuclide name="Gd157" decay_modes="0" reactions="1"  >
+    <reaction type="(n,gamma)" Q="0.0" target="Nothing" />
+  </nuclide>
+  <nuclide name="Gd156" decay_modes="0" reactions="1">
+    <reaction type="(n,gamma)" Q="0.0" target="Gd157" />
+  </nuclide>
+  <nuclide name="U234" decay_modes="0" reactions="1">
+    <reaction type="fission" Q="191840000."/>
+    <neutron_fission_yields>
+      <energies>2.53000e-02</energies>
+      <fission_yields energy="2.53000e-02">
+        <products>Gd157 Gd156 I135 Xe135 Xe136 Cs135</products>
+        <data>1.093250e-04 2.087260e-04 2.780820e-02 6.759540e-03 2.392300e-02 4.356330e-05</data>
+      </fission_yields>
+    </neutron_fission_yields>
+  </nuclide>
+  <nuclide name="U235" decay_modes="0" reactions="1">
+    <reaction type="fission" Q="193410000."/>
+    <neutron_fission_yields>
+      <energies>2.53000e-02</energies>
+      <fission_yields energy="2.53000e-02">
+        <products>Gd157 Gd156 I135 Xe135 Xe136 Cs135</products>
+        <data>6.142710e-5 1.483250e-04 0.0292737 0.002566345 0.0219242 4.9097e-6</data>
+      </fission_yields>
+    </neutron_fission_yields>
+  </nuclide>
+  <nuclide name="U238" decay_modes="0" reactions="1">
+    <reaction type="fission" Q="197790000."/>
+    <neutron_fission_yields>
+      <energies>2.53000e-02</energies>
+      <fission_yields energy="2.53000e-02">
+        <products>Gd157 Gd156 I135 Xe135 Xe136 Cs135</products>
+        <data>4.141120e-04 7.605360e-04 0.0135457 0.00026864 0.0024432 3.7100E-07</data>
+      </fission_yields>
+    </neutron_fission_yields>
+  </nuclide>
+</depletion_chain>

--- a/examples/python/pincell_depletion/run_depletion.py
+++ b/examples/python/pincell_depletion/run_depletion.py
@@ -12,11 +12,11 @@ particles = 1000
 
 # Depletion simulation parameters
 time_step = 1.*24*60*60 # s
-final_time = 45.*24*60*60 # s
+final_time = 15.*24*60*60 # s
 time_steps = np.full(np.int(final_time / time_step), time_step)
 
 chain_file = './chain_simple.xml'
-power = 174.1 # W/cm, for 2D simulations only
+power = 174 # W/cm, for 2D simulations only (use W for 3D)
 
 ###############################################################################
 #                              Define materials
@@ -134,7 +134,7 @@ settings_file.entropy_mesh = entropy_mesh
 settings_file.export_to_xml()
 
 ###############################################################################
-#                         Run depletion calculation
+#                   Initialize and run depletion calculation
 ###############################################################################
 
 op = openmc.deplete.Operator(geometry, settings_file, chain_file)
@@ -158,4 +158,4 @@ nuc_to_ind = results[0].nuc_to_ind
 time, keff = results.get_eigenvalue()
                                                                                                                                                                                                                                                                                                                                                                                                                                                         
 # Obtain U235 concentration as a function of time
-time, U5 = results.get_atoms(mat_id_to_ind['1'], nuc_to_ind['U235'])
+time, n_U235 = results.get_atoms(mat_id_to_ind['1'], nuc_to_ind['U235'])

--- a/examples/python/pincell_depletion/run_depletion.py
+++ b/examples/python/pincell_depletion/run_depletion.py
@@ -1,0 +1,161 @@
+import openmc
+import numpy as np
+
+###############################################################################
+#                      Simulation Input File Parameters
+###############################################################################
+
+# OpenMC simulation parameters
+batches = 100
+inactive = 10
+particles = 1000
+
+# Depletion simulation parameters
+time_step = 1.*24*60*60 # s
+final_time = 45.*24*60*60 # s
+time_steps = np.full(np.int(final_time / time_step), time_step)
+
+chain_file = './chain_simple.xml'
+power = 174.1 # W/cm, for 2D simulations only
+
+###############################################################################
+#                              Define materials
+###############################################################################
+
+# Instantiate some Materials and register the appropriate Nuclides
+uo2 = openmc.Material(material_id=1, name='UO2 fuel at 2.4% wt enrichment')
+uo2.set_density('g/cm3', 10.29769)
+uo2.add_element('U', 1., enrichment=2.4)
+uo2.add_element('O', 2.)
+uo2.depletable = True
+
+helium = openmc.Material(material_id=2, name='Helium for gap')
+helium.set_density('g/cm3', 0.001598)
+helium.add_element('He', 2.4044e-4)
+helium.depletable = False
+
+zircaloy = openmc.Material(material_id=3, name='Zircaloy 4')
+zircaloy.set_density('g/cm3', 6.55)
+zircaloy.add_element('Sn', 0.014  , 'wo')
+zircaloy.add_element('Fe', 0.00165, 'wo')
+zircaloy.add_element('Cr', 0.001  , 'wo')
+zircaloy.add_element('Zr', 0.98335, 'wo')
+zircaloy.depletable = False
+
+borated_water = openmc.Material(material_id=4, name='Borated water')
+borated_water.set_density('g/cm3', 0.740582)
+borated_water.add_element('B', 4.0e-5)
+borated_water.add_element('H', 5.0e-2)
+borated_water.add_element('O', 2.4e-2)
+borated_water.add_s_alpha_beta('c_H_in_H2O')
+borated_water.depletable = False
+
+###############################################################################
+#                 Exporting to OpenMC geometry.xml file
+###############################################################################
+
+# Instantiate ZCylinder surfaces
+fuel_or = openmc.ZCylinder(surface_id=1, x0=0, y0=0, R=0.39218, name='Fuel OR')
+clad_ir = openmc.ZCylinder(surface_id=2, x0=0, y0=0, R=0.40005, name='Clad IR')
+clad_or = openmc.ZCylinder(surface_id=3, x0=0, y0=0, R=0.45720, name='Clad OR')
+left = openmc.XPlane(surface_id=4, x0=-0.62992, name='left')
+right = openmc.XPlane(surface_id=5, x0=0.62992, name='right')
+bottom = openmc.YPlane(surface_id=6, y0=-0.62992, name='bottom')
+top = openmc.YPlane(surface_id=7, y0=0.62992, name='top')
+
+left.boundary_type = 'reflective'
+right.boundary_type = 'reflective'
+top.boundary_type = 'reflective'
+bottom.boundary_type = 'reflective'
+
+# Instantiate Cells
+fuel = openmc.Cell(cell_id=1, name='cell 1')
+gap = openmc.Cell(cell_id=2, name='cell 2')
+clad = openmc.Cell(cell_id=3, name='cell 3')
+water = openmc.Cell(cell_id=4, name='cell 4')
+
+# Use surface half-spaces to define regions
+fuel.region = -fuel_or
+gap.region = +fuel_or & -clad_ir
+clad.region = +clad_ir & -clad_or
+water.region = +clad_or & +left & -right & +bottom & -top
+
+# Register Materials with Cells
+fuel.fill = uo2
+gap.fill = helium
+clad.fill = zircaloy
+water.fill = borated_water
+
+# Instantiate Universe
+root = openmc.Universe(universe_id=0, name='root universe')
+
+# Register Cells with Universe
+root.add_cells([fuel, gap, clad, water])
+
+# Instantiate a Geometry, register the root Universe, and export to XML
+geometry = openmc.Geometry(root)
+geometry.export_to_xml()
+
+###############################################################################
+#                   Exporting to OpenMC materials.xml file
+###############################################################################
+
+# Compute cell areas
+area = {}
+area[fuel] = np.pi * fuel_or.coefficients['R'] ** 2
+
+# Set materials volume for depletion. Set to an area for 2D simulations
+uo2.volume = area[fuel]
+
+# Instantiate a Materials collection and export to XML
+materials_file = openmc.Materials([uo2, helium, zircaloy, borated_water])
+materials_file.export_to_xml()
+
+###############################################################################
+#                   Exporting to OpenMC settings.xml file
+###############################################################################
+
+# Instantiate a Settings object, set all runtime parameters, and export to XML
+settings_file = openmc.Settings()
+settings_file.batches = batches
+settings_file.inactive = inactive
+settings_file.particles = particles
+
+# Create an initial uniform spatial source distribution over fissionable zones
+bounds = [-0.62992, -0.62992, -1, 0.62992, 0.62992, 1]
+uniform_dist = openmc.stats.Box(bounds[:3], bounds[3:], only_fissionable=True)
+settings_file.source = openmc.source.Source(space=uniform_dist)
+
+entropy_mesh = openmc.Mesh()
+entropy_mesh.lower_left = [-0.39218, -0.39218, -1.e50]
+entropy_mesh.upper_right = [0.39218, 0.39218, 1.e50]
+entropy_mesh.dimension = [10, 10, 1]
+settings_file.entropy_mesh = entropy_mesh
+settings_file.export_to_xml()
+
+###############################################################################
+#                         Run depletion calculation
+###############################################################################
+
+op = openmc.deplete.Operator(geometry, settings_file, chain_file)
+op.round_number = True
+
+# Perform simulation using the predictor algorithm
+openmc.deplete.integrator.predictor(op, time_steps, power)
+
+###############################################################################
+#                    Read depletion calculation results
+###############################################################################
+
+# Open results file
+results = openmc.deplete.ResultsList("depletion_results.h5")
+
+# Dictionnary of materials and burned nuclides
+mat_id_to_ind = results[0].mat_to_ind
+nuc_to_ind = results[0].nuc_to_ind
+
+# Obtain K_eff as a function of time
+time, keff = results.get_eigenvalue()
+                                                                                                                                                                                                                                                                                                                                                                                                                                                        
+# Obtain U235 concentration as a function of time
+time, U5 = results.get_atoms(mat_id_to_ind['1'], nuc_to_ind['U235'])

--- a/examples/python/pincell_depletion/run_depletion.py
+++ b/examples/python/pincell_depletion/run_depletion.py
@@ -1,4 +1,5 @@
 import openmc
+import openmc.deplete
 import numpy as np
 
 ###############################################################################
@@ -11,9 +12,9 @@ inactive = 10
 particles = 1000
 
 # Depletion simulation parameters
-time_step = 1.*24*60*60 # s
-final_time = 15.*24*60*60 # s
-time_steps = np.full(np.int(final_time / time_step), time_step)
+time_step = 1*24*60*60 # s
+final_time = 15*24*60*60 # s
+time_steps = np.full(final_time // time_step, time_step)
 
 chain_file = './chain_simple.xml'
 power = 174 # W/cm, for 2D simulations only (use W for 3D)
@@ -32,7 +33,6 @@ uo2.depletable = True
 helium = openmc.Material(material_id=2, name='Helium for gap')
 helium.set_density('g/cm3', 0.001598)
 helium.add_element('He', 2.4044e-4)
-helium.depletable = False
 
 zircaloy = openmc.Material(material_id=3, name='Zircaloy 4')
 zircaloy.set_density('g/cm3', 6.55)
@@ -40,7 +40,6 @@ zircaloy.add_element('Sn', 0.014  , 'wo')
 zircaloy.add_element('Fe', 0.00165, 'wo')
 zircaloy.add_element('Cr', 0.001  , 'wo')
 zircaloy.add_element('Zr', 0.98335, 'wo')
-zircaloy.depletable = False
 
 borated_water = openmc.Material(material_id=4, name='Borated water')
 borated_water.set_density('g/cm3', 0.740582)
@@ -48,7 +47,6 @@ borated_water.add_element('B', 4.0e-5)
 borated_water.add_element('H', 5.0e-2)
 borated_water.add_element('O', 2.4e-2)
 borated_water.add_s_alpha_beta('c_H_in_H2O')
-borated_water.depletable = False
 
 ###############################################################################
 #                 Exporting to OpenMC geometry.xml file
@@ -92,9 +90,8 @@ root = openmc.Universe(universe_id=0, name='root universe')
 # Register Cells with Universe
 root.add_cells([fuel, gap, clad, water])
 
-# Instantiate a Geometry, register the root Universe, and export to XML
+# Instantiate a Geometry, register the root Universe
 geometry = openmc.Geometry(root)
-geometry.export_to_xml()
 
 ###############################################################################
 #                   Exporting to OpenMC materials.xml file
@@ -106,10 +103,6 @@ area[fuel] = np.pi * fuel_or.coefficients['R'] ** 2
 
 # Set materials volume for depletion. Set to an area for 2D simulations
 uo2.volume = area[fuel]
-
-# Instantiate a Materials collection and export to XML
-materials_file = openmc.Materials([uo2, helium, zircaloy, borated_water])
-materials_file.export_to_xml()
 
 ###############################################################################
 #                   Exporting to OpenMC settings.xml file
@@ -131,14 +124,12 @@ entropy_mesh.lower_left = [-0.39218, -0.39218, -1.e50]
 entropy_mesh.upper_right = [0.39218, 0.39218, 1.e50]
 entropy_mesh.dimension = [10, 10, 1]
 settings_file.entropy_mesh = entropy_mesh
-settings_file.export_to_xml()
 
 ###############################################################################
 #                   Initialize and run depletion calculation
 ###############################################################################
 
 op = openmc.deplete.Operator(geometry, settings_file, chain_file)
-op.round_number = True
 
 # Perform simulation using the predictor algorithm
 openmc.deplete.integrator.predictor(op, time_steps, power)
@@ -150,12 +141,8 @@ openmc.deplete.integrator.predictor(op, time_steps, power)
 # Open results file
 results = openmc.deplete.ResultsList("depletion_results.h5")
 
-# Dictionnary of materials and burned nuclides
-mat_id_to_ind = results[0].mat_to_ind
-nuc_to_ind = results[0].nuc_to_ind
-
 # Obtain K_eff as a function of time
 time, keff = results.get_eigenvalue()
                                                                                                                                                                                                                                                                                                                                                                                                                                                         
 # Obtain U235 concentration as a function of time
-time, n_U235 = results.get_atoms(mat_id_to_ind['1'], nuc_to_ind['U235'])
+time, n_U235 = results.get_atoms('1', 'U235')


### PR DESCRIPTION
Added a simple python example to help people use the new depletion capabilities. 
It's mostly based on:
- the pincell python example
- the regression test test_deplete_full.py

It introduces the units to be used in a non-confusing way, and some basic functions to run depletion and to examine the results. 

Longer term, we should have an iPython notebook for this. 