### PR TITLE
Checkvalue bug

### DIFF
--- a/openmc/checkvalue.py
+++ b/openmc/checkvalue.py
@@ -265,7 +265,7 @@ def check_filetype_version(obj, expected_type, expected_version):
         if this_version[0] != expected_version:
             raise IOError('{} file has a version of {} which is not '
                           'consistent with the version expected by OpenMC, {}'
-                          .format(this_filetype, '.'.join(this_version),
+                          .format(this_filetype, '.'.join(str(v) for v in this_version),
                                   expected_version))
     except AttributeError:
         raise IOError('Could not read {} file. This most likely means the {} '

--- a/openmc/checkvalue.py
+++ b/openmc/checkvalue.py
@@ -265,8 +265,9 @@ def check_filetype_version(obj, expected_type, expected_version):
         if this_version[0] != expected_version:
             raise IOError('{} file has a version of {} which is not '
                           'consistent with the version expected by OpenMC, {}'
-                          .format(this_filetype, '.'.join(str(v) for v in this_version),
-                                  expected_version))
+                          .format(this_filetype, 
+                              '.'.join(str(v) for v in this_version),
+                              expected_version))
     except AttributeError:
         raise IOError('Could not read {} file. This most likely means the {} '
                       'file was produced by a different version of OpenMC than '


### PR DESCRIPTION
Fix a bug in checkvalue.py
`.join()` can take only str as arguments, not numpy.int32.