### PR TITLE
Fix indexing error with openmc_cell_set_temperature

### DIFF
--- a/src/geometry_header.F90
+++ b/src/geometry_header.F90
@@ -736,7 +736,7 @@ contains
         ! find which material is associated with this cell (material_index
         ! is the index into the materials array)
         if (present(instance)) then
-          material_index = cells(index) % material(instance)
+          material_index = cells(index) % material(instance + 1)
         else
           material_index = cells(index) % material(1)
         end if


### PR DESCRIPTION
It looks like two different conventions were used for indexing in `openmc_cell_set_temperature`.  The indexing of a cell's `material` array expected that `instance` was 1-based, but the indexing of `sqrtkT` was 0-based.  This PR switches to a consistent 0-based convention.