### PR TITLE
Fix k_eff bug encountered with openmc.capi.reset()

### DIFF
--- a/src/api.F90
+++ b/src/api.F90
@@ -276,6 +276,10 @@ contains
     k_abs_tra = ZERO
     k_sum(:) = ZERO
 
+    ! Set the number of inactive batches (used to compute k_eff for the fission
+    ! bank).
+    n_inactive = current_batch
+
     ! Clear active tally lists
     call active_analog_tallies % clear()
     call active_tracklength_tallies % clear()


### PR DESCRIPTION
I found that running a few batches of OpenMC, calling `openmc.capi.reset()`, and then running more batches gave an error in the generation-based `keff` used for the fission bank.

The `keff` comes from dividing a tallied sum by the total number of active generations.  Calling `openmc.capi.reset()` sets that tallied sum to zero, but the number of active generations is not reset so `keff` is heavily underestimated.  This PR fixes bug by just setting updating `n_inactive` in `openmc.capi.reset()`.