### PR TITLE
Fix bug when no outer lattice universe is defined

### DIFF
--- a/src/geometry.F90
+++ b/src/geometry.F90
@@ -355,9 +355,10 @@ contains
             else
               ! Particle is outside the lattice.
               if (lat % outer == NO_OUTER_UNIVERSE) then
-                call p % mark_as_lost("Particle " // trim(to_str(p %id)) &
+                call warning("Particle " // trim(to_str(p %id)) &
                      // " is outside lattice " // trim(to_str(lat % id)) &
                      // " but the lattice has no defined outer universe.")
+                found = .false.
                 return
               else
                 p % coord(j + 1) % universe = lat % outer


### PR DESCRIPTION
I recently discovered that in a model with no outer universe defined for a lattice, you can actually run into segfaults because although `find_cell` marks the particle as lost, the `found` flag is never actually set to `.false.`, Thus, whoever called `find_cell` doesn't know that the calculation should stop for that particle. This two line-change PR fixes that unfortunate behavior. Note that the particle is now not marked as lost in `find_cell` because that is always done immediately after a call to `find_cell`.