### PR TITLE
Added some install information to documentation

### DIFF
--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -148,8 +148,8 @@ Prerequisites
       .. important::
 
           If you are building HDF5 version 1.8.x or earlier, you must include
-          ``--enable-fortran2003`` when configuring HDF5 or else OpenMC will not
-          be able to compile.
+          ``--enable-fortran2003`` as well when configuring HDF5 or else OpenMC 
+          will not be able to compile.
 
 .. admonition:: Optional
    :class: note
@@ -416,7 +416,8 @@ Prerequisites
 The Python API works with Python 3.4+. In addition to Python itself, the API
 relies on a number of third-party packages. All prerequisites can be installed
 using Conda_ (recommended), pip_, or through the package manager in most Linux
-distributions.
+distributions. To run simulations in parallel using MPI, it is recommended to
+build mpi4py, hdf5, h5py from source, in that order, using the same compilers.
 
 .. admonition:: Required
    :class: error
@@ -455,7 +456,7 @@ distributions.
    `mpi4py <http://mpi4py.scipy.org/>`_
       mpi4py provides Python bindings to MPI for running distributed-memory
       parallel runs. This package is needed if you plan on running depletion
-      simulations in parallel using MPI.
+      simulations.
 
    `Cython <http://cython.org/>`_
       Cython is used for resonance reconstruction for ENDF data converted to

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -418,7 +418,7 @@ relies on a number of third-party packages. All prerequisites can be installed
 using Conda_ (recommended), pip_, or through the package manager in most Linux
 distributions. To run simulations in parallel using MPI, it is recommended to
 build mpi4py, HDF5, h5py from source, in that order, using the same compilers
-as for openMC.
+as for OpenMC.
 
 .. admonition:: Required
    :class: error

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -417,7 +417,8 @@ The Python API works with Python 3.4+. In addition to Python itself, the API
 relies on a number of third-party packages. All prerequisites can be installed
 using Conda_ (recommended), pip_, or through the package manager in most Linux
 distributions. To run simulations in parallel using MPI, it is recommended to
-build mpi4py, hdf5, h5py from source, in that order, using the same compilers.
+build mpi4py, hdf5, h5py from source, in that order, using the same compilers
+as for openmc.
 
 .. admonition:: Required
    :class: error

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -417,8 +417,8 @@ The Python API works with Python 3.4+. In addition to Python itself, the API
 relies on a number of third-party packages. All prerequisites can be installed
 using Conda_ (recommended), pip_, or through the package manager in most Linux
 distributions. To run simulations in parallel using MPI, it is recommended to
-build mpi4py, hdf5, h5py from source, in that order, using the same compilers
-as for openmc.
+build mpi4py, HDF5, h5py from source, in that order, using the same compilers
+as for openMC.
 
 .. admonition:: Required
    :class: error
@@ -457,7 +457,7 @@ as for openmc.
    `mpi4py <http://mpi4py.scipy.org/>`_
       mpi4py provides Python bindings to MPI for running distributed-memory
       parallel runs. This package is needed if you plan on running depletion
-      simulations.
+      simulations in parallel using MPI.
 
    `Cython <http://cython.org/>`_
       Cython is used for resonance reconstruction for ENDF data converted to


### PR DESCRIPTION
Added a few details on how to install, based on my experience installing openmc on very simple machines. 
3 changes:
- when I add --enable-fortran2003 without --enable-fortran I get an error message for HDF5 1.8.9

- I had a lot of trouble re-installing openmc last time, and re-installing mpi4py and hdf5 before h5py seemed to help. Making sure to use the same compilers is advice I got from everyone. 

- I haven't checked but I think I remember @cjosey saying MPI was required to run depletion calculations (in parallel or not)