### PR TITLE
Allow tallies to be activated from C API

### DIFF
--- a/include/openmc.h
+++ b/include/openmc.h
@@ -88,12 +88,14 @@ extern "C" {
   int openmc_sphharm_filter_set_order(int32_t index, int order);
   int openmc_sphharm_filter_set_cosine(int32_t index, const char cosine[]);
   void openmc_statepoint_write(const char filename[]);
+  int openmc_tally_get_active(int32_t index, bool* active);
   int openmc_tally_get_id(int32_t index, int32_t* id);
   int openmc_tally_get_filters(int32_t index, int32_t** indices, int* n);
   int openmc_tally_get_n_realizations(int32_t index, int32_t* n);
   int openmc_tally_get_nuclides(int32_t index, int** nuclides, int* n);
   int openmc_tally_get_scores(int32_t index, int** scores, int* n);
   int openmc_tally_results(int32_t index, double** ptr, int shape_[3]);
+  int openmc_tally_set_active(int32_t index, bool active);
   int openmc_tally_set_filters(int32_t index, int n, const int32_t* indices);
   int openmc_tally_set_id(int32_t index, int32_t id);
   int openmc_tally_set_nuclides(int32_t index, int n, const char** nuclides);

--- a/openmc/capi/tally.py
+++ b/openmc/capi/tally.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-from ctypes import c_int, c_int32, c_double, c_char_p, POINTER
+from ctypes import c_int, c_int32, c_double, c_char_p, c_bool, POINTER
 from weakref import WeakValueDictionary
 
 import numpy as np
@@ -26,6 +26,9 @@ _dll.openmc_get_tally_index.errcheck = _error_handler
 _dll.openmc_global_tallies.argtypes = [POINTER(POINTER(c_double))]
 _dll.openmc_global_tallies.restype = c_int
 _dll.openmc_global_tallies.errcheck = _error_handler
+_dll.openmc_tally_get_active.argtypes = [c_int32, POINTER(c_bool)]
+_dll.openmc_tally_get_active.restype = c_int
+_dll.openmc_tally_get_active.errcheck = _error_handler
 _dll.openmc_tally_get_id.argtypes = [c_int32, POINTER(c_int32)]
 _dll.openmc_tally_get_id.restype = c_int
 _dll.openmc_tally_get_id.errcheck = _error_handler
@@ -48,6 +51,9 @@ _dll.openmc_tally_results.argtypes = [
     c_int32, POINTER(POINTER(c_double)), POINTER(c_int*3)]
 _dll.openmc_tally_results.restype = c_int
 _dll.openmc_tally_results.errcheck = _error_handler
+_dll.openmc_tally_set_active.argtypes = [c_int32, c_bool]
+_dll.openmc_tally_set_active.restype = c_int
+_dll.openmc_tally_set_active.errcheck = _error_handler
 _dll.openmc_tally_set_filters.argtypes = [c_int32, c_int, POINTER(c_int32)]
 _dll.openmc_tally_set_filters.restype = c_int
 _dll.openmc_tally_set_filters.errcheck = _error_handler
@@ -177,6 +183,16 @@ class Tally(_FortranObjectWithID):
             cls.__instances[index] = instance
 
         return cls.__instances[index]
+
+    @property
+    def active(self):
+        active = c_bool()
+        _dll.openmc_tally_get_active(self._index, active)
+        return active.value
+
+    @active.setter
+    def active(self, active):
+        _dll.openmc_tally_set_active(self._index, active)
 
     @property
     def id(self):

--- a/src/tallies/tally_header.F90
+++ b/src/tallies/tally_header.F90
@@ -24,12 +24,14 @@ module tally_header
   public :: openmc_extend_tallies
   public :: openmc_get_tally_index
   public :: openmc_global_tallies
+  public :: openmc_tally_get_active
   public :: openmc_tally_get_id
   public :: openmc_tally_get_filters
   public :: openmc_tally_get_n_realizations
   public :: openmc_tally_get_nuclides
   public :: openmc_tally_get_scores
   public :: openmc_tally_results
+  public :: openmc_tally_set_active
   public :: openmc_tally_set_filters
   public :: openmc_tally_set_id
   public :: openmc_tally_set_nuclides
@@ -512,6 +514,22 @@ contains
   end function openmc_global_tallies
 
 
+  function openmc_tally_get_active(index, active) result(err) bind(C)
+    ! Return whether a tally is active
+    integer(C_INT32_T), value    :: index
+    logical(C_BOOL), intent(out) :: active
+    integer(C_INT) :: err
+
+    if (index >= 1 .and. index <= size(tallies)) then
+      active = tallies(index) % obj % active
+      err = 0
+    else
+      err = E_OUT_OF_BOUNDS
+      call set_errmsg('Index in tallies array is out of bounds.')
+    end if
+  end function openmc_tally_get_active
+
+
   function openmc_tally_get_id(index, id) result(err) bind(C)
     ! Return the ID of a tally
     integer(C_INT32_T), value       :: index
@@ -665,6 +683,27 @@ contains
       call set_errmsg('Index in tallies array is out of bounds.')
     end if
   end function openmc_tally_set_filters
+
+
+  function openmc_tally_set_active(index, active) result(err) bind(C)
+    ! Set the ID of a tally
+    integer(C_INT32_T), value, intent(in) :: index
+    logical(C_BOOL),    value, intent(in) :: active
+    integer(C_INT) :: err
+
+    if (index >= 1 .and. index <= n_tallies) then
+      if (allocated(tallies(index) % obj)) then
+        tallies(index) % obj % active = active
+        err = 0
+      else
+        err = E_ALLOCATE
+        call set_errmsg("Tally type has not been set yet.")
+      end if
+    else
+      err = E_OUT_OF_BOUNDS
+      call set_errmsg('Index in tallies array is out of bounds.')
+    end if
+  end function openmc_tally_set_active
 
 
   function openmc_tally_set_id(index, id) result(err) bind(C)

--- a/tests/unit_tests/test_capi.py
+++ b/tests/unit_tests/test_capi.py
@@ -164,6 +164,10 @@ def test_tally(capi_init):
     t.scores = new_scores
     assert t.scores == new_scores
 
+    assert not t.active
+    t.active = True
+    assert t.active
+
 
 def test_new_tally(capi_init):
     with pytest.raises(exc.AllocationError):
@@ -177,7 +181,7 @@ def test_new_tally(capi_init):
 
 def test_tally_results(capi_run):
     t = openmc.capi.tallies[1]
-    assert t.num_realizations == 5
+    assert t.num_realizations == 10  # t was made active in test_tally
     assert np.all(t.mean >= 0)
     nonzero = (t.mean > 0.0)
     assert np.all(t.std_dev[nonzero] >= 0)


### PR DESCRIPTION
One other thing we'll need to implement CMFD from Python is the ability to activate tallies during inactive batches. This PR adds two new C API functions for getting/setting the active flag on `TallyObject` along with Python bindings via the `openmc.capi.Tally.active` property.

@shikhar413 care to review again?