### PR TITLE
[Hotfix] Updates for tallying currents with MeshSurfaceFilter

### DIFF
--- a/docs/source/usersguide/tallies.rst
+++ b/docs/source/usersguide/tallies.rst
@@ -261,7 +261,7 @@ The following tables show all valid scores:
     +----------------------+---------------------------------------------------+
     |Score                 | Description                                       |
     +======================+===================================================+
-    |current               |Used in combination with a mesh filter:            |
+    |current               |Used in combination with a meshsurface filter:     |
     |                      |Partial currents on the boundaries of each cell in |
     |                      |a mesh. It may not be used in conjunction with any |
     |                      |other score. Only energy and mesh filters may be   |
@@ -269,7 +269,7 @@ The following tables show all valid scores:
     |                      |Used in combination with a surface filter:         |
     |                      |Net currents on any surface previously defined in  |
     |                      |the geometry. It may be used along with any other  |
-    |                      |filter, except mesh filters.                       |
+    |                      |filter, except meshsurface filters.                |
     |                      |Surfaces can alternatively be defined with cell    |
     |                      |from and cell filters thereby resulting in tallying|
     |                      |partial currents.                                  |

--- a/examples/jupyter/tally-arithmetic.ipynb
+++ b/examples/jupyter/tally-arithmetic.ipynb
@@ -287,18 +287,7 @@
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Run openmc in plotting mode\n",
     "openmc.plot_geometry(output=False)"
@@ -313,7 +302,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPoAAAD6AgMAAAD1grKuAAAABGdBTUEAALGPC/xhBQAAACBjSFJN\nAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAADFBMVEX///9yEhLpgJFNv8Tq\nQYT7AAAAAWJLR0QAiAUdSAAAAAd0SU1FB+EMBQIrDwapSyIAAALKSURBVGje7dpLcqQwDAbgHHE2\nYeEj+D4cwQucBUfo+3CEXoSp8OhuhF70T4qpKXmdr21LogK2Pj7A8QmNP+HDhw8fPnz48Kf6VH9G\n+66vy+je8k19jnf8C5dXIPv86ms56lPdjvaYbyodx3ze+XLE76cXFiD4zPji99z0/AJ4n1lfvJ6f\nnl0A6x+578efMSg1wPr172/jPO5yFXM+Ef78gdblM+WPHyguP//t1/g6pA0wfln+ho/fwgYYn19C\n/xwDvwHGc9OvC+hs37DTrwuwfWanXxdQTC9Mvyygs3wjTL8uwPJpn/tNDbSGz7T0SBEWw4vLXzbQ\n6b6RoveIoO6TvPxlA63qs7z8ZQPF9F+SH22vbX8OQKf5Rtv+EgDNJ3X58wZaxWd1+fMGiuFvir8b\nvjp8J/tGy/6jAmRvhW8fwL3vVT+o3grfPoB7r/IpALI3tz8FoJN84/NV873hB8UnM3xzANtf8nb4\ndwmg3grfFEDJO8JPE0i9Ff4pAYL3pI8mkHor/HMCeO9JH00g9SafEsh7T/ppARBvp48UwJnelT5S\nACd7O31TAlnvKx9SQCd7B58KgPO+8iMFuPWe9E8F8BveWX7bAjzX9y4//Jve+fhsH6Ctv7n8PTzj\nvY/v9gEOHz58+PBX+6v/f/wPvnd54f3j6venE/yl769Xv7+j3x/o98/V32/o9+fl389Xnx+g5x/o\n+Qt6/oOeP6HnX+j5G3z+h54/ouefV5/foufP6Pk3ev4On/+j9w/o/Qd6/4Le/6D3T/D9V67Y/ZsV\nQBq+s+8f0ftP+P41axXguP9NWgDuu/Cdfv+N3r/D9/9TAID+A7T/Ae2/gPs/0P4TtP8F7r9J3AIO\n9P+g/Udw/9Oygbf7r9D+L7j/DO1/Q/vv4P4/tP8Q7n9E+y/h/k+0/xTuf4X7b+H+X7T/+BPuf3aM\n8OHDhw8fPnz4w/4vzcvgeY10sY0AAAAldEVYdGRhdGU6Y3JlYXRlADIwMTctMTItMDRUMjA6NDM6\nMTQtMDY6MDCrFYTfAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE3LTEyLTA0VDIwOjQzOjE0LTA2OjAw\n2kg8YwAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPoAAAD6AgMAAAD1grKuAAAABGdBTUEAALGPC/xhBQAAAAFzUkdC\nAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAxQTFRF\n////chIS6YCRTb/E6kGE+wAAAAFiS0dEAIgFHUgAAAAJcEhZcwAAAEgAAABIAEbJaz4AAALKSURB\nVGje7dpLcqQwDAbgHHE2YeEj+D4cwQucBUfo+3CEXoSp8OhuhF70T4qpKXmdr21LogK2Pj7A8QmN\nP+HDhw8fPnz48Kf6VH9G+66vy+je8k19jnf8C5dXIPv86ms56lPdjvaYbyodx3ze+XLE76cXFiD4\nzPji99z0/AJ4n1lfvJ6fnl0A6x+578efMSg1wPr172/jPO5yFXM+Ef78gdblM+WPHyguP//t1/g6\npA0wfln+ho/fwgYYn19C/xwDvwHGc9OvC+hs37DTrwuwfWanXxdQTC9Mvyygs3wjTL8uwPJpn/tN\nDbSGz7T0SBEWw4vLXzbQ6b6RoveIoO6TvPxlA63qs7z8ZQPF9F+SH22vbX8OQKf5Rtv+EgDNJ3X5\n8wZaxWd1+fMGiuFvir8bvjp8J/tGy/6jAmRvhW8fwL3vVT+o3grfPoB7r/IpALI3tz8FoJN84/NV\n873hB8UnM3xzANtf8nb4dwmg3grfFEDJO8JPE0i9Ff4pAYL3pI8mkHor/HMCeO9JH00g9SafEsh7\nT/ppARBvp48UwJnelT5SACd7O31TAlnvKx9SQCd7B58KgPO+8iMFuPWe9E8F8BveWX7bAjzX9y4/\n/Jve+fhsH6Ctv7n8PTzjvY/v9gEOHz58+PBX+6v/f/wPvnd54f3j6venE/yl769Xv7+j3x/o98/V\n32/o9+fl389Xnx+g5x/o+Qt6/oOeP6HnX+j5G3z+h54/ouefV5/foufP6Pk3ev4On/+j9w/o/Qd6\n/4Le/6D3T/D9V67Y/ZsVQBq+s+8f0ftP+P41axXguP9NWgDuu/Cdfv+N3r/D9/9TAID+A7T/Ae2/\ngPs/0P4TtP8F7r9J3AIO9P+g/Udw/9Oygbf7r9D+L7j/DO1/Q/vv4P4/tP8Q7n9E+y/h/k+0/xTu\nf4X7b+H+X7T/+BPuf3aM8OHDhw8fPnz4w/4vzcvgeY10sY0AAAAldEVYdGRhdGU6Y3JlYXRlADIw\nMTgtMDQtMDNUMjE6MTE6MzgtMDQ6MDD1dVTHAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE4LTA0LTAz\nVDIxOjExOjM4LTA0OjAwhCjsewAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<IPython.core.display.Image object>"
       ]
@@ -392,21 +381,21 @@
     "mesh.dimension = [1, 1, 1]\n",
     "mesh.lower_left = [-0.63, -0.63, -100.]\n",
     "mesh.width = [1.26, 1.26, 200.]\n",
-    "mesh_filter = openmc.MeshFilter(mesh)\n",
+    "meshsurface_filter = openmc.MeshSurfaceFilter(mesh)\n",
     "\n",
     "# Instantiate thermal, fast, and total leakage tallies\n",
     "leak = openmc.Tally(name='leakage')\n",
-    "leak.filters = [mesh_filter]\n",
+    "leak.filters = [meshsurface_filter]\n",
     "leak.scores = ['current']\n",
     "tallies_file.append(leak)\n",
     "\n",
     "thermal_leak = openmc.Tally(name='thermal leakage')\n",
-    "thermal_leak.filters = [mesh_filter, openmc.EnergyFilter([0., 0.625])]\n",
+    "thermal_leak.filters = [meshsurface_filter, openmc.EnergyFilter([0., 0.625])]\n",
     "thermal_leak.scores = ['current']\n",
     "tallies_file.append(thermal_leak)\n",
     "\n",
     "fast_leak = openmc.Tally(name='fast leakage')\n",
-    "fast_leak.filters = [mesh_filter, openmc.EnergyFilter([0.625, 20.0e6])]\n",
+    "fast_leak.filters = [meshsurface_filter, openmc.EnergyFilter([0.625, 20.0e6])]\n",
     "fast_leak.scores = ['current']\n",
     "tallies_file.append(fast_leak)"
    ]
@@ -504,11 +493,11 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/romano/openmc/openmc/mixin.py:61: IDWarning: Another EnergyFilter instance already exists with id=6.\n",
+      "/home/liangjg/.local/lib/python3.5/site-packages/openmc-0.10.0-py3.5.egg/openmc/mixin.py:71: IDWarning: Another Filter instance already exists with id=6.\n",
       "  warn(msg, IDWarning)\n",
-      "/home/romano/openmc/openmc/mixin.py:61: IDWarning: Another CellFilter instance already exists with id=3.\n",
+      "/home/liangjg/.local/lib/python3.5/site-packages/openmc-0.10.0-py3.5.egg/openmc/mixin.py:71: IDWarning: Another Filter instance already exists with id=3.\n",
       "  warn(msg, IDWarning)\n",
-      "/home/romano/openmc/openmc/mixin.py:61: IDWarning: Another CellFilter instance already exists with id=2.\n",
+      "/home/liangjg/.local/lib/python3.5/site-packages/openmc-0.10.0-py3.5.egg/openmc/mixin.py:71: IDWarning: Another Filter instance already exists with id=2.\n",
       "  warn(msg, IDWarning)\n"
      ]
     }
@@ -563,24 +552,25 @@
       "                                     %%%%%%%%%%%\n",
       "\n",
       "                   | The OpenMC Monte Carlo Code\n",
-      "         Copyright | 2011-2017 Massachusetts Institute of Technology\n",
+      "         Copyright | 2011-2018 Massachusetts Institute of Technology\n",
       "           License | http://openmc.readthedocs.io/en/latest/license.html\n",
-      "           Version | 0.9.0\n",
-      "          Git SHA1 | 9b7cebf7bc34d60e0f1750c3d6cb103df11e8dc4\n",
-      "         Date/Time | 2017-12-04 20:43:15\n",
-      "    OpenMP Threads | 4\n",
+      "           Version | 0.10.0\n",
+      "          Git SHA1 | 47fbf8282ea94c138f75219bd10fdb31501d3fb7\n",
+      "         Date/Time | 2018-04-03 21:12:27\n",
+      "     MPI Processes | 1\n",
+      "    OpenMP Threads | 20\n",
       "\n",
       " Reading settings XML file...\n",
       " Reading cross sections XML file...\n",
       " Reading materials XML file...\n",
       " Reading geometry XML file...\n",
       " Building neighboring cells lists for each surface...\n",
-      " Reading U235 from /home/romano/openmc/scripts/nndc_hdf5/U235.h5\n",
-      " Reading U238 from /home/romano/openmc/scripts/nndc_hdf5/U238.h5\n",
-      " Reading O16 from /home/romano/openmc/scripts/nndc_hdf5/O16.h5\n",
-      " Reading H1 from /home/romano/openmc/scripts/nndc_hdf5/H1.h5\n",
-      " Reading B10 from /home/romano/openmc/scripts/nndc_hdf5/B10.h5\n",
-      " Reading Zr90 from /home/romano/openmc/scripts/nndc_hdf5/Zr90.h5\n",
+      " Reading U235 from /home/liangjg/nucdata/nndc_hdf5/U235.h5\n",
+      " Reading U238 from /home/liangjg/nucdata/nndc_hdf5/U238.h5\n",
+      " Reading O16 from /home/liangjg/nucdata/nndc_hdf5/O16.h5\n",
+      " Reading H1 from /home/liangjg/nucdata/nndc_hdf5/H1.h5\n",
+      " Reading B10 from /home/liangjg/nucdata/nndc_hdf5/B10.h5\n",
+      " Reading Zr90 from /home/liangjg/nucdata/nndc_hdf5/Zr90.h5\n",
       " Maximum neutron transport energy: 2.00000E+07 eV for U235\n",
       " Reading tallies XML file...\n",
       " Writing summary.h5 file...\n",
@@ -614,20 +604,20 @@
       "\n",
       " =======================>     TIMING STATISTICS     <=======================\n",
       "\n",
-      " Total time for initialization     =  5.6782E-01 seconds\n",
-      "   Reading cross sections          =  5.3276E-01 seconds\n",
-      " Total time in simulation          =  6.4149E+00 seconds\n",
-      "   Time in transport only          =  6.2767E+00 seconds\n",
-      "   Time in inactive batches        =  6.8747E-01 seconds\n",
-      "   Time in active batches          =  5.7274E+00 seconds\n",
-      "   Time synchronizing fission bank =  2.7492E-03 seconds\n",
-      "     Sampling source sites         =  1.9584E-03 seconds\n",
-      "     SEND/RECV source sites        =  7.4113E-04 seconds\n",
-      "   Time accumulating tallies       =  1.0576E-04 seconds\n",
-      " Total time for finalization       =  2.2075E-03 seconds\n",
-      " Total time elapsed                =  7.0056E+00 seconds\n",
-      " Calculation Rate (inactive)       =  18182.5 neutrons/second\n",
-      " Calculation Rate (active)         =  6547.45 neutrons/second\n",
+      " Total time for initialization     =  4.9090E-01 seconds\n",
+      "   Reading cross sections          =  4.2387E-01 seconds\n",
+      " Total time in simulation          =  1.4928E+00 seconds\n",
+      "   Time in transport only          =  1.3545E+00 seconds\n",
+      "   Time in inactive batches        =  1.3625E-01 seconds\n",
+      "   Time in active batches          =  1.3565E+00 seconds\n",
+      "   Time synchronizing fission bank =  2.4053E-03 seconds\n",
+      "     Sampling source sites         =  1.6466E-03 seconds\n",
+      "     SEND/RECV source sites        =  5.6159E-04 seconds\n",
+      "   Time accumulating tallies       =  3.3647E-04 seconds\n",
+      " Total time for finalization       =  1.6066E-02 seconds\n",
+      " Total time elapsed                =  2.0336E+00 seconds\n",
+      " Calculation Rate (inactive)       =  91743.2 neutrons/second\n",
+      " Calculation Rate (active)         =  27644.5 neutrons/second\n",
       "\n",
       " ============================>     RESULTS     <============================\n",
       "\n",
@@ -638,16 +628,6 @@
       " Leakage Fraction            =  0.01717 +/-  0.00107\n",
       "\n"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "0"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -741,8 +721,7 @@
     "\n",
     "# Get the leakage tally\n",
     "leak = sp.get_tally(name='leakage')\n",
-    "leak = leak.summation(filter_type=openmc.SurfaceFilter, remove_filter=True)\n",
-    "leak = leak.summation(filter_type=openmc.MeshFilter, remove_filter=True)\n",
+    "leak = leak.summation(filter_type=openmc.MeshSurfaceFilter, remove_filter=True)\n",
     "\n",
     "# Compute k-infinity using tally arithmetic\n",
     "keff = fiss_rate / (abs_rate + leak)\n",
@@ -812,8 +791,7 @@
     "# Compute resonance escape probability using tally arithmetic\n",
     "therm_abs_rate = sp.get_tally(name='therm. abs. rate')\n",
     "thermal_leak = sp.get_tally(name='thermal leakage')\n",
-    "thermal_leak = thermal_leak.summation(filter_type=openmc.SurfaceFilter, remove_filter=True)\n",
-    "thermal_leak = thermal_leak.summation(filter_type=openmc.MeshFilter, remove_filter=True)\n",
+    "thermal_leak = thermal_leak.summation(filter_type=openmc.MeshSurfaceFilter, remove_filter=True)\n",
     "res_esc = (therm_abs_rate + thermal_leak) / (abs_rate + thermal_leak)\n",
     "res_esc.get_pandas_dataframe()"
    ]

--- a/src/input_xml.F90
+++ b/src/input_xml.F90
@@ -2853,6 +2853,9 @@ contains
                 call fatal_error("Cannot tally other scores in the &
                      &same tally as surface currents")
               end if
+            else
+                call fatal_error("Cannot tally currents without surface &
+                     &type filters")
             end if
 
           case ('events')


### PR DESCRIPTION
PR #986 implemented MeshSurfaceFilter which can be used to tally currents of mesh surfaces. However, the example jupyter notebook `Tally Arithmetic` was not updated (Zhuoran found this when doing homework of 22.211). openmc crashes when it tries to tally a `current` tally without a surface-type filter because of the uninitialized array `score_bins`. This PR fixes these minor errors.