### PR TITLE
Consistently check derived for sum and sum_sq in tallies

### DIFF
--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -248,7 +248,7 @@ class Tally(IDManagerMixin):
 
     @property
     def sum_sq(self):
-        if not self._sp_filename:
+        if not self._sp_filename or self.derived:
             return None
 
         if not self._results_read:


### PR DESCRIPTION
Per discussion in #1010, `sum` and `sum_sq` attributes should only really correspond to tallies that are being accumulated during the simulation transport process.

Closes #1010 